### PR TITLE
ci: adjust workflow target of documentation build

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,7 +1,12 @@
 name: Algorithm Docs Generation
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
-  pull_request:
+  workflow_dispatch:
+  push:
     branches:
       - main
 


### PR DESCRIPTION
## Description
In line with our efforts to **use the GitHub action resources mindfully**, this PR proposes to run the documentation after a merge to main or on dispatch (with the click of a button), similar to the [installation workflow](https://github.com/PrunaAI/pruna/pull/43). 
Rationale:
- this workflow is only relevant for a PR adding a documentation snippet or a new algorithm. Since this is the case for a smaller-ish portion of the PRs I would propose this change - if needed this can be run by the PR opening person or reviewer.
- to catch any mistakes that might have been overlooked this is run once when a PR is merged to main. Even in the case where it fails, this is fine, as the documentation will only be built on a new release and we will be able to fix it until then.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
None - the workflow target is tested already with the installation and works as intended.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
Quickly also added the permissions for the workflow in this PR - this is recommended by the GitHub security actions.
