### PR TITLE
build: bump version number to `v0.2.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ ignore_missing_imports = true
 
 [tool.poetry]
 name = "pruna"
-version = "0.2.1"
+version = "0.2.2"
 description = "Smash your AI models"
 authors = ["Pruna AI <hello@pruna.ai>"]
 license = "All Rights Reserved"


### PR DESCRIPTION
## Description
This PR bumps the version number to `v0.2.2`.
