### PR TITLE
fix: python version compatibility and mypy issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: check-pruna-pro
         name: Check for pruna_pro
         entry: >
-          bash -c "git diff --cached --name-status | awk '$1 != \"D\" {print $2}' | xargs grep -q 'pruna_pro' && { echo 'Error: pruna_pro found'; exit 1; } || exit 0"
+          bash -c "git diff --cached --name-status | awk '\$1 != \"D\" && \$2 !~ /^docs\\// {print \$2}'| xargs grep -q 'pruna_pro' && { echo 'Error: pruna_pro found'; exit 1; } || exit 0"
         language: system
         stages: [pre-commit]
         types: [text]

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 from typing import Any
 
@@ -42,7 +44,9 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}." if required_install_str else "",
+            f"| **Required install**: {required_install_str}."
+            if required_install_str
+            else "",
         ]
     )
 
@@ -78,12 +82,20 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+    header_line = (
+        "|"
+        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
+        + "|"
+    )
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+        row_line = (
+            "|"
+            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
+            + "|"
+        )
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 121
 
 [tool.ruff.lint]
 ignore = ["ANN002", "ANN003", "ANN401", "C901", "D100", "D104", "D401", "D406", "C408"]
-select = ["A", "C", "CPY", "D", "E", "ERA", "F", "FIX", "I", "N", "SIM", "T20", "W"]
+select = ["A", "C", "CPY", "D", "E", "ERA", "F", "FIX", "I", "N", "SIM", "T20", "W", "FA"]
 preview = true  # enable preview features for copyright checking
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import os
 import shutil
@@ -20,10 +21,10 @@ from ConfigSpace import OrdinalHyperparameter
 from tokenizers import Tokenizer
 from transformers import (
     AutomaticSpeechRecognitionPipeline,
-    AutoModelForSpeechSeq2Seq,
     AutoTokenizer,
     WhisperForConditionalGeneration,
 )
+from transformers.modeling_utils import PreTrainedModel
 
 from pruna.algorithms.batching import PrunaBatcher
 from pruna.algorithms.compilation.c_translate import WhisperWrapper
@@ -196,13 +197,13 @@ class WhisperS2TWrapper:
 
     Parameters
     ----------
-    whisper : AutoModelForSpeechSeq2Seq
+    whisper : PreTrainedModel
         The underlying WhisperS2T model.
     batch_size : int | None
         The batch size for the model.
     """
 
-    def __init__(self, whisper: AutoModelForSpeechSeq2Seq, batch_size: int | None = None) -> None:
+    def __init__(self, whisper: PreTrainedModel, batch_size: int | None = None) -> None:
         self.whisper = whisper
         self.batch_size = batch_size
         self._device = whisper.device

--- a/src/pruna/algorithms/pruna_base.py
+++ b/src/pruna/algorithms/pruna_base.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict

--- a/src/pruna/algorithms/pruning/torch_structured.py
+++ b/src/pruna/algorithms/pruning/torch_structured.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import torch
 import torch.nn as nn
@@ -495,7 +496,7 @@ def update_dimensions_post_pruning(model: nn.Module, pruner: Any, imported_modul
             if isinstance(m, LlamaAttention):
                 # override attention parameters to handle pruned model
                 # handles both prune_num_heads and prune_head_dims
-                m.num_heads = pruner.num_heads[m.q_proj]
+                m.num_heads = cast(int, pruner.num_heads[m.q_proj])  # type: ignore[assignment]
                 m.num_key_value_heads = pruner.num_heads[m.k_proj]
                 m.head_dim = m.q_proj.out_features // m.num_heads
                 m.hidden_size = m.head_dim * m.num_heads

--- a/src/pruna/algorithms/quantization/__init__.py
+++ b/src/pruna/algorithms/quantization/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from pruna.algorithms.pruna_base import PrunaAlgorithmBase
 from pruna.config.smash_space import QUANTIZER
 from pruna.engine.save import SAVE_FUNCTIONS

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -23,9 +23,10 @@ from warnings import warn
 
 import numpy as np
 import torch
-import transformers
 from ConfigSpace import Configuration, ConfigurationSpace
 from transformers import AutoProcessor, AutoTokenizer
+from transformers.processing_utils import ProcessorMixin
+from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from pruna.config.smash_space import ALGORITHM_GROUPS, SMASH_SPACE
 from pruna.data.pruna_datamodule import PrunaDataModule, TokenizerMissingError
@@ -84,8 +85,8 @@ class SmashConfig:
         self.save_fns: list[str] = []
         self.load_fn: str | None = None
         self.reapply_after_load: dict[str, str | None] = dict.fromkeys(ALGORITHM_GROUPS)
-        self.tokenizer = None
-        self.processor = None
+        self.tokenizer: PreTrainedTokenizerBase | None = None
+        self.processor: ProcessorMixin | None = None
         self._data: PrunaDataModule | None = None
 
         # internal variable *to save time* by avoiding compilers saving models for inference-only smashing
@@ -344,7 +345,7 @@ class SmashConfig:
     def _(self, datamodule: PrunaDataModule) -> None:
         self._data = datamodule
 
-    def add_tokenizer(self, tokenizer: str | transformers.AutoTokenizer) -> None:
+    def add_tokenizer(self, tokenizer: str | PreTrainedTokenizerBase) -> None:
         """
         Add a tokenizer to the SmashConfig.
 
