### PR TITLE
feat: switch autogptq to gptqmodel

### DIFF
--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -152,7 +152,11 @@ def get_required_install(obj: PrunaAlgorithmBase) -> str | None:
         "``--extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/cn/``"
     )
 
-    full_install = base_install if required_install is not None and "pro" not in required_install else pro_install
+    full_install = (
+        base_install
+        if required_install is not None and "pro" not in required_install and "gptq" not in required_install
+        else pro_install
+    )
     if required_install:
         return f"{required_install} or {full_install}"
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ optimum = "*"
 ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
 hqq = "*"
-auto-gptq = { version = "*", markers = "sys_platform == 'linux'" }
 torchao = "*"
+gptqmodel = "*"
 
 # Added Optional Dependencies from Extras
 ruff = { version = "*", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ stable-fast-cu11 = [
     "xformers",
     "stable-fast-pruna",
 ]
+# Note: You must first install the base package with ``pip install pruna`` before installing the GPTQ extension with ``pip install pruna[gptq]``
 gptq = [
     "gptqmodel",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,6 @@ ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
 hqq = "*"
 torchao = "*"
-gptqmodel = "*"
-
 # Added Optional Dependencies from Extras
 ruff = { version = "*", optional = true }
 autoawq = { version = "*", optional = true }
@@ -108,6 +106,7 @@ stable-fast-pruna = [
 numpydoc-validation = { version = "*", optional = true }
 mypy = { version = "*", optional = true }
 types-PyYAML = { version = "*", optional = true }
+gptqmodel = { version = "*", optional = true }
 
 [tool.poetry.extras]
 stable-fast = [
@@ -117,6 +116,9 @@ stable-fast = [
 stable-fast-cu11 = [
     "xformers",
     "stable-fast-pruna",
+]
+gptq = [
+    "gptqmodel",
 ]
 autoawq = [
     "autoawq",

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -57,7 +57,7 @@ class GPTQQuantizer(PrunaQuantizer):
         return [
             OrdinalHyperparameter(
                 "weight_bits",
-                sequence=[2, 3, 4],
+                sequence=[2, 3, 4, 8],
                 default_value=4,
                 meta=dict(desc="Sets the number of bits to use for weight quantization."),
             ),

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -22,7 +22,6 @@ from pruna.config.smash_config import SmashConfigPrefixWrapper
 from pruna.config.smash_space import Boolean
 from pruna.data.utils import recover_text_from_dataloader
 from pruna.engine.model_checks import is_causal_lm
-from pruna.engine.save import SAVE_FUNCTIONS
 from pruna.engine.utils import safe_memory_cleanup
 
 
@@ -44,6 +43,7 @@ class GPTQQuantizer(PrunaQuantizer):
     run_on_cuda = True
     dataset_required = True
     compatible_algorithms = dict()
+    required_install = "``pip install pruna[gptq]``"
 
     def get_hyperparameters(self) -> list:
         """
@@ -132,7 +132,6 @@ class GPTQQuantizer(PrunaQuantizer):
             model.quantize(calib_data, batch_size=smash_config["batch_size"])
             model.save(temp_dir)
             model = imported_modules["GPTQModel"].load(temp_dir)
-            model.model_local_path = "facebook/opt-125m"
 
         return model
 

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -43,7 +43,6 @@ class GPTQQuantizer(PrunaQuantizer):
     run_on_cpu = False
     run_on_cuda = True
     dataset_required = True
-    save_fn = SAVE_FUNCTIONS.pickled
     compatible_algorithms = dict()
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/engine/handler/handler_utils.py
+++ b/src/pruna/engine/handler/handler_utils.py
@@ -21,7 +21,7 @@ from pruna.engine.handler.handler_standard import StandardHandler
 from pruna.engine.handler.handler_transformer import TransformerHandler
 
 HANDLER_EXCEPTIONS: dict[type[InferenceHandler], list[str]] = {
-    TransformerHandler: ["OptAWQForCausalLM", "AutoHQQHFModel", "TranslatorWrapper", "GeneratorWrapper"],
+    TransformerHandler: ["AWQForCausalLM", "AutoHQQHFModel", "TranslatorWrapper", "GeneratorWrapper", "GPTQ"],
     DiffuserHandler: ["AutoHQQHFDiffusersModel"],
 }
 
@@ -71,6 +71,6 @@ def scan_for_exceptions(model: Any) -> InferenceHandler | None:
     # this avoids directly importing external packages
     for handler, model_classes in HANDLER_EXCEPTIONS.items():
         for model_class in model_classes:
-            if model_class == model.__class__.__name__:
+            if model_class in model.__class__.__name__:
                 return handler()
     return None

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pruna import PrunaModel
 from pruna.algorithms.quantization.gptq_model import GPTQQuantizer
 from pruna.algorithms.quantization.half import HalfQuantizer
 from pruna.algorithms.quantization.hqq import HQQQuantizer
@@ -96,6 +97,10 @@ class TestGPTQ(AlgorithmTesterBase):
     reject_models = ["stable_diffusion_v1_4"]
     allow_pickle_files = False
     algorithm_class = GPTQQuantizer
+
+    def post_smash_hook(self, model: PrunaModel) -> None:
+        """Hook to modify the model after smashing."""
+        assert "GPTQ" in model.model.__class__.__name__
 
 
 @pytest.mark.slow

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pruna.algorithms.quantization.gptq_model import GPTQQuantizer
 from pruna.algorithms.quantization.half import HalfQuantizer
 from pruna.algorithms.quantization.hqq import HQQQuantizer
 from pruna.algorithms.quantization.hqq_diffusers import HQQDiffusersQuantizer
@@ -7,7 +8,6 @@ from pruna.algorithms.quantization.huggingface_awq import AWQQuantizer
 from pruna.algorithms.quantization.huggingface_diffusers_int8 import (
     DiffusersInt8Quantizer,
 )
-from pruna.algorithms.quantization.huggingface_gptq import GPTQQuantizer
 from pruna.algorithms.quantization.huggingface_llm_int8 import LLMInt8Quantizer
 from pruna.algorithms.quantization.quanto import QuantoQuantizer
 from pruna.algorithms.quantization.torch_dynamic import TorchDynamicQuantizer


### PR DESCRIPTION
## Description
AutoGPTQ is now deprecated. This PR switches our GPTQ algorithm to gptqmodel instead.

## Related Issue
autogptq already caused problems with supporting python 3.12.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
integration test still runs.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
I did not investigate the extent of the new repo. This is only to make the switch. We might be able to find some nice speedups with some investigations.