### PR TITLE
feat: enable bnb with torch compile

### DIFF
--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -45,7 +45,7 @@ class TorchCompileCompiler(PrunaCompiler):
     run_on_cuda = True
     dataset_required = False
     compatible_algorithms = dict(
-        quantizer=["half", "hqq_diffusers"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8"],
         cacher=["deepcache"],
     )
 

--- a/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
@@ -46,9 +46,7 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
     dataset_required = False
     run_on_cpu = False
     run_on_cuda = True
-    compatible_algorithms = dict(
-        cacher=["deepcache"],
-    )
+    compatible_algorithms = dict(cacher=["deepcache"], compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -40,6 +40,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("whisper_tiny", dict(batcher="whisper_s2t", compiler="c_whisper"), False),
         ("stable_diffusion_v1_4", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
         ("sana", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
+        ("stable_diffusion_v1_4", dict(quantizer="diffusers_int8", compiler="torch_compile", torch_compile_fullgraph=False), False),
     ],
     indirect=["model_fixture"],
 )


### PR DESCRIPTION
## Description
Small PR that enable the combination of `diffusers_int8` quantizer and `torch_compile` for diffusers model.
The change in the code is minimal, but the results are interesting:
- following the previous work on HQQ (#23), we quantize and compile the denoiser inside the diffusers pipeline;
- I tested to compile the forward function of the denoiser instead (ie the call function of the unet or transformer), but the inference is not accelerated;
- I tested the inference time for 50 denoising steps on a Flux-8B-freepik model on a L40S GPU and obtained $23.63s$. After Bnb quantization, this number increases to $28.48s$. After quantization+compilation, we can reduce this number to $23.69s$;
- Note that the default compilation (ie capturing the full graph) will raise an error on a bnb-quantized model (because bnb will dynamically look for outliers in the inputs. JIT compilation does not support dynamic input with the default torch.compile parameters). To bypass this, we should set `smash_config['torch_compile_fullgraph'] = False`
- I also tested to compile (both the model and the forward) of a model quantized with `quanto`, but it fails because quanto uses 'fake_tensors' that are not compatible with torch.compile.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
I added a combination test on a sd model: 
![image](https://github.com/user-attachments/assets/11c1000a-c540-4123-99ff-cbf9c21d5282)
Other unit test are still valid, and I have tested to save and re-load the model that was quantized+compiled in this [notebook](https://drive.google.com/file/d/1Wf623h9Lzjl-XnUF--jHj_Edk7XxRBKi/view?usp=sharing).


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
Similar results can be obtained in `pruna_pro` with the combination of HIGGS quantizer and torch.compile (but with better memory reduction! you can go up to $3$ or $2$ bits):
- Initial inference time after quantization is $31.40s$, and can be reduced to $25.65s$ after compilation;
- current experiments are run to improve this speedup, and also enjoy speedup for batch inference. 