### PR TITLE
fix: enhance algorithm group management in SmashConfig when loading old configs

### DIFF
--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -188,11 +188,6 @@ class SmashConfig:
 
         # Add missing groups with info message
         for group in expected_groups - current_groups:
-            pruna_logger.info(
-                f"Adding missing algorithm group: {group}\n"
-                "This is likely due to a version difference between the saved model and the current library.\n"
-                "This is not an error, but it is recommended to update the model."
-            )
             config_dict[group] = None
 
         self._configuration = Configuration(SMASH_SPACE, values=config_dict)

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -172,6 +172,27 @@ class SmashConfig:
 
             setattr(self, name, config_dict.pop(name))
 
+        # ensure all algorithm groups are present and remove extra ones
+        extra_groups = set(config_dict.keys()) - set(ALGORITHM_GROUPS)
+        if extra_groups:
+            for group in extra_groups:
+                if config_dict[group] is not None:
+                    pruna_logger.warning(
+                        f"Removing non-existing algorithm group: {group}, with value: {config_dict[group]}.\n"
+                        "This is likely due to a version difference between the saved model and the current library.\n"
+                        "You can use an older version of Pruna to load the model or reconfigure the model."
+                    )
+                del config_dict[group]
+
+        for group in ALGORITHM_GROUPS:
+            if group not in config_dict:
+                pruna_logger.info(
+                    f"Adding missing algorithm group: {group}\n"
+                    "This is likely due to a version difference between the saved model and the current library.\n"
+                    "This is not an error, but it is recommended to update the model."
+                )
+                config_dict[group] = None
+
         self._configuration = Configuration(SMASH_SPACE, values=config_dict)
 
         if os.path.exists(os.path.join(path, TOKENIZER_SAVE_PATH)):


### PR DESCRIPTION
## Description
This should align the config keys we pass to the ConfigSpace, with the actually available algorithms and warn or inform if that is not the case. 

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #116 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
