### PR TITLE
feat: context manager for `pruna_logger`and warnings

### DIFF
--- a/src/pruna/logging/filter.py
+++ b/src/pruna/logging/filter.py
@@ -23,6 +23,11 @@ def apply_warning_filter() -> None:
     warnings.filterwarnings("ignore")
 
 
+def remove_warning_filter() -> None:
+    """Remove the warning filter globally."""
+    warnings.filterwarnings("default")
+
+
 def is_notebook() -> bool:
     """
     Check if the code is running in a Jupyter notebook.

--- a/src/pruna/logging/logger.py
+++ b/src/pruna/logging/logger.py
@@ -13,10 +13,65 @@
 # limitations under the License.
 
 import logging
+from typing import Any
 
 from colorama import Fore, Style, init
 
+from pruna.logging.filter import apply_warning_filter, remove_warning_filter
+
 init(autoreset=True)
+
+
+class PrunaLoggerContext:
+    """
+    Context to manage the pruna_logger logging level and warning filters.
+
+    Parameters
+    ----------
+    verbose : bool
+        Whether to log at high detail or not.
+    logging_level : int
+        The logging level to set for the pruna_logger.
+    """
+
+    active_contexts: list["PrunaLoggerContext"] = []
+
+    def __init__(self, verbose: bool, logging_level: int = logging.INFO) -> None:
+        self.verbose = verbose
+        self.original_level = 0
+        self.logging_level = logging_level
+
+    def __enter__(self) -> None:
+        """Enter the context manager."""
+        self.original_level = pruna_logger.getEffectiveLevel()
+        self.active_contexts.append(self)
+
+        if not self.verbose:
+            apply_warning_filter()
+
+        # Only set the level if it would make logging more restrictive
+        new_level = logging.DEBUG if self.verbose else self.logging_level
+        if new_level > self.original_level or len(self.active_contexts) == 1:
+            pruna_logger.setLevel(new_level)
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """
+        Exit the context manager.
+
+        Parameters
+        ----------
+        exc_type : Any
+            The type of the exception.
+        exc_val : Any
+            The value of the exception.
+        exc_tb : Any
+            The traceback of the exception.
+        """
+        pruna_logger.setLevel(self.original_level)
+        # if no more contexts are active, remove the warning filter
+        if len(self.active_contexts) == 1:
+            remove_warning_filter()
+        self.active_contexts.remove(self)
 
 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
## Description
This PR introduces a logging context for the `pruna_logger` and e.g. managing warnings. It is currently used in the `smash` function to handle better the level information given to the user (see examples below). It also helps us to restore better the state of logging (e.g. w.r.t. warnings) when `smash` is done.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I tested the logging locally - see example below.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
Example with `verbose=False`:
```
smashed_model = smash(model, smash_config, verbose=False)

> INFO - Starting compiler torch_compile...
> INFO - compiler torch_compile was applied successfully.
```

Example with `verbose=True`:
```
smashed_model = smash(model, smash_config, verbose=True)

> INFO - Starting compiler torch_compile...
> DEBUG - Moving saved model...
> INFO - compiler torch_compile was applied successfully.
```