### PR TITLE
feat: add torchao quantizer

### DIFF
--- a/src/pruna/algorithms/caching/fora.py
+++ b/src/pruna/algorithms/caching/fora.py
@@ -43,6 +43,7 @@ class FORACacher(PrunaCacher):
     compatible_algorithms: dict[str, list[str]] = dict(
         compiler=["stable_fast", "torch_compile"],
         quantizer=["diffusers_int8", "hqq_diffusers", "torchao"],
+        factorizer=["qkv_diffusers"],
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/caching/fora.py
+++ b/src/pruna/algorithms/caching/fora.py
@@ -42,7 +42,7 @@ class FORACacher(PrunaCacher):
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         compiler=["stable_fast", "torch_compile"],
-        quantizer=["diffusers_int8", "hqq_diffusers"],
+        quantizer=["diffusers_int8", "hqq_diffusers", "torchao"],
     )
 
     def get_hyperparameters(self) -> list:
@@ -255,7 +255,6 @@ class CacheHelper:
             num_steps = len(self.pipe.scheduler.timesteps)
             if self.step == 0:
                 self.cache_schedule = self.get_cache_schedule(num_steps)
-
             result = transformer_forward(*args, **kwargs)
             self.step += 1
             return result

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -51,7 +51,7 @@ class TorchCompileCompiler(PrunaCompiler):
     dataset_required = False
     compatible_algorithms = dict(
         factorizer=["qkv_diffusers"],
-        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
         cacher=["deepcache", "fora"],
     )
 

--- a/src/pruna/algorithms/factorizing/qkv_diffusers.py
+++ b/src/pruna/algorithms/factorizing/qkv_diffusers.py
@@ -41,8 +41,8 @@ class QKVDiffusers(PrunaFactorizer):
     run_on_cuda = True
     dataset_required = False
     compatible_algorithms = dict(
-        quantizer=["diffusers_int8", "hqq_diffusers", "quanto"],
-        cacher=["deepcache"],
+        quantizer=["diffusers_int8", "hqq_diffusers", "quanto", "torchao"],
+        cacher=["deepcache", "fora"],
         compiler=["torch_compile"],
     )
 

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -209,7 +209,8 @@ class TorchaoQuantizer(PrunaQuantizer):
             )
         # Only apply quantization on module list level if torch compile is also applied at that level
         if (
-            smash_config._base_config["torch_compile_target"] == "model"
+            smash_config["compiler"] == "torch_compile"
+            and smash_config._base_config["torch_compile_target"] == "model"
             or smash_config["compiler"] is None
             or smash_config["compiler"] != "torch_compile"
         ):

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -150,6 +150,8 @@ class TorchaoQuantizer(PrunaQuantizer):
             return True
         if isinstance(model, tuple(unet_models)):
             return True
+        if hasattr(model, "unet") and isinstance(model.unet, tuple(unet_models)):
+            return True
         if hasattr(model, "transformer") and isinstance(model.transformer, tuple(transformer_models)):
             return True
         if is_causal_lm(model):
