### PR TITLE
fix: remove two incorrect checks from the algorithm overview in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,6 @@ Since Pruna offers a broad range of compression algorithms, the following table 
       <td>cacher</td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
-      <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td></td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td></td>
@@ -423,7 +422,6 @@ Since Pruna offers a broad range of compression algorithms, the following table 
       <td><strong>HYPER<sup><a href="#footnote4" id="ref4">4</a></sup></strong></td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td>distiller</td>
-      <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td align="center"><img src="./docs/assets/images/check.png" alt="Check" height="16"></td>
       <td></td>


### PR DESCRIPTION
## Description
This PR removes two incorrect checks in the algorithm overview (for Periodic Caching and HYPER) .

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Verified the Readme on the branch on Github.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