@@ -358,7 +359,7 @@ class SmashConfig:
         else:
             self.tokenizer = tokenizer
 
-    def add_processor(self, processor: str | transformers.AutoProcessor) -> None:
+    def add_processor(self, processor: str | ProcessorMixin) -> None:
         """
         Add a processor to the SmashConfig.
 

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import atexit
 import json
 import os

--- a/src/pruna/config/smash_space.py
+++ b/src/pruna/config/smash_space.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import copy
 import itertools
 from typing import Any, Union

--- a/src/pruna/data/collate.py
+++ b/src/pruna/data/collate.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Callable, List, Tuple
 
 import torch

--- a/src/pruna/data/collate.py
+++ b/src/pruna/data/collate.py
@@ -16,7 +16,7 @@ from typing import Any, Callable, List, Tuple
 
 import torch
 from torchvision import transforms
-from transformers import AutoTokenizer
+from transformers.tokenization_utils import PreTrainedTokenizer as AutoTokenizer
 
 
 def image_format_to_transforms(output_format: str, img_size: int) -> transforms.Compose:

--- a/src/pruna/data/pruna_datamodule.py
+++ b/src/pruna/data/pruna_datamodule.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import inspect
 from functools import partial
 from typing import Callable, List, Tuple, Union

--- a/src/pruna/data/pruna_datamodule.py
+++ b/src/pruna/data/pruna_datamodule.py
@@ -20,7 +20,7 @@ from datasets import Dataset, IterableDataset
 from pytorch_lightning import LightningDataModule
 from torch.utils.data import DataLoader, Subset
 from torch.utils.data import Dataset as TorchDataset
-from transformers import AutoTokenizer
+from transformers.tokenization_utils import PreTrainedTokenizer as AutoTokenizer
 
 from pruna.data import base_datasets
 from pruna.data.collate import pruna_collate_fns

--- a/src/pruna/data/utils.py
+++ b/src/pruna/data/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Tuple, Union
 
 import torch

--- a/src/pruna/engine/handler/handler_diffuser.py
+++ b/src/pruna/engine/handler/handler_diffuser.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import inspect
 from typing import Any, Dict, Optional, Tuple
 

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Tuple
 

--- a/src/pruna/engine/handler/handler_standard.py
+++ b/src/pruna/engine/handler/handler_standard.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch

--- a/src/pruna/engine/handler/handler_transformer.py
+++ b/src/pruna/engine/handler/handler_transformer.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch

--- a/src/pruna/engine/handler/handler_utils.py
+++ b/src/pruna/engine/handler/handler_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import inspect
 from typing import Any
 

--- a/src/pruna/engine/model_checks.py
+++ b/src/pruna/engine/model_checks.py
@@ -14,14 +14,16 @@
 
 import inspect
 from types import ModuleType
-from typing import Any, List
+from typing import Any, Dict, List, Type
 
 import diffusers
 import diffusers.models.transformers as diffusers_transformers
-from transformers import (
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.auto.modeling_auto import (
     MODEL_FOR_CAUSAL_LM_MAPPING,
-    AutoModelForSeq2SeqLM,
-    AutoModelForSpeechSeq2Seq,
+    MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING,
+    MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
 )
 
 
@@ -56,7 +58,7 @@ def is_translation_model(model: Any) -> bool:
     bool
         True if the model is a translation model, False otherwise.
     """
