### PR TITLE
fix: specify autogptq only for linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ exclude = '''
 
 [tool.poetry]
 name = "pruna"
-version = "0.2.0"
+version = "0.2.0.post1"
 description = "Smash your AI models"
 authors = ["Pruna AI <hello@pruna.ai>"]
 license = "All Rights Reserved"
@@ -88,7 +88,7 @@ optimum = "*"
 ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
 hqq = "*"
-auto-gptq = "*"
+auto-gptq = { version = "*", markers = "sys_platform == 'linux'" }
 torchao = "*"
 
 # Added Optional Dependencies from Extras


### PR DESCRIPTION
## Description
This PR specifies that autogptq only works on linux.

## Related Issue
#15 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Installed the new wheel on a Mac machine.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
