### PR TITLE
fix: `GPUMemory` metric memory bug

### DIFF
--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -103,7 +103,7 @@ def move_to_device(model: Any, device: str | torch.device, raise_error: bool = F
             # there is anyway no way to recover from this error
             # raise it here for better traceability
             raise e
-        except (ValueError, RecursionError, RuntimeError) as e:
+        except (ValueError, RecursionError, RuntimeError, AttributeError) as e:
             if raise_error:
                 raise ValueError(f"Could not move model to device: {str(e)}")
             else:

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -99,6 +99,10 @@ def move_to_device(model: Any, device: str | torch.device, raise_error: bool = F
     if hasattr(model, "to"):
         try:
             model.to(device)
+        except torch.cuda.OutOfMemoryError as e:
+            # there is anyway no way to recover from this error
+            # raise it here for better traceability
+            raise e
         except (ValueError, RecursionError, RuntimeError) as e:
             if raise_error:
                 raise ValueError(f"Could not move model to device: {str(e)}")

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -135,6 +135,7 @@ class GPUMemoryMetric(BaseMetric):
         save_path = model.smash_config.cache_dir + "/metrics_save"
         model_cls = model.__class__
         model.save_pretrained(save_path)
+        model.move_to_device("cpu")
 
         gpu_manager = GPUManager(self.gpu_indices)
         with gpu_manager.manage_resources():


### PR DESCRIPTION
## Description
This PR fixes a bug in the GPUMemory metric where two models are kept on the GPU at the same time. While this does not affect the correctness of the memory measurement, it can lead to OOM issues with models like e.g. Flux despite the model fitting on the GPU (as we are keeping it twice).

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Executed the metric on a previously failing Flux model.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
