### PR TITLE
chore: remove a double dependency when installing pruna[full]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ full = [
     "autoawq",
     "xformers",
     "stable-fast-pruna",
-    "autoawq",
 ]
 dev = [
     "jupyterlab",


### PR DESCRIPTION
## Description
full installation of pruna contained the dependancy autoawq twice, so removed one


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Uninstalled pruna&autoawq and reinstalled both via installing pruna[full]

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
