### PR TITLE
fix: `collate_fn` compatibility check logging

### DIFF
--- a/src/pruna/data/pruna_datamodule.py
+++ b/src/pruna/data/pruna_datamodule.py
@@ -116,7 +116,8 @@ class PrunaDataModule(LightningDataModule):
         train_ds, val_ds, test_ds = datasets
         collate_func = get_collate_fn(collate_fn, collate_fn_args)
 
-        pruna_logger.info(f"Testing compatibility with {collate_func}...")
+        collate_func_name = collate_func.func.__name__ if isinstance(collate_func, partial) else collate_func.__name__
+        pruna_logger.info(f"Testing compatibility with {collate_func_name}...")
         try:
             for ds in [train_ds, val_ds, test_ds]:
                 # try collating two samples to test if batching works with the dataset


### PR DESCRIPTION
## Description
This PR quickly adjusts the logging when checking the dataset <-> `collate_fn` check happens.

before:
```
INFO - Using max_seq_len of tokenizer: None
INFO - Testing compatibility with functools.partial(<function text_generation_collate at 0x7f340cc3e8c0>, tokenizer=GPT2TokenizerFast(name_or_path='facebook/opt-125m', vocab_size=50265, model_max_length=1000000000000000019884624838656, is_fast=True, padding_side='right', truncation_side='right', special_tokens={'bos_token': '</s>', 'eos_token': '</s>', 'unk_token': '</s>', 'pad_token': '<pad>'}, clean_up_tokenization_spaces=False),  added_tokens_decoder={
	1: AddedToken("<pad>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=True),
	2: AddedToken("</s>", rstrip=False, lstrip=False, single_word=False, normalized=True, special=True),
}, max_seq_len=None)...
Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
INFO - Using call_type: y_gt for metric perplexity
INFO - Using provided list of metric instances.
```

after:
```
INFO - Using max_seq_len of tokenizer: None
INFO - Testing compatibility with text_generation_collate...
Asking to truncate to max_length but no maximum length is provided and the model has no predefined maximum length. Default to no truncation.
INFO - Using call_type: y_gt for metric perplexity
INFO - Using provided list of metric instances.
```

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Instantiated datamodule (for logs see above).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