-    seq2seq_mapping = AutoModelForSeq2SeqLM._model_mapping
+    seq2seq_mapping: Dict[str, Type[PreTrainedModel]] = MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING
     return isinstance(model, tuple(seq2seq_mapping.values()))
 
 
@@ -74,7 +76,7 @@ def is_speech_seq2seq_model(model: Any) -> bool:
     bool
         True if the model is a speech seq2seq model, False otherwise.
     """
-    speech_seq2seq_mapping = AutoModelForSpeechSeq2Seq._model_mapping
+    speech_seq2seq_mapping: Dict[Type[PretrainedConfig], Type[PreTrainedModel]] = MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING
     return isinstance(model, tuple(speech_seq2seq_mapping.values()))
 
 

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, List, Tuple
 
 import torch

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import gc
 import inspect
 import json

--- a/src/pruna/evaluation/metrics/metric_cmmd.py
+++ b/src/pruna/evaluation/metrics/metric_cmmd.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, List
 
 import torch

--- a/src/pruna/evaluation/metrics/metric_elapsed_time.py
+++ b/src/pruna/evaluation/metrics/metric_elapsed_time.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import time
 from typing import Any, Dict
 

--- a/src/pruna/evaluation/metrics/metric_energy.py
+++ b/src/pruna/evaluation/metrics/metric_energy.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, Dict
 
 import torch

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Optional, Type
 

--- a/src/pruna/evaluation/metrics/metric_model_architecture.py
+++ b/src/pruna/evaluation/metrics/metric_model_architecture.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import inspect
 from typing import Any, Dict, List, Tuple
 

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, List, cast
 
 import torch

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -17,8 +17,8 @@ from typing import Any, List, cast
 import torch
 from torch import Tensor
 from torchmetrics.multimodal.clip_score import CLIPScore
-from transformers import CLIPModel as _CLIPModel
-from transformers import CLIPProcessor as _CLIPProcessor
+from transformers.models.clip.modeling_clip import CLIPModel as _CLIPModel
+from transformers.models.clip.processing_clip import CLIPProcessor as _CLIPProcessor
 
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
@@ -64,7 +64,12 @@ class PairwiseClipScore(CLIPScore, StatefulMetric):
         """
         metric_inputs = metric_data_processor(x, gt, outputs, self.call_type)
         source, target = metric_inputs
-        score, n_samples = _clip_score_update(cast(Tensor, source), cast(Tensor, target), self.model, self.processor)
+        score, n_samples = _clip_score_update(
+            cast(Tensor, source),
+            cast(Tensor, target),
+            cast(_CLIPModel, self.model),
+            cast(_CLIPProcessor, self.processor),
+        )
         self.score += score.sum(0)
         self.n_samples += n_samples
 
@@ -156,7 +161,7 @@ def _clip_score_update(
     target_data = _process_image_data(target)
 
     device = source_data[0].device
-    model = model.to(device)
+    model = cast(Any, model).to(device)
 
     source_features = _get_features(source_data, device, model, processor)
     target_features = _get_features(target_data, device, model, processor)

--- a/src/pruna/evaluation/metrics/metric_stateful.py
+++ b/src/pruna/evaluation/metrics/metric_stateful.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from abc import abstractmethod
 from copy import deepcopy
 from typing import Any, Dict, List

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, List, Optional, Union

--- a/src/pruna/evaluation/metrics/utils.py
+++ b/src/pruna/evaluation/metrics/utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, List
 
 import torch

--- a/src/pruna/evaluation/task.py
+++ b/src/pruna/evaluation/task.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any, List, cast
 
 import torch

--- a/src/pruna/telemetry/metrics.py
+++ b/src/pruna/telemetry/metrics.py
@@ -43,6 +43,8 @@ Configuration:
     >>> set_telemetry_metrics(True, set_as_default=True)
 """
 
+from __future__ import annotations
+
 import functools
 import inspect
 import logging


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
`transformers == 4.51` introduced some mypy errors as referenced huggingface/transformers#37339
Also addresses compatibility issues with Python <3.10 caused by the use of the `|` (union) operator.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

