### PR TITLE
fix: fix cudnn libs path in CTranslate compiler

### DIFF
--- a/src/pruna/algorithms/compilation/c_translate.py
+++ b/src/pruna/algorithms/compilation/c_translate.py
@@ -214,7 +214,7 @@ class CTranslateCompiler(PrunaCompiler):
             The algorithm packages.
         """
         cudnn_path = os.path.join(
-            os.path.dirname(sys.executable),
+            os.path.dirname(sys.executable).strip("bin"),
             f"lib/python{sys.version_info[0]}.{sys.version_info[1]}/site-packages/nvidia/cudnn/lib",
         )
         ld_library_path = os.environ.get("LD_LIBRARY_PATH", "")


### PR DESCRIPTION
## Description
This PR changes the path used to detect the cudnn binairies available for CTranslate compilation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
This solves a failing test in the nightly tests environment.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
