### PR TITLE
fix: add support for py312 by making gptq optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ optimum = "*"
 ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
 hqq = "*"
-auto-gptq = { version = "*", markers = "sys_platform == 'linux'" }
 torchao = "*"
 
 # Added Optional Dependencies from Extras
@@ -118,6 +117,8 @@ isort = { version = "*", optional = true }
 numpydoc-validation = { version = "*", optional = true }
 mypy = { version = "*", optional = true }
 types-PyYAML = { version = "*", optional = true }
+auto-gptq = { version = "*", markers = "sys_platform == 'linux'", optional = true }
+
 
 [tool.poetry.extras]
 stable-fast = [
@@ -132,6 +133,9 @@ onediff = [
     "onediff",
     "nexfort",
 ]
+autogptq = [
+    "auto-gptq",
+]
 autoawq = [
     "autoawq",
 ]
@@ -142,6 +146,7 @@ full = [
     "autoawq",
     "onediff",
     "nexfort",
+    "auto-gptq",
 ]
 dev = [
     "jupyterlab",

--- a/src/pruna/algorithms/quantization/huggingface_gptq.py
+++ b/src/pruna/algorithms/quantization/huggingface_gptq.py
@@ -44,6 +44,8 @@ class GPTQQuantizer(PrunaQuantizer):
     run_on_cuda = True
     dataset_required = True
     compatible_algorithms = dict()
+    required_install = "``pip install pruna[autogptq]``"
+
 
     def get_hyperparameters(self) -> list:
         """


### PR DESCRIPTION
## Description
This PR makes auto-gptq optional which is incompatible with python 3.12

## Related Issue
Fixes [#(21)](https://github.com/PrunaAI/pruna/issues/21)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
pruna is installable on python 3.12

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
None.
