### PR TITLE
refactor: move argument compatibility checks

### DIFF
--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -408,27 +408,6 @@ class SmashConfig:
         else:
             self.processor = processor
 
-    def check_argument_compatibility(self, algorithm_name: str) -> None:
-        """
-        Check if the SmashConfig has the required arguments (tokenizer, processor, dataset) for an algorithm.
-
-        Parameters
-        ----------
-        algorithm_name : str
-            The algorithm name that is about to be activated.
-        """
-        algorithm_requirements = SMASH_SPACE.model_requirements[algorithm_name]
-        if algorithm_requirements["tokenizer_required"] and self.tokenizer is None:
-            raise ValueError(
-                f"{algorithm_name} requires a tokenizer. Please provide it with smash_config.add_tokenizer()."
-            )
-        if algorithm_requirements["processor_required"] and self.processor is None:
-            raise ValueError(
-                f"{algorithm_name} requires a processor. Please provide it with smash_config.add_processor()."
-            )
-        if algorithm_requirements["dataset_required"] and self.data is None:
-            raise ValueError(f"{algorithm_name} requires a dataset. Please provide it with smash_config.add_data().")
-
     def get_tokenizer_name(self) -> str | None:
         """
         Get a tokenizer object from a tokenizer name.
@@ -563,9 +542,6 @@ class SmashConfig:
                 deprecated = True
             ###
             # end of deprecation logic for assignment of algorithms as lists
-            ###
-            if value is not None:
-                self.check_argument_compatibility(value)
             if deprecated:
                 warn(f"Continuing with setting smash_config['{name}'] = '{value}'.", DeprecationWarning, stacklevel=2)
             self._configuration.__setitem__(name, value)

--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -110,6 +110,8 @@ def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str)
 
     Parameters
     ----------
+    smash_config : SmashConfig
+        The SmashConfig to check the argument consistency with.
     algorithm_name : str
         The algorithm name that is about to be activated.
     """

--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from pruna import PrunaModel, SmashConfig
 from pruna.algorithms import PRUNA_ALGORITHMS
-from pruna.config.smash_space import ALGORITHM_GROUPS
+from pruna.config.smash_space import ALGORITHM_GROUPS, SMASH_SPACE
 from pruna.logging.logger import PrunaLoggerContext, pruna_logger
 from pruna.telemetry import track_usage
 
@@ -96,12 +96,30 @@ def check_model_compatibility(
         algorithm = smash_config[current_group]
         if algorithm is not None:
             check_algorithm_availability(algorithm, current_group, algorithm_dict)
-
+            check_argument_compatibility(smash_config, algorithm)
             # check for model-algorithm compatibility with the model_check_fn
             if not algorithm_dict[current_group][algorithm].model_check_fn(model):
                 raise ValueError(
                     f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
                 )
+
+
+def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str) -> None:
+    """
+    Check if the SmashConfig has the required arguments (tokenizer, processor, dataset) for an algorithm.
+
+    Parameters
+    ----------
+    algorithm_name : str
+        The algorithm name that is about to be activated.
+    """
+    algorithm_requirements = SMASH_SPACE.model_requirements[algorithm_name]
+    if algorithm_requirements["tokenizer_required"] and smash_config.tokenizer is None:
+        raise ValueError(f"{algorithm_name} requires a tokenizer. Please provide it with smash_config.add_tokenizer().")
+    if algorithm_requirements["processor_required"] and smash_config.processor is None:
+        raise ValueError(f"{algorithm_name} requires a processor. Please provide it with smash_config.add_processor().")
+    if algorithm_requirements["dataset_required"] and smash_config.data is None:
+        raise ValueError(f"{algorithm_name} requires a dataset. Please provide it with smash_config.add_data().")
 
 
 def check_algorithm_availability(algorithm: str, algorithm_group: str, algorithm_dict: dict[str, Any]) -> None:


### PR DESCRIPTION
## Description
This PR moves the checks on whether data/tokenizers/processors are present to the `smash` function, so that people can specify them in any order during configuration setup, but are still informed before the smashing begins.

Tests fail at the moment as this PR already adheres to the renaming of `.data` in #67 , this PR will be merged tomorrow.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested warnings for non-accepted configs locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
None.
