### PR TITLE
fix: add ctranslate2 cudnn libraries to path automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,7 @@ include = ["**/*.so"]
 # **Exclude specific files or directories from the built distributions**
 exclude = [
     "tests*",
-    "scripts*",
-    "pruna_internal.huggingface_integration*",
-    "pruna_internal.utils*",
-    "pruna_internal.run_*",
-    "pruna_internal.evaluations*",
+    "docs*",
 ]
 
 [tool.poetry.dependencies]
@@ -89,7 +85,7 @@ timm = "*"
 bitsandbytes = "*"
 optimum-quanto = "==0.2.4"
 optimum = "*"
-ctranslate2 = "==4.4.0"
+ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
 hqq = "*"
 auto-gptq = "*"


### PR DESCRIPTION
## Description
This PR fixes a common ctranslate2 error where its incompatible with the new torch version. To fix it we automatically add missing cudnn libraries when ctranslate2 is passed as a method.

## Related Issue
https://github.com/OpenNMT/CTranslate2/issues/1826

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
All ctranslate2 unit tests pass.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