@@ -172,7 +174,12 @@ class TorchaoQuantizer(PrunaQuantizer):
         Any
             The quantized model.
         """
-        working_model = model.transformer if hasattr(model, "transformer") else model
+        if hasattr(model, "unet"):
+            working_model = model.unet
+        elif hasattr(model, "transformer"):
+            working_model = model.transformer
+        else:
+            working_model = model
 
         excluded_modules = []
         if "norm" in smash_config["excluded_modules"]:

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -53,7 +53,7 @@ class TorchaoQuantizer(PrunaQuantizer):
         return [
             CategoricalHyperparameter(
                 "quant_type",
-                choices=["int8dq", "int8wo", "fp8wo", "fp8dq", "fp8dqrow"],
+                choices=["int4dq", "int4wo", "int8dq", "int8wo", "fp8wo", "fp8dq", "fp8dqrow"],
                 default_value="int8dq",
                 meta=dict(desc="Quantization type to use."),
             ),
@@ -113,6 +113,8 @@ class TorchaoQuantizer(PrunaQuantizer):
         from torchao.quantization import (
             float8_dynamic_activation_float8_weight,
             float8_weight_only,
+            int4_weight_only,
+            int8_dynamic_activation_int4_weight,
             int8_dynamic_activation_int8_weight,
             int8_weight_only,
             quantize_,
@@ -120,6 +122,8 @@ class TorchaoQuantizer(PrunaQuantizer):
         from torchao.quantization.quant_api import PerRow
 
         return dict(quantize=quantize_,
+                    int4dq=int8_dynamic_activation_int4_weight(),
+                    int4wo=int4_weight_only(),
                     int8dq=int8_dynamic_activation_int8_weight(),
                     int8wo=int8_weight_only(),
                     fp8wo=float8_weight_only(),

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -84,6 +84,7 @@ class TorchaoQuantizer(PrunaQuantizer):
     compatible_algorithms = dict(
         cacher=["fora"],
         compiler=["torch_compile"],
+        factorizer=["qkv_diffusers"],
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -1,0 +1,128 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Dict
+
+import torch
+
+from pruna.algorithms.quantization import PrunaQuantizer
+from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.config.smash_space import CategoricalHyperparameter
+from pruna.engine.model_checks import get_diffusers_transformer_models
+from pruna.engine.save import SAVE_FUNCTIONS
+
+
+class TorchaoQuantizer(PrunaQuantizer):
+    """
+    Implement quantization using the torchao library.
+
+    This algorithm quantizes the weights and activations of linear layers in a model.
+    Combined with torch compile, it can give speedups compared to the base model.
+    """
+
+    algorithm_name = "torchao"
+    references = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
+    save_fn = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required = False
+    processor_required = False
+    run_on_cpu: bool = True
+    run_on_cuda: bool = True
+    dataset_required = False
+    compatible_algorithms = dict(compiler=["torch_compile"])
+
+    def get_hyperparameters(self) -> list:
+        """
+        Configure all algorithm-specific hyperparameters with ConfigSpace.
+
+        Returns
+        -------
+        list
+            The hyperparameters.
+        """
+        return [
+            CategoricalHyperparameter(
+                "quant_type",
+                choices=["int8dq", "int8wo", "fp8wo", "fp8dq", "fp8dqrow"],
+                default_value="int8dq",
+                meta=dict(desc="Quantization type to use."),
+            ),
+        ]
+
+    def model_check_fn(self, model: Any) -> bool:
+        """
+        Check if the model is a torch.nn.Module or a diffusers pipeline with a transformer model.
+
+        Parameters
+        ----------
+        model : Any
+            The model to check.
+
+        Returns
+        -------
+        bool
+            True if the model is suitable for torchao quantization, False otherwise.
+        """
+        transformer_models = get_diffusers_transformer_models()
+        if isinstance(model, tuple(transformer_models)):
+            return True
+        if hasattr(model, "transformer") and isinstance(model.transformer, tuple(transformer_models)):
+            return True
+        return isinstance(model, torch.nn.Module)
+
+    def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
+        """
+        Quantize the model.
+
+        Parameters
+        ----------
+        model : Any
+            The model to quantize.
+        smash_config : SmashConfigPrefixWrapper
+            The configuration for the quantization.
+
+        Returns
+        -------
+        Any
+            The quantized model.
+        """
+        working_model = model.transformer if hasattr(model, "transformer") else model
+        imported_modules = self.import_algorithm_packages()
+        imported_modules["quantize"](working_model, imported_modules[smash_config["quant_type"]])
+        return model
+
+    def import_algorithm_packages(self) -> Dict[str, Any]:
+        """
+        Provide a algorithm packages for the algorithm.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The algorithm packages.
+        """
+        from torchao.quantization import (
+            float8_dynamic_activation_float8_weight,
+            float8_weight_only,
+            int8_dynamic_activation_int8_weight,
+            int8_weight_only,
+            quantize_,
+        )
+        from torchao.quantization.quant_api import PerRow
+
+        return dict(quantize=quantize_,
+                    int8dq=int8_dynamic_activation_int8_weight(),
+                    int8wo=int8_weight_only(),
+                    fp8wo=float8_weight_only(),
+                    fp8dq=float8_dynamic_activation_float8_weight(),
+                    fp8dqrow=float8_dynamic_activation_float8_weight(PerRow()),
+                )

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -62,7 +62,7 @@ EMBEDDING_MODULES: list[str] = [
 
 class TorchaoQuantizer(PrunaQuantizer):
     """
-     Implement quantization using TorchAO.
+    Implement quantization using torchao.
 
     This replaces each nn.Linear in-place with a low-precision Tensor subclass via
     torchao.quantization.quantize_. It uses per-channel uniform affine

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -94,7 +94,7 @@ class TestTorchao(AlgorithmTesterBase):
     """Test the torchao quantizer."""
 
     models = ["flux_tiny_random"]
-    reject_models = ["opt_125m"]
+    reject_models = ["stable_diffusion_v1_4"]
     allow_pickle_files = False
     algorithm_class = TorchaoQuantizer
 

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -13,6 +13,7 @@ from pruna.algorithms.quantization.huggingface_llm_int8 import LLMInt8Quantizer
 from pruna.algorithms.quantization.quanto import QuantoQuantizer
 from pruna.algorithms.quantization.torch_dynamic import TorchDynamicQuantizer
 from pruna.algorithms.quantization.torch_static import TorchStaticQuantizer
+from pruna.algorithms.quantization.torchao import TorchaoQuantizer
 
 from .base_tester import AlgorithmTesterBase
 
@@ -87,6 +88,15 @@ class TestHalf(AlgorithmTesterBase):
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = HalfQuantizer
+
+
+class TestTorchao(AlgorithmTesterBase):
+    """Test the torchao quantizer."""
+
+    models = ["flux_tiny_random"]
+    reject_models = ["opt_125m"]
+    allow_pickle_files = False
+    algorithm_class = TorchaoQuantizer
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Description
This PR introduces torchao as an additional quantizer for diffusion transformer models (e.g., FLUX). When combined with torch.compile, torchao delivers significant inference speedups for FLUX:

- Baseline (no optimization): 16 s
- torch.compile: 12.2 s
- torchao + torch.compile: 9.5 s

All timings were measured on an L40S GPU. Full benchmark (including visual comparison) are available [here](https://pruna.notion.site/torchao-bench-1ee70a039e5f80f88007d577e5fd4229?pvs=4).

The implementation closely follows the [diffusers-torchao](https://github.com/sayakpaul/diffusers-torchao) repository, which includes additional benchmarks and tests for the CogVideoX-5b video model.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- Added a dedicated algorithm test
- Manually tested all quantization modes on FLUX, both with and without torch.compile.
- Manually tested quantization of LLama model.
- Verified model quality via a small benchmark (see link above).
Note: fp8dqrow mode was not tested due to its requirement for Hopper-series GPUs. Also the int4 quantization techniques are not compatible with FLUX.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
