### PR TITLE
feat: automate loading arguments

### DIFF
--- a/docs/user_manual/save_load.rst
+++ b/docs/user_manual/save_load.rst
@@ -80,31 +80,6 @@ The load operation will:
 Special Considerations
 ----------------------
 
-Loading Keyword Arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~
-We generally recommend to load the smashed model in the same configuration as the base model, **in particular** if the two should be compared in terms of efficiency and quality.
-So, when the base model was loaded with e.g. a specific precision:
-
-.. code-block:: python
-
-    import torch
-    from diffusers import StableDiffusionPipeline
-
-    base_model = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.float16)
-
-you should also load the smashed model as follows:
-
-.. code-block:: python
-
-    from pruna import PrunaModel
-
-    loaded_model = PrunaModel.from_pretrained("saved_model/", torch_dtype=torch.float16)
-
-Depending on the saving function of the algorithm combination not all keyword arguments are required for loading (e.g. some are set by the algorithm combination itself).
-In that case, we discard and log a warning about unused keyword arguments.
-
-
-
 Algorithm Reapplication
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Some algorithms, particularly compilers and certain quantization methods, need to be reapplied after loading, as, for example, a compiled model can be rarely saved in its compiled state.

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -276,6 +276,19 @@ def load_diffusers_model(path: str, **kwargs) -> Any:
         # individual components like the unet or the vae are saved with a config.json file
         model_index = load_json_config(path, "config.json")
 
+    # make loading of model backward compatible with older versions
+    # in newer versions the dtype is always saved in the model_config.json file
+    dtype_info = load_json_config(path, "dtype_info.json")
+    try:
+        dtype = dtype_info["dtype"]
+        dtype = getattr(torch, dtype)
+    except KeyError:
+        dtype = torch.float32
+
+    # do not override user specified dtype
+    if "torch_dtype" not in kwargs:
+        kwargs["torch_dtype"] = dtype
+
     cls = getattr(diffusers, model_index["_class_name"])
     # transformers discards kwargs automatically, no need for filtering
     return cls.from_pretrained(path, **kwargs)

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -235,6 +235,10 @@ def load_transformers_model(path: str, **kwargs) -> Any:
     AutoModel | pipeline
         The loaded model or pipeline.
     """
+    if "torch_dtype" not in kwargs:
+        # unless specified by the user, load the model in the same dtype as the base model
+        kwargs["torch_dtype"] = "auto"
+
     if os.path.exists(os.path.join(path, PIPELINE_INFO_FILE_NAME)):
         with open(os.path.join(path, PIPELINE_INFO_FILE_NAME), "r") as f:
             pipeline_info = json.load(f)

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -34,6 +34,7 @@ from pruna.engine.load import (
     SAVE_BEFORE_SMASH_CACHE_DIR,
 )
 from pruna.engine.model_checks import get_helpers
+from pruna.engine.utils import determine_dtype
 from pruna.logging.logger import pruna_logger
 
 
@@ -190,6 +191,11 @@ def original_save_fn(model: Any, model_path: str, smash_config: SmashConfig) -> 
     if "diffusers" in model.__module__:
         smash_config.load_fns.append(LOAD_FUNCTIONS.diffusers.name)
         model.save_pretrained(model_path)
+        # save dtype of the model as diffusers does not provide this at the moment
+        dtype = determine_dtype(model)
+        # save dtype
+        with open(os.path.join(model_path, "dtype_info.json"), "w") as f:
+            json.dump({"dtype": str(dtype).split(".")[-1]}, f)
 
     elif "transformers" in model.__module__:
         smash_config.load_fns.append(LOAD_FUNCTIONS.transformers.name)


### PR DESCRIPTION
## Description
This PR aims to eliminate a common error, where the base model is loaded in a specific precision but the user forgets to specify this precision again when loading the smashed model. This can also lead to wrong results for the `GPUMemory` metric. 
Generally I've updated the documentation to remove guidance on loading arguments, as the most important arguments are covered:
- torch_dtype is handled automatically now based on the base model
- device is handled via the smash config device (even though in the future, for multi-gpu support, this has to be improved)
- other arguments like e.g. deactivating the safety checked for image generation are automatically ported to the new model

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Tested by running:
```python
import torch
from transformers import AutoModelForCausalLM, AutoTokenizer
from pruna import PrunaModel

model_id = "meta-llama/Llama-3.2-1B"
base_model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.bfloat16)
base_model = PrunaModel(base_model)
base_model.save_pretrained("saved_llm")
loaded_model = PrunaModel.from_pretrained("saved_llm")
print(loaded_model.lm_head.weight.dtype)
```
```bash
>> torch.bfloat16
```

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
