### PR TITLE
feat: `max_batch_size` refactoring

### DIFF
--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -114,6 +114,7 @@ class IFWBatcher(PrunaBatcher):
 
         # ignore mypy warnings here because we ensure beforehand that processor is not None
         pruna_logger.info(f"Preparing model for inference with batch size {smash_config.batch_size}")
+        smash_config.lock_batch_size()
         pipe = pipeline(
             "automatic-speech-recognition",
             model=model,

--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -22,6 +22,7 @@ from transformers.utils import is_flash_attn_2_available
 from pruna.algorithms.batching import PrunaBatcher
 from pruna.algorithms.compilation.c_translate import WhisperWrapper
 from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.logging.logger import pruna_logger
 
 
 class IFWBatcher(PrunaBatcher):
@@ -31,6 +32,8 @@ class IFWBatcher(PrunaBatcher):
     Insanely Fast Whisper is an optimized version of Whisper models that significantly speeds up transcription.
     It achieves lower latency and higher throughput through low-level code optimizations and efficient batching,
     making real-time speech recognition more practical.
+    Note: IFW prepares the model for inference with the batch size specified in the smash config. Make sure to set the
+    batch size to a value that corresponds to your inference requirements.
     """
 
     algorithm_name = "ifw"
@@ -110,6 +113,7 @@ class IFWBatcher(PrunaBatcher):
         torch_dtype = torch.float16 if smash_config["weight_bits"] == 16 else torch.float32
 
         # ignore mypy warnings here because we ensure beforehand that processor is not None
+        pruna_logger.info(f"Preparing model for inference with batch size {smash_config.batch_size}")
         pipe = pipeline(
             "automatic-speech-recognition",
             model=model,

--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -58,12 +58,6 @@ class IFWBatcher(PrunaBatcher):
                 default_value=16,
                 meta=dict(desc="Sets the number of bits to use for weight quantization."),
             ),
-            OrdinalHyperparameter(
-                "batch_size",
-                sequence=[1, 2, 4, 8, 16, 32, 64],
-                default_value=16,
-                meta=dict(desc="The batch size to use for inference. Higher is faster but needs more memory."),
-            ),
             Constant(name="chunk_length", value=30),
         ]
 
@@ -122,7 +116,7 @@ class IFWBatcher(PrunaBatcher):
             tokenizer=smash_config.processor.tokenizer,  # type: ignore[attr-defined]
             feature_extractor=smash_config.processor.feature_extractor,  # type: ignore[attr-defined]
             chunk_length_s=smash_config["chunk_length"],
-            batch_size=smash_config["batch_size"],
+            batch_size=smash_config.batch_size,
             torch_dtype=torch_dtype,
             model_kwargs=(
                 {"attn_implementation": "flash_attention_2"}

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -39,6 +39,8 @@ class WS2TBatcher(PrunaBatcher):
     Implement whisper_s2t processing using the whisper_s2t library.
 
     WhisperS2T is an optimized speech-to-text pipeline built for Whisper models.
+    Note: WS2T prepares the model for inference with the batch size specified in the smash config. Make sure to set the
+    batch size to a value that corresponds to your inference requirements.
     """
 
     algorithm_name = "whisper_s2t"
@@ -168,6 +170,7 @@ class WS2TBatcher(PrunaBatcher):
             model.max_speech_len = max_speech_len
         if "max_text_token_len" in locals():
             model.max_text_token_len = max_text_token_len
+        pruna_logger.info(f"Preparing model for inference with batch size {smash_config.batch_size}...")
         return WhisperS2TWrapper(model, smash_config.batch_size)
 
     def import_algorithm_packages(self) -> Dict[str, Any]:

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -17,7 +17,6 @@ import os
 import shutil
 from typing import Any, Dict, List, Union
 
-from ConfigSpace import OrdinalHyperparameter
 from tokenizers import Tokenizer
 from transformers import (
     AutomaticSpeechRecognitionPipeline,
@@ -62,12 +61,6 @@ class WS2TBatcher(PrunaBatcher):
         """
         return [
             Boolean("int8", meta=dict(desc="Whether to quantize to int8 for inference.")),
-            OrdinalHyperparameter(
-                "batch_size",
-                sequence=[1, 2, 4, 8, 16, 32, 64],
-                meta=dict(desc="The batch size to use for inference. Higher is faster but needs more memory."),
-                default_value=16,
-            ),
         ]
 
     def model_check_fn(self, model: Any) -> bool:
@@ -175,7 +168,7 @@ class WS2TBatcher(PrunaBatcher):
             model.max_speech_len = max_speech_len
         if "max_text_token_len" in locals():
             model.max_text_token_len = max_text_token_len
-        return WhisperS2TWrapper(model, smash_config["batch_size"])
+        return WhisperS2TWrapper(model, smash_config.batch_size)
 
     def import_algorithm_packages(self) -> Dict[str, Any]:
         """

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -171,6 +171,7 @@ class WS2TBatcher(PrunaBatcher):
         if "max_text_token_len" in locals():
             model.max_text_token_len = max_text_token_len
         pruna_logger.info(f"Preparing model for inference with batch size {smash_config.batch_size}...")
+        smash_config.lock_batch_size()
         return WhisperS2TWrapper(model, smash_config.batch_size)
 
     def import_algorithm_packages(self) -> Dict[str, Any]:

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -88,12 +88,6 @@ class TorchCompileCompiler(PrunaCompiler):
                 meta=dict(desc="Whether to use dynamic shape tracing or not."),
             ),
             OrdinalHyperparameter(
-                "batch_size",
-                sequence=[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024],
-                default_value=1,
-                meta=dict(desc="The batch size to use for compilation, for LLMs."),
-            ),
-            OrdinalHyperparameter(
                 "max_kv_cache_size",
                 sequence=[100, 200, 400, 512, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400],
                 default_value=400,
@@ -342,7 +336,7 @@ def causal_lm_logic(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         top_k=top_k,
         compile_mode=smash_config["mode"],
         compile_fullgraph=smash_config["fullgraph"],
-        batch_size=smash_config["batch_size"],
+        batch_size=smash_config.batch_size,
         device=smash_config.device,
     )
     # If we are using max-autotune-no-cudagraphs, we need to handle the cudagraphs manually.

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -127,7 +127,7 @@ class GPTQQuantizer(PrunaQuantizer):
             )
 
             model = imported_modules["GPTQModel"].load(temp_dir, gptq_config)
-            model.quantize(calib_data, batch_size=smash_config.max_batch_size)
+            model.quantize(calib_data, batch_size=smash_config.batch_size)
             model.save(temp_dir)
             model = imported_modules["GPTQModel"].load(temp_dir)
 

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -64,7 +64,6 @@ class QuantoQuantizer(PrunaQuantizer):
             Constant("act_bits", value=None),
             Boolean("calibrate", default=True, meta=dict(desc="Whether to calibrate the model.")),
             Constant(name="calibration_samples", value=64),
-            Constant(name="calibration_batch_size", value=16),
         ]
 
     def model_check_fn(self, model: Any) -> bool:
