### PR TITLE
fix: make kv cache dynamic based on input

### DIFF
--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -347,7 +347,7 @@ def causal_lm_logic(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
     )
     # If we are using max-autotune-no-cudagraphs, we need to handle the cudagraphs manually.
     if smash_config["mode"] == "max-autotune-no-cudagraphs":
-        gen.enable_cuda_graph(max_kv_cache_size=smash_config["seqlen_manual_cuda_graph"])
+        pruna_logger.error("max-autotune-no-cudagraphs is not supported for causal language models.")
     model.generate = gen.generate
     return model
 

--- a/src/pruna/algorithms/compilation/utils.py
+++ b/src/pruna/algorithms/compilation/utils.py
@@ -295,7 +295,7 @@ class TransformersGenerator:
 
         # Check if batch size changed compared to the cache configuration
         # Round up max_new_tokens to the nearest 1000 for better memory allocation
-        rounded_cache_size = ((max_new_tokens + 999) // 1000) * 1000
+        rounded_cache_size = ((inputs.shape[1] + max_new_tokens + 999) // 1000) * 1000
         if new_batch_size != self.cache_batch_size or self.cache_size != rounded_cache_size:
             if new_batch_size != self.cache_batch_size:
                 pruna_logger.info(

--- a/src/pruna/algorithms/compilation/utils.py
+++ b/src/pruna/algorithms/compilation/utils.py
@@ -297,25 +297,21 @@ class TransformersGenerator:
         # Round up max_new_tokens to the nearest 1000 for better memory allocation
         rounded_cache_size = ((inputs.shape[1] + max_new_tokens + 999) // 1000) * 1000
         if new_batch_size != self.cache_batch_size or self.cache_size != rounded_cache_size:
-            if new_batch_size != self.cache_batch_size:
-                pruna_logger.info(
-                    f"Batch size changed from {self.cache_batch_size} to {new_batch_size}. Re-initializing StaticCache."
-                )
-            else:
-                pruna_logger.info(
-                    f"Cache size changed from {self.cache_size} to {rounded_cache_size}. Re-initializing StaticCache."
-                )
+            pruna_logger.info(
+                f"Cache size changed from {self.cache_batch_size}x{self.cache_size} to "
+                f"{new_batch_size}x{rounded_cache_size}. Re-initializing StaticCache."
+            )
             self.batch_size = new_batch_size
             self.cache_batch_size = new_batch_size
             self.cache_size = rounded_cache_size
             self.setup_cache()
 
-            # If CUDA graph was used, it's now invalid
+            # If CUDA graph was used, recompile the graph
             if hasattr(self, "cuda_graph") and self.cuda_graph is not None:
-                pruna_logger.warning("CUDA graph is invalidated due to batch size change. Disabling CUDA graph usage.")
-                self.cuda_graph = None
-                self.gen_next_token = self.original_gen_next_token
-                self.do_capture_graph = False
+                pruna_logger.warning(
+                    "CUDA graph is invalidated due to batch size or cache size change. Recompiling the graph."
+                )
+                self.enable_cuda_graph(max_kv_cache_size=self.cache_size)
 
         # Reset cache contents (does not change shape)
         self.reset_cache()


### PR DESCRIPTION
## Description
This PR makes the kv cache dynamic and the user doesnt need to worry about defining this anymore. It also means we are using the most efficient kv cache possible.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Unit tests + notebook.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
We should remove batch size and cache_size after this change.