### PR TITLE
feat: Add Hugging Face integration to save and load models

### DIFF
--- a/src/pruna/engine/model_card_template.md
+++ b/src/pruna/engine/model_card_template.md
@@ -1,0 +1,45 @@
+---
+library_name: {library_name}
+tags:
+- pruna-ai
+---
+
+# Model Card for {repo_id}
+
+This model was created using the [pruna](https://github.com/PrunaAI/pruna) library. Pruna is a model optimization framework built for developers, enabling you to deliver more efficient models with minimal implementation overhead.
+
+## Usage
+
+You can load this model using the following code:
+
+```python
+from pruna import PrunaModel
+
+loaded_model = PrunaModel.from_hub("{repo_id}")
+```
+
+After loading the model, you can use the inference methods of the original model.
+
+## Model Configuration
+
+The configuration of the model is stored in the `config.json` file.
+
+```bash
+{model_config}
+```
+
+## Smash Configuration
+
+The configuration of the model is stored in the `smash_config.json` file.
+
+```bash
+{smash_config}
+```
+
+## 🌍 Join the Pruna AI community!
+
+[![Twitter](https://img.shields.io/twitter/follow/PrunaAI?style=social)](https://twitter.com/PrunaAI)
+[![GitHub](https://img.shields.io/github/followers/PrunaAI?label=Follow%20%40PrunaAI&style=social)](https://github.com/PrunaAI)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Connect-blue)](https://www.linkedin.com/company/93832878/admin/feed/posts/?feedType=following)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Us-blue?style=social&logo=discord)](https://discord.com/invite/rskEr4BZJx)
+[![Reddit](https://img.shields.io/reddit/subreddit-subscribers/PrunaAI?style=social)](https://www.reddit.com/r/PrunaAI/)

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 from typing import Any, List, Tuple
 
 import torch
 
 from pruna.config.smash_config import SmashConfig
 from pruna.engine.handler.handler_utils import register_inference_handler
-from pruna.engine.load import load_pruna_model
-from pruna.engine.save import save_pruna_model
+from pruna.engine.load import load_pruna_model, load_pruna_model_from_hub
+from pruna.engine.save import save_pruna_model, save_pruna_model_to_hub
 from pruna.engine.utils import get_nn_modules, move_to_device, set_to_eval
 from pruna.logging.filter import apply_warning_filter
 from pruna.telemetry import increment_counter, track_usage
@@ -69,7 +70,9 @@ class PrunaModel:
             with torch.no_grad():
                 return self.model.__call__(*args, **kwargs)
 
-    def run_inference(self, batch: Tuple[List[str] | torch.Tensor, ...], device: torch.device | str) -> Any:
+    def run_inference(
+        self, batch: Tuple[List[str] | torch.Tensor, ...], device: torch.device | str
+    ) -> Any:
         """
         Run inference on the model.
 
@@ -149,7 +152,48 @@ class PrunaModel:
             The path to the directory where the model will be saved.
         """
         save_pruna_model(self.model, model_path, self.smash_config)
-        increment_counter("save_pretrained", success=True, smash_config=repr(self.smash_config))
+        increment_counter(
+            "save_pretrained", success=True, smash_config=repr(self.smash_config)
+        )
+
+    def save_to_hub(
+        self,
+        repo_id: str,
+        folder_path: str | Path,
+        *,
+        revision: str | None = None,
+        private: bool = False,
+        allow_patterns: List[str] | str | None = None,
+        ignore_patterns: List[str] | str | None = None,
+        num_workers: int | None = None,
+        print_report: bool = False,
+        print_report_every: int = 0,
+    ) -> None:
+        """Save the model to the specified repository.
+
+        Parameters
+        ----------
+        repo_id : str
+            The repository ID to save the model to.
+        folder_path : str | Path
+            The folder path to save the model to.
+        """
+        save_pruna_model_to_hub(
+            model=self.model,
+            smash_config=self.smash_config,
+            repo_id=repo_id,
+            folder_path=folder_path,
+            revision=revision,
+            private=private,
+            allow_patterns=allow_patterns,
+            ignore_patterns=ignore_patterns,
+            num_workers=num_workers,
+            print_report=print_report,
+            print_report_every=print_report_every,
+        )
+        increment_counter(
+            "save_to_hub", success=True, smash_config=repr(self.smash_config)
+        )
 
     @staticmethod
     @track_usage
@@ -181,6 +225,15 @@ class PrunaModel:
         else:
             model.smash_config = smash_config
         return model
+
+    @staticmethod
+    @track_usage
+    def from_hub(repo_id: str, token: str | None = None) -> Any:
+        """
+        Load a `PrunaModel` from the specified repository.
+        """
+        model, smash_config = load_pruna_model_from_hub(repo_id, token)
+        return PrunaModel(model=model, smash_config=smash_config)
 
     def destroy(self) -> None:
         """Destroy model."""


### PR DESCRIPTION
## Description
- Introduced `load_pruna_model_from_hub` to load models directly from the Hugging Face hub.
- Added `save_pruna_model_to_hub` to save models along with a model card template.
- Updated `PrunaModel` class to include methods for loading and saving from/to the hub.
- Improved code formatting and logging for better readability and debugging.
- 
## Related Issue
Closes #24 
Related to #26 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
tests WIP

Repo: https://huggingface.co/davidberenstein1957/my_smashed_model

```python
from transformers import AutoModelForCausalLM, AutoTokenizer

from pruna import PrunaModel, SmashConfig, smash

model_id = "facebook/opt-125m"
model = AutoModelForCausalLM.from_pretrained(
    model_id, torch_dtype="auto", device_map="mps"
)

text = "The 45th president of the United States of America is"

tokenizer = AutoTokenizer.from_pretrained(model_id)
ins = tokenizer(text, return_tensors="pt")

# Initialize the SmashConfig
smash_config = SmashConfig()
smash_config.add_tokenizer(model_id)
# smash_config.add_data("WikiText")
# smash_config["quantizer"] = "gptq"


# Smash the model
smashed_model = smash(model=model, smash_config=smash_config, experimental=True)

# Save the model to the hub
smashed_model.save_pretrained("smashed_model")
smashed_model.save_to_hub(
    repo_id="davidberenstein1957/my_smashed_model",
    folder_path="smashed_model",
)

# Load the model from the hub
pruna_model = PrunaModel.from_hub(repo_id="davidberenstein1957/my_smashed_model")
```

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
