### PR TITLE
feat: enable combination of torch_compile and hqq_diffusers

### DIFF
--- a/docs/tutorials/diffusion_quantization_acceleration.ipynb
+++ b/docs/tutorials/diffusion_quantization_acceleration.ipynb
@@ -1,0 +1,194 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "#  Speedup and Quantize any Diffusion Model"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "metadata": {
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "<a target=\"_blank\" href=\"https://colab.research.google.com/github/PrunaAI/pruna/blob/v|version|/docs/tutorials/sana_diffusers_int8.ipynb\">\n",
+                "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+                "</a>"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "This tutorial demonstrates how to use the ``pruna`` package to optimize both the latency and the memory footprint of any diffusion model from the diffusers package.\n",
+                "We will use the ``Flux Dev`` model as an example, but this tutorial is working on any stable diffusion or flux model."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
+                "# the following command will install the latest version of pruna\n",
+                "!pip install pruna"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### 1. Loading the Diffusion Model\n",
+                "\n",
+                "First, load your diffusion model."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import torch\n",
+                "from diffusers import FluxPipeline\n",
+                "\n",
+                "pipe = FluxPipeline.from_pretrained(\"black-forest-labs/FLUX.1-schnell\", torch_dtype=torch.bfloat16, cache_dir=\"/efs/hf_cache\").to(\"cuda\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### 2. Initializing the Smash Config"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "Next, initialize the smash_config (we make use, here, of the :doc:`hqq-diffusers </compression>` and :doc:`torch-compile </compression>` algorithms)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from pruna_pro import SmashConfig\n",
+                "\n",
+                "smash_config = SmashConfig()\n",
+                "smash_config['compiler'] = 'torch_compile'\n",
+                "smash_config['quantizer'] = 'hqq_diffusers'"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### 3. Smashing the Model\n",
+                "\n",
+                "Now, smash the model. This can take up to 30 seconds."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from pruna import smash\n",
+                "\n",
+                "# Smash the model\n",
+                "pipe = smash(\n",
+                "    model=pipe,\n",
+                "    smash_config=smash_config,\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### 4. Running the Model\n"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "Finally, run the model to generate the image, note there will be a warmup the first time you run it."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# Define the prompt\n",
+                "prompt = \"a smiling cat dancing on a table. Miyazaki style\"\n",
+                "\n",
+                "# Display the result\n",
+                "pipe(prompt).images[0]"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "metadata": {},
+            "source": [
+                "### Wrap Up"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "Congratulations! You've optimized a diffusion model using HQQ quantization and TorchCompile! The quantized model uses less memory and runs faster while maintaining good quality. You can try different settings like weight bits and group size to find the best balance between size and quality.\n",
+                "\n",
+                "Want more optimization techniques? Check out our other tutorials!"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "pruna",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.11.11"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 2
+}

--- a/docs/tutorials/diffusion_quantization_acceleration.ipynb
+++ b/docs/tutorials/diffusion_quantization_acceleration.ipynb
@@ -15,7 +15,7 @@
                 }
             },
             "source": [
-                "<a target=\"_blank\" href=\"https://colab.research.google.com/github/PrunaAI/pruna/blob/v|version|/docs/tutorials/sana_diffusers_int8.ipynb\">\n",
+                "<a target=\"_blank\" href=\"https://colab.research.google.com/github/PrunaAI/pruna/blob/v|version|/docs/tutorials/diffusion_quantization_acceleration.ipynb\">\n",
                 "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
                 "</a>"
             ]
@@ -140,7 +140,19 @@
             "cell_type": "code",
             "execution_count": null,
             "metadata": {},
