### PR TITLE
fix: add missing compatibilities for pab and fastercache

### DIFF
--- a/src/pruna/algorithms/caching/deepcache.py
+++ b/src/pruna/algorithms/caching/deepcache.py
@@ -38,7 +38,7 @@ class DeepCacheCacher(PrunaCacher):
     run_on_cpu = True
     run_on_cuda = True
     compatible_algorithms = dict(
-        compiler=["torch_compile"],
+        compiler=["stable_fast", "torch_compile"],
         quantizer=["half", "hqq_diffusers", "diffusers_int8"],
     )
 

--- a/src/pruna/algorithms/caching/deepcache.py
+++ b/src/pruna/algorithms/caching/deepcache.py
@@ -38,7 +38,7 @@ class DeepCacheCacher(PrunaCacher):
     run_on_cpu = True
     run_on_cuda = True
     compatible_algorithms = dict(
-        compiler=["stable_fast", "torch_compile"],
+        compiler=["torch_compile"],
         quantizer=["half", "hqq_diffusers", "diffusers_int8"],
     )
 

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -46,7 +46,7 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
     run_on_cpu = False
     run_on_cuda = True
     dataset_required = False
-    compatible_algorithms = dict(cacher=["deepcache"], compiler=["torch_compile"])
+    compatible_algorithms = dict(cacher=["deepcache", "fastercache", "pab"], compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
@@ -46,7 +46,7 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
     dataset_required = False
     run_on_cpu = False
     run_on_cuda = True
-    compatible_algorithms = dict(cacher=["deepcache"], compiler=["torch_compile"])
+    compatible_algorithms = dict(cacher=["deepcache", "fastercache", "pab"], compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """


### PR DESCRIPTION
## Description
Add missing compatibilities for pab and fastercache to hqq_diffusers and diffusers_int8.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Reran the tests including the one that failed. 

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