@@ -132,7 +131,7 @@ class QuantoQuantizer(PrunaQuantizer):
                             working_model,
                             smash_config.val_dataloader(),
                             smash_config["device"],
-                            batch_size=smash_config["calibration_batch_size"],
+                            batch_size=smash_config.batch_size,
                             samples=smash_config["calibration_samples"],
                         )
                 except Exception as e:

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -125,7 +125,7 @@ class QuantoQuantizer(PrunaQuantizer):
             raise
 
         if smash_config["calibrate"]:
-            if smash_config.tokenizer is not None and smash_config._data is not None:
+            if smash_config.tokenizer is not None and smash_config.data is not None:
                 try:
                     with imported_modules["Calibration"](streamline=True, debug=False):
                         calibrate(

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -592,6 +592,7 @@ class SmashConfig:
                 "ifw_batch_size",
                 "higgs_example_batch_size",
                 "diffusers_higgs_example_batch_size",
+                "torch_compile_batch_size",
             ]
             if name in deprecated_hyperparameters:
                 warn(

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -81,7 +81,7 @@ class SmashConfig:
         self.config_space: ConfigurationSpace = self._configuration.config_space
         if max_batch_size is not None:
             warn(
-                "max_batch_size is soon to be deprecated. Please use batch_size instead.",
+                "max_batch_size is deprecated. Please use batch_size instead.",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -105,6 +105,9 @@ class SmashConfig:
         # internal variable *to save time* by avoiding compilers saving models for inference-only smashing
         self._prepare_saving = True
 
+        # internal variable to indicated that a model has been smashed for a specific batch size
+        self.__locked_batch_size = False
+
         # ensure the cache directory is deleted on program exit
         atexit.register(self.cleanup_cache_dir)
 
@@ -442,6 +445,14 @@ class SmashConfig:
         else:
             return self.tokenizer.name_or_path
 
+    def lock_batch_size(self) -> None:
+        """Lock the batch size in the SmashConfig."""
+        self.__locked_batch_size = True
+
+    def is_batch_size_locked(self) -> bool:
+        """Check if the batch size is locked in the SmashConfig."""
+        return self.__locked_batch_size
+
     def __getitem__(self, name: str) -> Any:
         """
         Get a configuration value from the configuration.
@@ -663,6 +674,10 @@ class SmashConfigPrefixWrapper:
             The value from the config.
         """
         return getattr(self._base_config, attr)
+
+    def lock_batch_size(self) -> None:
+        """Lock the batch size in the SmashConfig."""
+        self._base_config.lock_batch_size()
 
 
 def convert_numpy_types(input_value: Any) -> Any:

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -450,7 +450,14 @@ class SmashConfig:
         self.__locked_batch_size = True
 
     def is_batch_size_locked(self) -> bool:
-        """Check if the batch size is locked in the SmashConfig."""
+        """
+        Check if the batch size is locked in the SmashConfig.
+
+        Returns
+        -------
+        bool
+            True if the batch size is locked, False otherwise.
+        """
         return self.__locked_batch_size
 
     def __getitem__(self, name: str) -> Any:

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -89,7 +89,7 @@ class SmashConfig:
         self.reapply_after_load: dict[str, str | None] = dict.fromkeys(ALGORITHM_GROUPS)
         self.tokenizer: PreTrainedTokenizerBase | None = None
         self.processor: ProcessorMixin | None = None
-        self._data: PrunaDataModule | None = None
+        self.data: PrunaDataModule | None = None
 
         # internal variable *to save time* by avoiding compilers saving models for inference-only smashing
         self._prepare_saving = True
@@ -188,7 +188,7 @@ class SmashConfig:
             self.tokenizer.save_pretrained(os.path.join(path, TOKENIZER_SAVE_PATH))
         if self.processor:
             self.processor.save_pretrained(os.path.join(path, PROCESSOR_SAVE_PATH))
-        if self._data is not None:
+        if self.data is not None:
             pruna_logger.info("Data detected in smash config, this will be detached and not reloaded...")
 
     def load_dict(self, config_dict: dict) -> None:
@@ -324,7 +324,7 @@ class SmashConfig:
     def _(self, dataset_name: str, *args, **kwargs) -> None:
         try:
             kwargs["tokenizer"] = self.tokenizer
-            self._data = PrunaDataModule.from_string(dataset_name, *args, **kwargs)
+            self.data = PrunaDataModule.from_string(dataset_name, *args, **kwargs)
         except TokenizerMissingError:
             raise ValueError(
                 f"Tokenizer is required for {dataset_name} but not provided. "
@@ -335,7 +335,7 @@ class SmashConfig:
     def _(self, datasets: list, collate_fn: str, *args, **kwargs) -> None:
         try:
             kwargs["tokenizer"] = self.tokenizer
-            self._data = PrunaDataModule.from_datasets(datasets, collate_fn, *args, **kwargs)
+            self.data = PrunaDataModule.from_datasets(datasets, collate_fn, *args, **kwargs)
         except TokenizerMissingError:
             raise ValueError(
                 f"Tokenizer is required for {collate_fn} but not provided. "
@@ -346,7 +346,7 @@ class SmashConfig:
     def _(self, datasets: tuple, collate_fn: str, *args, **kwargs) -> None:
         try:
             kwargs["tokenizer"] = self.tokenizer
-            self._data = PrunaDataModule.from_datasets(datasets, collate_fn, *args, **kwargs)
+            self.data = PrunaDataModule.from_datasets(datasets, collate_fn, *args, **kwargs)
         except TokenizerMissingError:
             raise ValueError(
                 f"Tokenizer is required for {collate_fn} but not provided. "
@@ -355,7 +355,7 @@ class SmashConfig:
 
     @add_data.register(PrunaDataModule)
     def _(self, datamodule: PrunaDataModule) -> None:
-        self._data = datamodule
+        self.data = datamodule
 
     def add_tokenizer(self, tokenizer: str | PreTrainedTokenizerBase) -> None:
         """
@@ -403,7 +403,7 @@ class SmashConfig:
             raise ValueError(
                 f"{algorithm_name} requires a processor. Please provide it with smash_config.add_processor()."
             )
-        if algorithm_requirements["dataset_required"] and self._data is None:
+        if algorithm_requirements["dataset_required"] and self.data is None:
             raise ValueError(f"{algorithm_name} requires a dataset. Please provide it with smash_config.add_data().")
 
     def get_tokenizer_name(self) -> str | None:

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -161,6 +161,12 @@ class SmashConfig:
                 if name in config_dict:
                     del config_dict[name]
                 continue
+
+            # backwards compatibility for old batch size argument
+            if name == "batch_size" and "batch_size" not in config_dict:
+                setattr(self, name, config_dict.pop("max_batch_size"))
+                continue
+
             setattr(self, name, config_dict.pop(name))
 
         self._configuration = Configuration(SMASH_SPACE, values=config_dict)

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -262,7 +262,7 @@ class SmashConfig:
         if "batch_size" in kwargs and kwargs["batch_size"] != self.batch_size:
             pruna_logger.warning(
                 f"Batch size {kwargs['batch_size']} is not the same as the batch size {self.batch_size}"
-                f"set in the SmashConfig. Using the {self.batch_size} from the SmashConfig."
+                f"set in the SmashConfig. Using the {self.batch_size}."
             )
         kwargs["batch_size"] = self.batch_size
         return getattr(self.data, dataloader_name)(**kwargs)
@@ -298,7 +298,7 @@ class SmashConfig:
 
         Returns
         -------
-        DataLoader | None
+        torch.utils.data.DataLoader | None
             The DataLoader instance associated with the SmashConfig.
         """
         return self.__get_dataloader("val_dataloader", **kwargs)
@@ -316,7 +316,7 @@ class SmashConfig:
 
         Returns
         -------
-        DataLoader | None
+        torch.utils.data.DataLoader | None
             The DataLoader instance associated with the SmashConfig.
         """
         return self.__get_dataloader("test_dataloader", **kwargs)

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -563,16 +563,23 @@ class SmashConfig:
             name = remove_starting_prefix(name)
             # deprecation logic over
             # start of deprecation logic for batch size as algorithm hyperparameter
-            deprecated_hyperparameters = ["batch_size"]
+            deprecated_hyperparameters = [
+                "whisper_s2t_batch_size",
+                "ifw_batch_size",
+                "higgs_example_batch_size",
+                "diffusers_higgs_example_batch_size",
+            ]
             if name in deprecated_hyperparameters:
                 warn(
-                    f"The {name} hyperparameter is deprecated. Please use smash_config.batch_size instead.",
+                    f"The {name} hyperparameter is deprecated. You can use SmashConfig(batch_size={value}) or "
+                    f"smash_config.batch_size={value} instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
                 self.batch_size = value
             # end of deprecation logic for batch size as algorithm hyperparameter
-            return self._configuration.__setitem__(name, value)
+            else:
+                return self._configuration.__setitem__(name, value)
 
     def __getattr__(self, attr: str) -> object:  # noqa: D105
         if attr == "_data":

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -124,6 +124,18 @@ class EvaluationAgent:
             pruna_logger.info("Evaluating a base model.")
 
         model.inference_handler.log_model_info()
+        if (
+            "batch_size" in self.task.datamodule.dataloader_args
+            and self.task.datamodule.dataloader_args["batch_size"] != model.smash_config.batch_size
+            and not is_base
+        ):
+            pruna_logger.warning(
+                "Batch size mismatch between evaluation datamodule and smashed model's smash config. "
+                "This may lead to incorrect metric computation due to compression algorithms being batch size specific. "
+                "Adjust the datamodule creation to match the smashed model's batch size, e.g., "
+                "datamodule = PrunaDataModule.from_string(dataset_name, dataloader_args={'batch_size': %d})",
+                model.smash_config.batch_size,
+            )
 
         return model
 

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -128,6 +128,7 @@ class EvaluationAgent:
             "batch_size" in self.task.datamodule.dataloader_args
             and self.task.datamodule.dataloader_args["batch_size"] != model.smash_config.batch_size
             and not is_base
+            and model.smash_config.is_batch_size_locked()
         ):
             pruna_logger.warning(
                 "Batch size mismatch between evaluation datamodule and smashed model's smash config. "

--- a/tests/config/test_smashconfig_data.py
+++ b/tests/config/test_smashconfig_data.py
@@ -44,7 +44,7 @@ def test_dm_from_datasets_to_config(setup_fn: Callable, collate_fn: Callable, co
 @pytest.mark.cpu
 @pytest.mark.parametrize(
     "setup_fn, collate_fn_defaults, args_override",
-    [(setup_imagenet_dataset, dict(img_size=224), dict(img_size=16, batch_size=5))],
+    [(setup_imagenet_dataset, dict(img_size=224))],
 )
 def test_img_args_override(
     setup_fn: Callable, collate_fn_defaults: dict[str, Any], args_override: dict[str, Any]

--- a/tests/config/test_smashconfig_data.py
+++ b/tests/config/test_smashconfig_data.py
@@ -44,7 +44,7 @@ def test_dm_from_datasets_to_config(setup_fn: Callable, collate_fn: Callable, co
 @pytest.mark.cpu
 @pytest.mark.parametrize(
     "setup_fn, collate_fn_defaults, args_override",
-    [(setup_imagenet_dataset, dict(img_size=224))],
+    [(setup_imagenet_dataset, dict(img_size=224), dict(img_size=16))],
 )
 def test_img_args_override(
     setup_fn: Callable, collate_fn_defaults: dict[str, Any], args_override: dict[str, Any]
@@ -56,6 +56,5 @@ def test_img_args_override(
     for get_dataloader in [smash_config.train_dataloader, smash_config.val_dataloader, smash_config.test_dataloader]:
         dataloader = get_dataloader(**args_override)
         image, _ = next(iter(dataloader))
-        assert image.shape[0] == args_override["batch_size"]
         assert image.shape[2] == args_override["img_size"]
         assert image.shape[3] == args_override["img_size"]

--- a/tests/config/test_smashconfig_data.py
+++ b/tests/config/test_smashconfig_data.py
@@ -15,7 +15,7 @@ def test_dm_from_string_to_config(dataset_name: str, collate_fn_args: dict[str, 
     """Test the datamodule from a string to config."""
     smash_config = SmashConfig()
     smash_config.add_data(dataset_name, collate_fn_args=collate_fn_args)
-    iterate_dataloaders(smash_config._data)
+    iterate_dataloaders(smash_config.data)
 
 
 @pytest.mark.cpu
@@ -25,7 +25,7 @@ def test_dm_to_config(dataset_name: str, collate_fn_args: dict[str, Any]) -> Non
     datamodule = PrunaDataModule.from_string(dataset_name, collate_fn_args=collate_fn_args)
     smash_config = SmashConfig()
     smash_config.add_data(datamodule)
-    iterate_dataloaders(smash_config._data)
+    iterate_dataloaders(smash_config.data)
 
 
 @pytest.mark.cpu
@@ -38,7 +38,7 @@ def test_dm_from_datasets_to_config(setup_fn: Callable, collate_fn: Callable, co
     datasets = setup_fn(seed=123)
     smash_config = SmashConfig()
     smash_config.add_data(datasets, collate_fn=collate_fn, collate_fn_args=collate_fn_args)
-    iterate_dataloaders(smash_config._data)
+    iterate_dataloaders(smash_config.data)
 
 
 @pytest.mark.cpu


### PR DESCRIPTION
## Description
This PR refactors the usage of a batch size arguments for various methods. The user now sets the expected inference batch size once in the SmashConfig and this is used throughout the algorithms. The batch_size hyperparameters in the algorithms are deprecated accordingly. Additionally, I deprecated the naming of `max_batch_size` and renamed it to `batch_size`, as "max" might be misleading.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Ran tests for all affected methods and tested the deprecation locally - works as intended.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
None.