-            "outputs": [],
+            "outputs": [
+                {
+                    "ename": "",
+                    "evalue": "",
+                    "output_type": "error",
+                    "traceback": [
+                        "\u001b[1;31mThe Kernel crashed while executing code in the current cell or a previous cell. \n",
+                        "\u001b[1;31mPlease review the code in the cell(s) to identify a possible cause of the failure. \n",
+                        "\u001b[1;31mClick <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. \n",
+                        "\u001b[1;31mView Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+                    ]
+                }
+            ],
             "source": [
                 "# Define the prompt\n",
                 "prompt = \"a smiling cat dancing on a table. Miyazaki style\"\n",

--- a/docs/tutorials/diffusion_quantization_acceleration.ipynb
+++ b/docs/tutorials/diffusion_quantization_acceleration.ipynb
@@ -62,7 +62,7 @@
                 "import torch\n",
                 "from diffusers import FluxPipeline\n",
                 "\n",
-                "pipe = FluxPipeline.from_pretrained(\"black-forest-labs/FLUX.1-schnell\", torch_dtype=torch.bfloat16, cache_dir=\"/efs/hf_cache\").to(\"cuda\")"
+                "pipe = FluxPipeline.from_pretrained(\"black-forest-labs/FLUX.1-schnell\", torch_dtype=torch.bfloat16).to(\"cuda\")"
             ]
         },
         {

--- a/docs/tutorials/diffusion_quantization_acceleration.ipynb
+++ b/docs/tutorials/diffusion_quantization_acceleration.ipynb
@@ -90,11 +90,12 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "from pruna_pro import SmashConfig\n",
+                "from pruna import SmashConfig\n",
                 "\n",
                 "smash_config = SmashConfig()\n",
                 "smash_config['compiler'] = 'torch_compile'\n",
-                "smash_config['quantizer'] = 'hqq_diffusers'"
+                "smash_config['quantizer'] = 'hqq_diffusers'\n",
+                "# smash_config['torch_compile_mode'] = 'max-autotune' # Uncomment to enable extra speedups"
             ]
         },
         {

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -118,12 +118,10 @@ class TorchCompileCompiler(PrunaCompiler):
         Any
             The compiled model.
         """
-        import pdb; pdb.set_trace()
-
         cacher_type = smash_config["cacher"]
         if cacher_type in compilation_map:
             return compilation_map[cacher_type](model, smash_config)
-        
+
         if hasattr(model, "transformer") and isinstance(model.transformer, tuple(get_diffusers_transformer_models())):
             return unet_transformer_pipeline_logic(model, smash_config)
 

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -122,10 +122,11 @@ class TorchCompileCompiler(PrunaCompiler):
         if cacher_type in compilation_map:
             return compilation_map[cacher_type](model, smash_config)
 
-        if (hasattr(model, "transformer")
+        if (
+            hasattr(model, "transformer")
             and isinstance(model.transformer, tuple(get_diffusers_transformer_models()))
-            or (hasattr(model, "unet")
-                and isinstance(model.unet, tuple(get_diffusers_unet_models())))):
+            or (hasattr(model, "unet") and isinstance(model.unet, tuple(get_diffusers_unet_models())))
+        ):
             return unet_transformer_pipeline_logic(model, smash_config)
         return compile_callable(model, smash_config)
 

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -122,10 +122,10 @@ class TorchCompileCompiler(PrunaCompiler):
         if cacher_type in compilation_map:
             return compilation_map[cacher_type](model, smash_config)
 
-        if hasattr(model, "transformer") and isinstance(model.transformer, tuple(get_diffusers_transformer_models())):
-            return unet_transformer_pipeline_logic(model, smash_config)
-
-        if hasattr(model, "unet") and isinstance(model.unet, tuple(get_diffusers_unet_models())):
+        if (hasattr(model, "transformer")
+            and isinstance(model.transformer, tuple(get_diffusers_transformer_models()))
+            or (hasattr(model, "unet")
+                and isinstance(model.unet, tuple(get_diffusers_unet_models())))):
             return unet_transformer_pipeline_logic(model, smash_config)
         return compile_callable(model, smash_config)
 
@@ -219,7 +219,7 @@ def deepcache_logic(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
 
 def unet_transformer_pipeline_logic(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
     """
-    Apply compilation logic for HQQ models.
+    Apply compilation logic for unet and transformer based diffusers pipelines.
 
     Parameters
     ----------

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -236,8 +236,7 @@ def unet_transformer_pipeline_logic(model: Any, smash_config: SmashConfigPrefixW
     if hasattr(model, "transformer"):
         model.transformer.forward = compile_callable(model.transformer.forward, smash_config)
     elif hasattr(model, "unet"):
-        if isinstance(model.unet, tuple):
-            model.unet.forward = compile_callable(model.unet.forward, smash_config)
+        model.unet.forward = compile_callable(model.unet.forward, smash_config)
     else:
         model.forward = compile_callable(model.forward, smash_config)
     return model

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -157,14 +157,23 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
         )
 
         # Prepare the model for fast inference based on the backend, we use the conditions from the hqq documentation
-        if (smash_config["backend"] == "torchao_int4" and smash_config["weight_bits"] == 4
-                and next(iter(working_model.parameters())).dtype == torch.bfloat16):
+        if (
+            smash_config["backend"] == "torchao_int4"
+            and smash_config["weight_bits"] == 4
+            and next(iter(working_model.parameters())).dtype == torch.bfloat16
+        ):
             imported_modules["prepare_for_inference"](working_model, backend="torchao_int4")
-        elif (smash_config["backend"] == "gemlite" and smash_config["weight_bits"] in [4, 2, 1]
-                and next(iter(working_model.parameters())).dtype == torch.float16):
+        elif (
+            smash_config["backend"] == "gemlite"
+            and smash_config["weight_bits"] in [4, 2, 1]
+            and next(iter(working_model.parameters())).dtype == torch.float16
+        ):
             imported_modules["prepare_for_inference"](working_model, backend="gemlite")
-        elif (smash_config["backend"] == "bitblas" and smash_config["weight_bits"] in [4, 2]
-                and next(iter(working_model.parameters())).dtype == torch.float16):
+        elif (
+            smash_config["backend"] == "bitblas"
+            and smash_config["weight_bits"] in [4, 2]
+            and next(iter(working_model.parameters())).dtype == torch.float16
+        ):
             imported_modules["prepare_for_inference"](working_model, backend="bitblas")
         else:
             # We default to the torch backend if the input backend is not applicable

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -45,7 +45,7 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
     run_on_cpu = False
     run_on_cuda = True
     dataset_required = False
-    compatible_algorithms = dict(cacher=["deepcache"])
+    compatible_algorithms = dict(cacher=["deepcache"], compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """
@@ -156,12 +156,10 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
         )
 
         # Prepare the model for fast inference
-        try:
-            if smash_config["weight_bits"] == 4:
-                imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])
-        except Exception as e:
-            pruna_logger.error(f"Error: {e}")
-            pass
+        if smash_config["weight_bits"] == 4:
+            imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])
+        else:
+            imported_modules["prepare_for_inference"](working_model)
 
         if hasattr(model, "transformer"):
             model.transformer = working_model

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -156,10 +156,18 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
             device=smash_config["device"],
         )
 
-        # Prepare the model for fast inference
-        if smash_config["weight_bits"] == 4 and next(iter(working_model.parameters())).dtype == torch.bfloat16:
-            imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])
+        # Prepare the model for fast inference based on the backend, we use the conditions from the hqq documentation
+        if (smash_config["backend"] == "torchao_int4" and smash_config["weight_bits"] == 4
+                and next(iter(working_model.parameters())).dtype == torch.bfloat16):
+            imported_modules["prepare_for_inference"](working_model, backend="torchao_int4")
+        elif (smash_config["backend"] == "gemlite" and smash_config["weight_bits"] in [4, 2, 1]
+                and next(iter(working_model.parameters())).dtype == torch.float16):
+            imported_modules["prepare_for_inference"](working_model, backend="gemlite")
+        elif (smash_config["backend"] == "bitblas" and smash_config["weight_bits"] in [4, 2]
+                and next(iter(working_model.parameters())).dtype == torch.float16):
+            imported_modules["prepare_for_inference"](working_model, backend="bitblas")
         else:
+            # We default to the torch backend if the input backend is not applicable
             imported_modules["prepare_for_inference"](working_model)
 
         if hasattr(model, "transformer"):

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -14,6 +14,7 @@
 
 from typing import Any, Dict, Type
 
+import torch
 from ConfigSpace import OrdinalHyperparameter
 
 from pruna.algorithms.quantization import PrunaQuantizer
@@ -156,7 +157,7 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
         )
 
         # Prepare the model for fast inference
-        if smash_config["weight_bits"] == 4:
+        if smash_config["weight_bits"] == 4 and next(iter(working_model.parameters())).dtype == torch.bfloat16:
             imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])
         else:
             imported_modules["prepare_for_inference"](working_model)

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -285,19 +285,26 @@ def load_hqq_diffusers(path: str, **kwargs) -> Any:
     hf_quantizer = HQQDiffusersQuantizer()
     AutoHQQHFDiffusersModel = construct_base_class(hf_quantizer.import_algorithm_packages())
 
+    # If a pipeline was saved, load the backbone and the rest of the pipeline separately
     if os.path.exists(os.path.join(path, "backbone_quantized")):
+        # load the backbone
         loaded_backbone = AutoHQQHFDiffusersModel.from_quantized(os.path.join(path, "backbone_quantized"), **kwargs)
+        # Get the pipeline class name
         model_index = load_json_config(path, "model_index.json")
         cls = getattr(diffusers, model_index["_class_name"])
+        # If the pipeline has a transformer, load the transformer
         if "transformer" in model_index:
             model = cls.from_pretrained(path, transformer=loaded_backbone, **kwargs)
+        # If the pipeline has a unet, load the unet
         elif "unet" in model_index:
             model = cls.from_pretrained(path, unet=loaded_backbone, **kwargs)
+            # If the unet has up_blocks, we need to change the upsampler name to conv
             for layer in model.unet.up_blocks:
                 if layer.upsamplers is not None:
                     layer.upsamplers[0].name = "conv"
     else:
-        model = AutoHQQHFDiffusersModel.from_quantized(path)
+        # load the whole model if a pipeline wasn't saved
+        model = AutoHQQHFDiffusersModel.from_quantized(path, **kwargs)
     return model
 
 

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -286,12 +286,11 @@ def load_hqq_diffusers(path: str, **kwargs) -> Any:
     AutoHQQHFDiffusersModel = construct_base_class(hf_quantizer.import_algorithm_packages())
 
     if os.path.exists(os.path.join(path, "backbone_quantized")):
-        loaded_backbone = AutoHQQHFDiffusersModel.from_quantized(os.path.join(path, "backbone_quantized"))
+        loaded_backbone = AutoHQQHFDiffusersModel.from_quantized(os.path.join(path, "backbone_quantized"), **kwargs)
         model_index = load_json_config(path, "model_index.json")
         cls = getattr(diffusers, model_index["_class_name"])
         if "transformer" in model_index:
-            model = cls.from_pretrained(path, transformer=None, **kwargs)
-            model.transformer = loaded_backbone
+            model = cls.from_pretrained(path, transformer=loaded_backbone, **kwargs)
         elif "unet" in model_index:
             model = cls.from_pretrained(path, unet=loaded_backbone, **kwargs)
             for layer in model.unet.up_blocks:

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -227,15 +227,19 @@ def save_model_hqq_diffusers(model: Any, model_path: str, smash_config: SmashCon
     hf_quantizer = HQQDiffusersQuantizer()
     AutoHQQHFDiffusersModel = construct_base_class(hf_quantizer.import_algorithm_packages())
     if hasattr(model, "transformer"):
+        # save the backbone
         AutoHQQHFDiffusersModel.save_quantized(model.transformer, os.path.join(model_path, "backbone_quantized"))
         transformer_backup = model.transformer
         model.transformer = None
+        # save the rest of the pipeline
         model.save_pretrained(model_path)
         model.transformer = transformer_backup
     elif hasattr(model, "unet"):
+        # save the backbone
         AutoHQQHFDiffusersModel.save_quantized(model.unet, os.path.join(model_path, "backbone_quantized"))
         unet_backup = model.unet
         model.unet = None
+        # save the rest of the pipeline
         model.save_pretrained(model_path)
         model.unet = unet_backup
     else:

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -49,7 +49,6 @@ def save_pruna_model(model: Any, model_path: str, smash_config: SmashConfig) -> 
     """
     if not os.path.exists(model_path):
         os.makedirs(model_path)
-
     # in the case of no specialized save functions, we use the model's original save function
     if len(smash_config.save_fns) == 0:
         pruna_logger.debug("Using model's original save function...")
@@ -73,7 +72,6 @@ def save_pruna_model(model: Any, model_path: str, smash_config: SmashConfig) -> 
         pruna_logger.debug(f"Several save functions stacked: {smash_config.save_fns}, defaulting to pickled")
         save_fn = SAVE_FUNCTIONS.pickled
         smash_config.load_fn = LOAD_FUNCTIONS.pickled.name
-
     # execute selected save function
     save_fn(model, model_path, smash_config)
 
@@ -229,13 +227,17 @@ def save_model_hqq_diffusers(model: Any, model_path: str, smash_config: SmashCon
     hf_quantizer = HQQDiffusersQuantizer()
     AutoHQQHFDiffusersModel = construct_base_class(hf_quantizer.import_algorithm_packages())
     if hasattr(model, "transformer"):
-        AutoHQQHFDiffusersModel.save_quantized(model.transformer, model_path + "/transformer_quantized")
-        del model.transformer
+        AutoHQQHFDiffusersModel.save_quantized(model.transformer, os.path.join(model_path, "backbone_quantized"))
+        transformer_backup = model.transformer
+        model.transformer = None
         model.save_pretrained(model_path)
+        model.transformer = transformer_backup
     elif hasattr(model, "unet"):
-        AutoHQQHFDiffusersModel.save_quantized(model.unet, model_path + "/unet_quantized")
-        del model.unet
+        AutoHQQHFDiffusersModel.save_quantized(model.unet, os.path.join(model_path, "backbone_quantized"))
+        unet_backup = model.unet
+        model.unet = None
         model.save_pretrained(model_path)
+        model.unet = unet_backup
     else:
         AutoHQQHFDiffusersModel.save_quantized(model, model_path)
     smash_config.load_fn = LOAD_FUNCTIONS.hqq_diffusers.name

--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -59,7 +59,6 @@ def smash(
 
             if current_algorithm is not None:
                 check_algorithm_availability(current_algorithm, algorithm_group, PRUNA_ALGORITHMS)
-
                 # apply the active algorithm to the model
                 pruna_logger.info(f"Starting {algorithm_group} {current_algorithm}...")
                 algorithm_instance = PRUNA_ALGORITHMS[algorithm_group][current_algorithm]

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -38,6 +38,8 @@ class CombinationsTester(AlgorithmTesterBase):
         ("stable_diffusion_v1_4", dict(cacher="deepcache", compiler="stable_fast"), False),
         ("mobilenet_v2", dict(pruner="torch_unstructured", quantizer="half"), True),
         ("whisper_tiny", dict(batcher="whisper_s2t", compiler="c_whisper"), False),
+        ("stable_diffusion_v1_4", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
+        ("sana", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
     ],
     indirect=["model_fixture"],
 )


### PR DESCRIPTION
## Description
This PR enables the combination of `torch_compile` and `hqq_diffusers`. This allows the speedup of hqq quantized models in all precisions. This means that we can accelerate any diffusion model after quantization!

You can use it by simply defining the following config:

```
from pruna import SmashConfig

smash_config = SmashConfig()
smash_config['compiler'] = 'torch_compile'
smash_config['quantizer'] = 'hqq_diffusers'
# smash_config['torch_compile_mode'] = 'max-autotune' # Uncomment to enable extra speedups
```

This PR also includes many fixes to hqq_diffusers save/load functions. They were only working in 1/3 usecase (transformer-based models).

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
2 unit tests added that pass (1 unet-based and 1 transformer-based). Tutorial notebook added as well that is also passing.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
This can also be extended to LLMs through the `hqq` method but is out of this scope of this PR.

### Small Benchmark on H100, SD1.4, 50 steps

| Model                          | E2E Time  |
|-------------------------------|-----------|
| base                          | 1.4s      |
| hqq (4 bits)                  | 2s        |
| hqq (8 bits)                  | 1.57s         |
| hqq (4 bits) + torch.compile  | 872ms     |
| hqq (8 bits) + torch.compile  | 830ms     |

### Visual Comparison

**Base image:**  
<img width="510" alt="Base image" src="https://github.com/user-attachments/assets/32181c42-1f0e-4d82-956d-8f62f46d0443" />

**8 bits image:**  
<img width="506" alt="8 bits image" src="https://github.com/user-attachments/assets/9b5828d2-f44d-47c4-ab53-f1c4743cc233" />

**4 bits image:**  
<img width="503" alt="4 bits image" src="https://github.com/user-attachments/assets/fe21e9b7-0eb5-457d-8dad-2fb9361fd2ad" />