### PR TITLE
feat: `accelerate` support

### DIFF
--- a/docs/user_manual/customize_algorithm.rst
+++ b/docs/user_manual/customize_algorithm.rst
@@ -48,8 +48,7 @@ These attributes are used to provide information about the algorithm to the user
         tokenizer_required = False
         processor_required = False
         dataset_required = False
-        run_on_cpu = True
-        run_on_cuda = True
+        runs_on = ["cpu", "cuda"]
         compatible_algorithms = dict(quantizer=["quanto"])
 
 
@@ -60,7 +59,7 @@ Step 4. Add Algorithm Attributes
 - ``algorithm_name``: Identifier used to activate the algorithm, name should be in snake case.
 - ``references``: A dictionary of any references that can be provided for the algorithm, typically a link to the GitHub repository or a paper.
 - ``tokenizer_required``, ``processor_required``, ``dataset_required``: Indicate required components.
-- ``run_on_cpu``, ``run_on_cuda``: Define hardware compatibility.
+- ``runs_on``: Define which of the hardwares listed in ``SUPPORTED_DEVICES`` are compatible with the algorithm.
 - ``compatible_algorithms``: Lists compatible algorithms, i.e. any algorithm that can be applied on the same model together with the current algorithm. This compatibility should be specified both ways; if “quanto” is compatible with “superfast”, “superfast” must also list “quanto”.
 - Additionally, you might have to specify a saving function. We provide more details on this in the section below.
 
@@ -242,8 +241,7 @@ Here’s the complete ``superfast.py`` implementation:
         tokenizer_required = False
         processor_required = False
         dataset_required = False
-        run_on_cpu = True
-        run_on_cuda = True
+        runs_on = ["cpu", "cuda"]
         compatible_algorithms = dict(quantizer=["quanto"])
 
         def get_hyperparameters(self) -> list:

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -44,7 +44,9 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}." if required_install_str else "",
+            f"| **Required install**: {required_install_str}."
+            if required_install_str
+            else "",
         ]
     )
 
@@ -80,12 +82,20 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+    header_line = (
+        "|"
+        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
+        + "|"
+    )
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+        row_line = (
+            "|"
+            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
+            + "|"
+        )
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 
@@ -133,10 +143,7 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
             "mps": "MPS",
             "accelerate": "Accelerate distributed",
         }
-        if device in name_map:
-            compatible_devices.append(name_map[device])
-        else:
-            compatible_devices.append(device)
+        compatible_devices.append(name_map[device])
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -44,9 +44,7 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}."
-            if required_install_str
-            else "",
+            f"| **Required install**: {required_install_str}." if required_install_str else "",
         ]
     )
 
@@ -82,20 +80,12 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = (
-        "|"
-        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
-        + "|"
-    )
+    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = (
-            "|"
-            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
-            + "|"
-        )
+        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 
@@ -140,7 +130,11 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
         if device == "cpu":
             compatible_devices.append("CPU")
         elif device == "cuda":
-            compatible_devices.append("GPU")
+            compatible_devices.append("CUDA")
+        elif device == "mps":
+            compatible_devices.append("MPS")
+        elif device == "accelerate":
+            compatible_devices.append("Accelerate distributed")
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -136,7 +136,7 @@ def get_required_inputs(obj: PrunaAlgorithmBase) -> str:
 def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
     """Get the compatible devices of a Pruna algorithm."""
     compatible_devices = []
-    for device in obj.compatible_devices():
+    for device in obj.runs_on:
         name_map = {
             "cpu": "CPU",
             "cuda": "CUDA",

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -127,14 +127,16 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
     """Get the compatible devices of a Pruna algorithm."""
     compatible_devices = []
     for device in obj.compatible_devices():
-        if device == "cpu":
-            compatible_devices.append("CPU")
-        elif device == "cuda":
-            compatible_devices.append("CUDA")
-        elif device == "mps":
-            compatible_devices.append("MPS")
-        elif device == "accelerate":
-            compatible_devices.append("Accelerate distributed")
+        name_map = {
+            "cpu": "CPU",
+            "cuda": "CUDA",
+            "mps": "MPS",
+            "accelerate": "Accelerate distributed",
+        }
+        if device in name_map:
+            compatible_devices.append(name_map[device])
+        else:
+            compatible_devices.append(device)
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ wget = "*"
 torch = "2.7.0"
 torchvision = "0.22.0"
 torchmetrics = { version = "*", extras = ["image"] }
+accelerate = ">0.28.0"
 requests = ">=2.31.0"
 transformers = "*"
 pillow = ">=9.5.0"

--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -36,14 +36,13 @@ class IFWBatcher(PrunaBatcher):
     batch size to a value that corresponds to your inference requirements.
     """
 
-    algorithm_name = "ifw"
-    references = {"GitHub": "https://github.com/huggingface/transformers"}
-    tokenizer_required = True
-    processor_required = True
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(quantizer=["half"])
+    algorithm_name: str = "ifw"
+    references: dict[str, str] = {"GitHub": "https://github.com/huggingface/transformers"}
+    tokenizer_required: bool = True
+    processor_required: bool = True
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -43,14 +43,15 @@ class WS2TBatcher(PrunaBatcher):
     batch size to a value that corresponds to your inference requirements.
     """
 
-    algorithm_name = "whisper_s2t"
-    references = {"GitHub": "https://github.com/shashikg/WhisperS2T"}
-    tokenizer_required = True
-    processor_required = True
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(compiler=["c_translate", "c_generate", "c_whisper"], quantizer=["half"])
+    algorithm_name: str = "whisper_s2t"
+    references: dict[str, str] = {"GitHub": "https://github.com/shashikg/WhisperS2T"}
+    tokenizer_required: bool = True
+    processor_required: bool = True
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(
+        compiler=["c_translate", "c_generate", "c_whisper"], quantizer=["half"]
+    )
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/caching/deepcache.py
+++ b/src/pruna/algorithms/caching/deepcache.py
@@ -29,14 +29,16 @@ class DeepCacheCacher(PrunaCacher):
     features.
     """
 
-    algorithm_name = "deepcache"
-    references = {"GitHub": "https://github.com/horseee/DeepCache", "Paper": "https://arxiv.org/abs/2312.00858"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(
+    algorithm_name: str = "deepcache"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/horseee/DeepCache",
+        "Paper": "https://arxiv.org/abs/2312.00858",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
         compiler=["stable_fast", "torch_compile"],
         quantizer=["half", "hqq_diffusers", "diffusers_int8", "quanto"],

--- a/src/pruna/algorithms/caching/fastercache.py
+++ b/src/pruna/algorithms/caching/fastercache.py
@@ -43,14 +43,16 @@ class FasterCacheCacher(PrunaCacher):
     https://github.com/huggingface/diffusers/pull/9562.
     """
 
-    algorithm_name = "fastercache"
-    references = {"GitHub": "https://github.com/Vchitect/FasterCache", "Paper": "https://arxiv.org/abs/2410.19355"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
+    algorithm_name: str = "fastercache"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/Vchitect/FasterCache",
+        "Paper": "https://arxiv.org/abs/2410.19355",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/caching/fora.py
+++ b/src/pruna/algorithms/caching/fora.py
@@ -37,8 +37,7 @@ class FORACacher(PrunaCacher):
     references: dict[str, str] = {"Paper": "https://arxiv.org/abs/2407.01425"}
     tokenizer_required: bool = False
     processor_required: bool = False
-    run_on_cpu: bool = True
-    run_on_cuda: bool = True
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         compiler=["stable_fast", "torch_compile"],

--- a/src/pruna/algorithms/caching/pab.py
+++ b/src/pruna/algorithms/caching/pab.py
@@ -39,17 +39,16 @@ class PABCacher(PrunaCacher):
     reduces the number of tunable parameters by setting pipeline specific parameters according to https://github.com/huggingface/diffusers/pull/9562.
     """
 
-    algorithm_name = "pab"
-    references = {
+    algorithm_name: str = "pab"
+    references: dict[str, str] = {
         "Paper": "https://arxiv.org/abs/2408.12588",
         "HuggingFace": "https://huggingface.co/docs/diffusers/main/api/cache#pyramid-attention-broadcast",
     }
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/compilation/c_translate.py
+++ b/src/pruna/algorithms/compilation/c_translate.py
@@ -57,8 +57,7 @@ class CTranslateCompiler(PrunaCompiler):
     references = {"GitHub": "https://github.com/OpenNMT/CTranslate2"}
     tokenizer_required: bool = True
     processor_required: bool = False
-    run_on_cpu: bool = False
-    run_on_cuda: bool = True
+    runs_on: list[str] = ["cuda"]
     dataset_required: bool = False
     compatible_algorithms = dict(batcher=["whisper_s2t"], quantizer=["half"])
 

--- a/src/pruna/algorithms/compilation/stable_fast.py
+++ b/src/pruna/algorithms/compilation/stable_fast.py
@@ -28,15 +28,14 @@ class StableFastCompiler(PrunaCompiler):
     into optimized kernels and converting diffusion pipelines into efficient TorchScript graphs.
     """
 
-    algorithm_name = "stable_fast"
-    references = {"GitHub": "https://github.com/chengzeyi/stable-fast"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(cacher=["deepcache", "fora"], quantizer=["half"])
-    required_install = "``pip install pruna[stable-fast]``"
+    algorithm_name: str = "stable_fast"
+    references: dict[str, str] = {"GitHub": "https://github.com/chengzeyi/stable-fast"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(cacher=["deepcache", "fora"], quantizer=["half"])
+    required_install: str = "``pip install pruna[stable-fast]``"
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -42,16 +42,15 @@ class TorchCompileCompiler(PrunaCompiler):
     Optimizes given model or function using various backends and is compatible with any model containing PyTorch modules.
     """
 
-    algorithm_name = "torch_compile"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    algorithm_name: str = "torch_compile"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
-        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq"],
         cacher=["deepcache", "fora"],
     )
 

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -46,7 +46,7 @@ class TorchCompileCompiler(PrunaCompiler):
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -50,7 +50,7 @@ class TorchCompileCompiler(PrunaCompiler):
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
-        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
         cacher=["deepcache", "fora"],
     )
 

--- a/src/pruna/algorithms/factorizing/qkv_diffusers.py
+++ b/src/pruna/algorithms/factorizing/qkv_diffusers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from pruna.algorithms.factorizing import PrunaFactorizer
 from pruna.config.smash_config import SmashConfigPrefixWrapper
@@ -29,18 +29,17 @@ class QKVDiffusers(PrunaFactorizer):
     all at once: the matrix multiplication involve a larger matrix but we compute one operation instead of three.
     """
 
-    algorithm_name = "qkv_diffusers"
-    references = {
+    algorithm_name: str = "qkv_diffusers"
+    references: dict[str, str] = {
         "BFL": "https://github.com/black-forest-labs/flux/",
         "Github": "https://github.com/huggingface/diffusers/pull/9185",
     }
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         quantizer=["diffusers_int8", "hqq_diffusers", "quanto", "torchao"],
         cacher=["deepcache", "fora"],
         compiler=["torch_compile"],

--- a/src/pruna/algorithms/factorizing/qkv_diffusers.py
+++ b/src/pruna/algorithms/factorizing/qkv_diffusers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 from pruna.algorithms.factorizing import PrunaFactorizer
 from pruna.config.smash_config import SmashConfigPrefixWrapper
@@ -34,7 +34,7 @@ class QKVDiffusers(PrunaFactorizer):
         "BFL": "https://github.com/black-forest-labs/flux/",
         "Github": "https://github.com/huggingface/diffusers/pull/9185",
     }
-    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/src/pruna/algorithms/pruna_base.py
+++ b/src/pruna/algorithms/pruna_base.py
@@ -19,7 +19,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from pruna.config.smash_config import SmashConfig, SmashConfigPrefixWrapper
+from pruna.config.smash_config import SUPPORTED_DEVICES, SmashConfig, SmashConfigPrefixWrapper
 from pruna.config.smash_space import SMASH_SPACE
 from pruna.engine.save import (
     SAVE_BEFORE_SMASH_CACHE_DIR,
@@ -51,6 +51,7 @@ class PrunaAlgorithmBase(ABC):
             tokenizer_required=self.tokenizer_required,
             processor_required=self.processor_required,
         )
+        assert all(device in SUPPORTED_DEVICES for device in self.runs_on)
 
     def __init_subclass__(cls, **kwargs):
         """Intercept the instantiation of subclasses of the PrunaAlgorithmBase class."""
@@ -68,17 +69,9 @@ class PrunaAlgorithmBase(ABC):
         # Replace the function with the wrapped version
         cls.import_algorithm_packages = wrap_handle_imports(impl)
 
-    @classmethod
-    def compatible_devices(cls) -> list[str]:
+    def compatible_devices(self) -> list[str]:
         """Return the compatible devices for the algorithm."""
-        compatible_devices = []
-        if cls.run_on_cpu:  # type: ignore
-            compatible_devices.append("cpu")
-        if cls.run_on_cuda:  # type: ignore
-            compatible_devices.append("cuda")
-        if not compatible_devices:
-            raise ValueError(f"Algorithm {cls.algorithm_name} is not compatible with any device.")
-        return compatible_devices
+        return self.runs_on
 
     @property
     @abstractmethod

--- a/src/pruna/algorithms/pruna_base.py
+++ b/src/pruna/algorithms/pruna_base.py
@@ -70,7 +70,14 @@ class PrunaAlgorithmBase(ABC):
         cls.import_algorithm_packages = wrap_handle_imports(impl)
 
     def compatible_devices(self) -> list[str]:
-        """Return the compatible devices for the algorithm."""
+        """
+        Return the compatible devices for the algorithm.
+
+        Returns
+        -------
+        list[str]
+            The compatible devices for the algorithm.
+        """
         return self.runs_on
 
     @property
@@ -92,14 +99,8 @@ class PrunaAlgorithmBase(ABC):
 
     @property
     @abstractmethod
-    def run_on_cpu(self) -> bool:
-        """Subclasses need to provide a boolean indicating if the algorithm can be applied on cpu."""
-        pass
-
-    @property
-    @abstractmethod
-    def run_on_cuda(self) -> bool:
-        """Subclasses need to provide a boolean indicating if the algorithm can be applied on cuda."""
+    def runs_on(self) -> list[str]:
+        """Subclasses need to provide a list of devices the algorithm can run on."""
         pass
 
     @property

--- a/src/pruna/algorithms/pruning/torch_structured.py
+++ b/src/pruna/algorithms/pruning/torch_structured.py
@@ -47,16 +47,15 @@ class TorchStructuredPruner(PrunaPruner):
     and computationally efficient model while preserving a regular structure that standard hardware can easily optimize.
     """
 
-    algorithm_name = "torch_structured"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "torch_structured"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # when performing structured pruning, the tensor sizes can change and disrupt normal saving
     save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict(quantizer=["half"])
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/pruning/torch_unstructured.py
+++ b/src/pruna/algorithms/pruning/torch_unstructured.py
@@ -36,7 +36,7 @@ class TorchUnstructuredPruner(PrunaPruner):
     save_fn = None
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 

--- a/src/pruna/algorithms/pruning/torch_unstructured.py
+++ b/src/pruna/algorithms/pruning/torch_unstructured.py
@@ -30,16 +30,15 @@ class TorchUnstructuredPruner(PrunaPruner):
     exploit the efficiency gains.
     """
 
-    algorithm_name = "torch_unstructured"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "torch_unstructured"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # original model-saving can be retained as is, only parameter values are modified
     save_fn = None
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(quantizer=["half"])
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -35,15 +35,14 @@ class GPTQQuantizer(PrunaQuantizer):
     advantage of the lower precision.
     """
 
-    algorithm_name = "gptq"
-    references = {"GitHub": "https://github.com/ModelCloud/GPTQModel"}
-    tokenizer_required = True
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict(compiler=["torch_compile"])
-    required_install = (
+    algorithm_name: str = "gptq"
+    references: dict[str, str] = {"GitHub": "https://github.com/ModelCloud/GPTQModel"}
+    tokenizer_required: bool = True
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
+    required_install: str = (
         "You must first install the base package with ``pip install pruna`` "
         "before installing the GPTQ extension with ``pip install pruna[gptq] --extra-index-url https://prunaai.pythonanywhere.com/``"
     )
@@ -142,6 +141,9 @@ class GPTQQuantizer(PrunaQuantizer):
         Dict[str, Any]
             The algorithm packages.
         """
-        from gptqmodel import GPTQModel, QuantizeConfig
+        try:
+            from gptqmodel import GPTQModel, QuantizeConfig
+        except ImportError:
+            raise ImportError(f"gptqmodel is not installed. Please install it using {self.required_install}.")
 
         return dict(GPTQModel=GPTQModel, QuantizeConfig=QuantizeConfig)

--- a/src/pruna/algorithms/quantization/half.py
+++ b/src/pruna/algorithms/quantization/half.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import torch
 
@@ -32,7 +32,7 @@ class HalfQuantizer(PrunaQuantizer):
     algorithm_name: str = "half"
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # the half-helper is not saved with the model but is fast to reattach
-    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/src/pruna/algorithms/quantization/half.py
+++ b/src/pruna/algorithms/quantization/half.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 
@@ -29,16 +29,15 @@ class HalfQuantizer(PrunaQuantizer):
     that support it.
     """
 
-    algorithm_name = "half"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "half"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # the half-helper is not saved with the model but is fast to reattach
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         batcher=["ifw", "whisper_s2t"],
         cacher=["deepcache"],
         compiler=[

--- a/src/pruna/algorithms/quantization/half.py
+++ b/src/pruna/algorithms/quantization/half.py
@@ -35,7 +35,7 @@ class HalfQuantizer(PrunaQuantizer):
     save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         batcher=["ifw", "whisper_s2t"],

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -14,7 +14,7 @@
 
 import shutil
 import tempfile
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
@@ -37,15 +37,17 @@ class HQQQuantizer(PrunaQuantizer):
     eliminating the need for calibration data.
     """
 
-    algorithm_name = "hqq"
-    references = {"GitHub": "https://github.com/mobiusml/hqq", "Article": "https://mobiusml.github.io/hqq_blog/"}
-    save_fn = SAVE_FUNCTIONS.hqq
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(compiler=["torch_compile"])
+    algorithm_name: str = "hqq"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/mobiusml/hqq",
+        "Article": "https://mobiusml.github.io/hqq_blog/",
+    }
+    save_fn: Callable = SAVE_FUNCTIONS.hqq
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -14,7 +14,7 @@
 
 import shutil
 import tempfile
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import torch
 from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
@@ -42,7 +42,7 @@ class HQQQuantizer(PrunaQuantizer):
         "GitHub": "https://github.com/mobiusml/hqq",
         "Article": "https://mobiusml.github.io/hqq_blog/",
     }
-    save_fn: Callable = SAVE_FUNCTIONS.hqq
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.hqq
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cuda"]

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Type
 
 import torch
 import torch.nn as nn
@@ -40,18 +40,18 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
     adapted for diffusers models.
     """
 
-    algorithm_name = "hqq_diffusers"
-    references = {"GitHub": "https://github.com/mobiusml/hqq", "Article": "https://mobiusml.github.io/hqq_blog/"}
-    save_fn = SAVE_FUNCTIONS.hqq_diffusers
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache", "fastercache", "fora", "pab"],
-        compiler=["torch_compile"],
+    algorithm_name: str = "hqq_diffusers"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/mobiusml/hqq",
+        "Article": "https://mobiusml.github.io/hqq_blog/",
+    }
+    save_fn: Callable = SAVE_FUNCTIONS.hqq_diffusers
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
+        factorizer=["qkv_diffusers"], cacher=["deepcache", "fastercache", "fora", "pab"], compiler=["torch_compile"]
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict, Type
+from typing import Any, Dict, Type
 
 import torch
 import torch.nn as nn
@@ -45,7 +45,7 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
         "GitHub": "https://github.com/mobiusml/hqq",
         "Article": "https://mobiusml.github.io/hqq_blog/",
     }
-    save_fn: Callable = SAVE_FUNCTIONS.hqq_diffusers
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.hqq_diffusers
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cuda"]

--- a/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
@@ -26,7 +26,7 @@ from pruna.engine.model_checks import (
     get_diffusers_transformer_models,
     get_diffusers_unet_models,
 )
-from pruna.engine.utils import safe_memory_cleanup
+from pruna.engine.utils import determine_dtype, move_to_device
 
 
 class DiffusersInt8Quantizer(PrunaQuantizer):
@@ -122,25 +122,29 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
             The quantized model.
         """
         with tempfile.TemporaryDirectory(prefix=smash_config["cache_dir"]) as temp_dir:
-            # cast original model to CPU to free memory for smashed model
-            if hasattr(model, "to"):
-                input_device = model.device
-                model.to("cpu")
-                safe_memory_cleanup()
-
             # save the latent model (to be quantized) in a temp directory
             if hasattr(model, "transformer"):
-                model.transformer.save_pretrained(temp_dir)
-                latent_class = getattr(diffusers, type(model.transformer).__name__)
-                compute_dtype = next(iter(model.transformer.parameters())).dtype
+                working_model = model.transformer
+                device_map = {
+                    "": smash_config.device
+                    if smash_config.device != "accelerate"
+                    else smash_config.device_map["transformer"]
+                }
             elif hasattr(model, "unet"):
-                model.unet.save_pretrained(temp_dir)
-                latent_class = getattr(diffusers, type(model.unet).__name__)
-                compute_dtype = next(iter(model.unet.parameters())).dtype
+                working_model = model.unet
+                device_map = {
+                    "": smash_config.device if smash_config.device != "accelerate" else smash_config.device_map["unet"]
+                }
             else:
-                model.save_pretrained(temp_dir)
-                latent_class = getattr(diffusers, type(model).__name__)
-                compute_dtype = next(iter(model.parameters())).dtype
+                working_model = model
+                device_map = (
+                    {"": smash_config.device} if smash_config.device != "accelerate" else smash_config.device_map
+                )
+
+            move_to_device(working_model, "cpu")
+            working_model.save_pretrained(temp_dir)
+            latent_class = getattr(diffusers, type(working_model).__name__)
+            compute_dtype = determine_dtype(working_model)
 
             bnb_config = DiffusersBitsAndBytesConfig(
                 load_in_8bit=smash_config["weight_bits"] == 8,
@@ -159,6 +163,7 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
                 temp_dir,
                 quantization_config=bnb_config,
                 torch_dtype=compute_dtype,
+                device_map=device_map,
             )
             # replace the latent model in the pipeline
             if hasattr(model, "transformer"):
@@ -167,10 +172,6 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
                 model.unet = smashed_latent
             else:
                 model = smashed_latent
-
-            # move the model back to the original device
-            if hasattr(model, "to"):
-                model.to(input_device)
             return model
 
     def import_algorithm_packages(self) -> Dict[str, Any]:

--- a/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
@@ -39,17 +39,14 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
     This algorithm is specifically adapted for diffusers models.
     """
 
-    algorithm_name = "diffusers_int8"
-    references = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache", "fastercache", "fora", "pab"],
-        compiler=["torch_compile"],
+    algorithm_name: str = "diffusers_int8"
+    references: dict[str, str] = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda", "accelerate"]
+    compatible_algorithms: dict[str, list[str]] = dict(
+        factorizer=["qkv_diffusers"], cacher=["deepcache", "fastercache", "fora", "pab"], compiler=["torch_compile"]
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/quantization/huggingface_llm_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_llm_int8.py
@@ -127,9 +127,8 @@ class LLMInt8Quantizer(PrunaQuantizer):
                 quantization_config=bnb_config,
                 trust_remote_code=True,
                 torch_dtype=smash_config["compute_dtype"],  # storage type of the non-int8 params
-                device_map=smash_config.device_map if smash_config.device == "accelerate" else "auto",
+                device_map=smash_config.device_map if smash_config.device == "accelerate" else smash_config.device,
             )
-            move_to_device(smashed_model, smash_config.device)
 
         return smashed_model
 

--- a/src/pruna/algorithms/quantization/huggingface_llm_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_llm_int8.py
@@ -35,14 +35,13 @@ class LLMInt8Quantizer(PrunaQuantizer):
     while 4-bit quantization further compresses the model and is often used with QLoRA for fine-tuning.
     """
 
-    algorithm_name = "llm_int8"
-    references = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(compiler=["torch_compile"])
+    algorithm_name: str = "llm_int8"
+    references: dict[str, str] = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda", "accelerate"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/llm_compressor.py
+++ b/src/pruna/algorithms/quantization/llm_compressor.py
@@ -29,14 +29,13 @@ class LLMCompressorQuantizer(PrunaQuantizer):
     range of weights while minimizing accuracy loss to the most salient weight values.
     """
 
-    algorithm_name = "awq"
-    references = {"GitHub": "https://github.com/vllm-project/llm-compressor"}
-    tokenizer_required = True
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms: Dict[str, list[str]] = dict()
+    algorithm_name: str = "awq"
+    references: dict[str, str] = {"GitHub": "https://github.com/vllm-project/llm-compressor"}
+    tokenizer_required: bool = True
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict()
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -129,7 +129,7 @@ class QuantoQuantizer(PrunaQuantizer):
                         calibrate(
                             working_model,
                             smash_config.val_dataloader(),
-                            smash_config["device"],
+                            model.device,  # only e.g. CUDA here is not enough, we need also the correct device index
                             batch_size=smash_config.batch_size,
                             samples=smash_config["calibration_samples"],
                         )

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import Constant, OrdinalHyperparameter
@@ -35,18 +35,14 @@ class QuantoQuantizer(PrunaQuantizer):
     and device memory usage is roughly reduced in proportion to the bitwidth ratio.
     """
 
-    algorithm_name = "quanto"
-    references = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
-    save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache"],
-    )
+    algorithm_name: str = "quanto"
+    references: dict[str, str] = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
+    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(factorizer=["qkv_diffusers"], cacher=["deepcache"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import torch
 from ConfigSpace import Constant, OrdinalHyperparameter
@@ -37,7 +37,7 @@ class QuantoQuantizer(PrunaQuantizer):
 
     algorithm_name: str = "quanto"
     references: dict[str, str] = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
-    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.pickled
     tokenizer_required: bool = False
     processor_required: bool = False
     dataset_required: bool = False

--- a/src/pruna/algorithms/quantization/torch_dynamic.py
+++ b/src/pruna/algorithms/quantization/torch_dynamic.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import torch
 from ConfigSpace import OrdinalHyperparameter
@@ -34,7 +34,7 @@ class TorchDynamicQuantizer(PrunaQuantizer):
 
     algorithm_name = "torch_dynamic"
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.pickled
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/src/pruna/algorithms/quantization/torch_dynamic.py
+++ b/src/pruna/algorithms/quantization/torch_dynamic.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import OrdinalHyperparameter
@@ -33,14 +33,13 @@ class TorchDynamicQuantizer(PrunaQuantizer):
     """
 
     algorithm_name = "torch_dynamic"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict()
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
+    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict()
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/torch_dynamic.py
+++ b/src/pruna/algorithms/quantization/torch_dynamic.py
@@ -37,7 +37,7 @@ class TorchDynamicQuantizer(PrunaQuantizer):
     save_fn: Callable = SAVE_FUNCTIONS.pickled
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict()
 

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
 import torch
 
@@ -75,7 +75,7 @@ class TorchaoQuantizer(PrunaQuantizer):
 
     algorithm_name: str = "torchao"
     references: dict[str, str] = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
-    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 
@@ -73,15 +73,14 @@ class TorchaoQuantizer(PrunaQuantizer):
     full-precision model.
     """
 
-    algorithm_name = "torchao"
-    references = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu: bool = True
-    run_on_cuda: bool = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    algorithm_name: str = "torchao"
+    references: dict[str, str] = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         cacher=["fora"],
         compiler=["torch_compile"],
         factorizer=["qkv_diffusers"],

--- a/src/pruna/config/compatibility_checks.py
+++ b/src/pruna/config/compatibility_checks.py
@@ -94,9 +94,9 @@ def check_model_compatibility(
     for current_group in ALGORITHM_GROUPS:
         algorithm = smash_config[current_group]
         if algorithm is not None:
+            check_algorithm_availability(algorithm, current_group, algorithm_dict)
             # test if all required packages are installed, if not this will raise an ImportError
             algorithm_dict[current_group][algorithm].import_algorithm_packages()
-            check_algorithm_availability(algorithm, current_group, algorithm_dict)
             check_argument_compatibility(smash_config, algorithm)
             # check for model-algorithm compatibility with the model_check_fn
             if not algorithm_dict[current_group][algorithm].model_check_fn(model):

--- a/src/pruna/config/compatibility_checks.py
+++ b/src/pruna/config/compatibility_checks.py
@@ -1,0 +1,158 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any
+
+from pruna import SmashConfig
+from pruna.algorithms import PRUNA_ALGORITHMS
+from pruna.config.smash_space import SMASH_SPACE
+from pruna.engine.utils import get_device, move_to_device
+from pruna.logging.logger import pruna_logger
+
+
+def ensure_device_consistency(model, smash_config):
+    """
+    Ensure consistency between the device state of the model and the smash config.
+
+    Parameters
+    ----------
+    model : Any
+        The model to check for device consistency.
+    smash_config : SmashConfig
+        The smash config to check for device consistency.
+    """
+    model_device = get_device(model)
+
+    if smash_config.device in ["cpu", "cuda", "mps"]:
+        if model_device == smash_config.device:
+            pruna_logger.debug("Device consistency check passed.")
+        else:
+            if model_device != "accelerate":
+                pruna_logger.warning(
+                    (
+                        f"Model and SmashConfig have different devices. Model: {model_device}, "
+                        f"SmashConfig: {smash_config.device}. Casting model to {smash_config.device}."
+                        f"If this is not desired, please use SmashConfig(device='{model_device}')."
+                    )
+                )
+            else:
+                # in this case, the model_device is a device map and the model is on multiple GPUs
+                pruna_logger.warning(
+                    (
+                        f"SmashConfig specifies {smash_config.device} but model is distributed. "
+                        f"Casting model to {smash_config.device}. If this is not desired, please use "
+                        f"SmashConfig(device='accelerate') to continue with distributed model."
+                    )
+                )
+            move_to_device(model, smash_config.device)
+
+    elif smash_config.device == "accelerate":
+        if model_device == "accelerate":
+            pruna_logger.debug("Device consistency check passed.")
+            hf_device_map = get_device(model, return_device_map=True)
+            if not all(isinstance(v, int) for v in hf_device_map.values()):
+                raise ValueError("Device map indicates CPU offloading, this is not supported at this time.")
+            else:
+                smash_config.device_map = hf_device_map
+        else:
+            pruna_logger.warning(
+                (
+                    f"SmashConfig specifies 'accelerate' but model is not distributed and is on device {model_device}. "
+                    f"Updating SmashConfig to device='{model_device}'."
+                )
+            )
+            smash_config.device = model_device
+    else:
+        raise ValueError(f"Invalid device: {smash_config.device}")
+
+
+def check_model_compatibility(
+    model: Any,
+    smash_config: SmashConfig,
+    algorithm_dict: dict[str, Any] = PRUNA_ALGORITHMS,
+) -> None:
+    """
+    Check if the model is compatible with the given configuration.
+
+    Parameters
+    ----------
+    model : Any
+        The model to check for compatibility with the SmashConfig.
+    smash_config : SmashConfig
+        The SmashConfig to check the model against.
+    algorithm_dict : dict[str, Any]
+        The algorithm dictionary to hold all algorithm instances.
+    """
+    # algorithm groups are subject to change, make sure we have the latest version
+    from pruna.config.smash_space import ALGORITHM_GROUPS
+
+    # iterate through compiler, quantizer, ...
+    for current_group in ALGORITHM_GROUPS:
+        algorithm = smash_config[current_group]
+        if algorithm is not None:
+            # test if all required packages are installed, if not this will raise an ImportError
+            algorithm_dict[current_group][algorithm].import_algorithm_packages()
+            check_algorithm_availability(algorithm, current_group, algorithm_dict)
+            check_argument_compatibility(smash_config, algorithm)
+            # check for model-algorithm compatibility with the model_check_fn
+            if not algorithm_dict[current_group][algorithm].model_check_fn(model):
+                raise ValueError(
+                    f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
+                )
+
+
+def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str) -> None:
+    """
+    Check if the SmashConfig has the required arguments (tokenizer, processor, dataset) for an algorithm.
+
+    Parameters
+    ----------
+    smash_config : SmashConfig
+        The SmashConfig to check the argument consistency with.
+    algorithm_name : str
+        The algorithm name that is about to be activated.
+    """
+    algorithm_requirements = SMASH_SPACE.model_requirements[algorithm_name]
+    if algorithm_requirements["tokenizer_required"] and smash_config.tokenizer is None:
+        raise ValueError(f"{algorithm_name} requires a tokenizer. Please provide it with smash_config.add_tokenizer().")
+    if algorithm_requirements["processor_required"] and smash_config.processor is None:
+        raise ValueError(f"{algorithm_name} requires a processor. Please provide it with smash_config.add_processor().")
+    if algorithm_requirements["dataset_required"] and smash_config.data is None:
+        raise ValueError(f"{algorithm_name} requires a dataset. Please provide it with smash_config.add_data().")
+
+
+def check_algorithm_availability(algorithm: str, algorithm_group: str, algorithm_dict: dict[str, Any]) -> None:
+    """
+    Check if the algorithm is available in the algorithm dictionary.
+
+    Parameters
+    ----------
+    algorithm : str
+        The algorithm to check for availability.
+    algorithm_group : str
+        The algorithm group to check for availability.
+    algorithm_dict : dict[str, Any]
+        The algorithm dictionary to check for availability.
+
+    Raises
+    ------
+    ValueError
+        If the algorithm is not available in the algorithm dictionary.
+    """
+    if algorithm_group not in algorithm_dict:
+        raise RuntimeError(f"Algorithm group {algorithm_group} is unavailable with pruna.smash")
+    if algorithm not in algorithm_dict[algorithm_group]:
+        raise RuntimeError(f"Algorithm {algorithm} is unavailable with pruna.smash")

--- a/src/pruna/config/compatibility_checks.py
+++ b/src/pruna/config/compatibility_checks.py
@@ -48,7 +48,7 @@ def ensure_device_consistency(model, smash_config):
             else:
                 smash_config.device_map = hf_device_map
 
-    if smash_config.device in ["cpu", "cuda", "mps"] and model_device in ["cpu", "cuda", "mps"]:
+    elif smash_config.device in ["cpu", "cuda", "mps"] and model_device in ["cpu", "cuda", "mps"]:
         pruna_logger.warning(
             (
                 f"Model and SmashConfig have different devices. Model: {model_device}, "

--- a/src/pruna/config/compatibility_checks.py
+++ b/src/pruna/config/compatibility_checks.py
@@ -103,6 +103,11 @@ def check_model_compatibility(
                 raise ValueError(
                     f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
                 )
+            if get_device(model) not in algorithm_dict[current_group][algorithm].runs_on:
+                raise ValueError(
+                    f"{algorithm} is not compatible with device {get_device(model)}, "
+                    f"compatible devices are {algorithm_dict[current_group][algorithm].runs_on}"
+                )
 
 
 def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str) -> None:

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -166,16 +166,19 @@ class SmashConfig:
             value = config_dict.pop("load_fn")
             config_dict["load_fns"] = [value]
 
+        # support deprecated max batch size argument
+        if "max_batch_size" in config_dict:
+            config_dict["batch_size"] = config_dict.pop("max_batch_size")
+
         for name in ADDITIONAL_ARGS:
+            if name not in config_dict:
+                pruna_logger.warning(f"Argument {name} not found in config file. Skipping...")
+                continue
+
             # do not load the old cache directory
             if name == "cache_dir":
                 if name in config_dict:
                     del config_dict[name]
-                continue
-
-            # backwards compatibility for old batch size argument
-            if name == "batch_size" and "batch_size" not in config_dict:
-                setattr(self, name, config_dict.pop("max_batch_size"))
                 continue
 
             setattr(self, name, config_dict.pop(name))

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -38,6 +38,7 @@ from pruna.logging.logger import pruna_logger
 ADDITIONAL_ARGS = [
     "batch_size",
     "device",
+    "device_map",
     "cache_dir",
     "save_fns",
     "load_fns",
@@ -91,6 +92,7 @@ class SmashConfig:
         else:
             self.batch_size = batch_size
         self.device = set_to_best_available_device(device)
+        self.device_map = None
 
         self.cache_dir_prefix = cache_dir_prefix
         if not os.path.exists(cache_dir_prefix):

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -48,6 +48,7 @@ ADDITIONAL_ARGS = [
 TOKENIZER_SAVE_PATH = "tokenizer/"
 PROCESSOR_SAVE_PATH = "processor/"
 SMASH_CONFIG_FILE_NAME = "smash_config.json"
+SUPPORTED_DEVICES = ["cpu", "cuda", "mps", "accelerate"]
 
 
 class SmashConfig:
@@ -61,7 +62,7 @@ class SmashConfig:
     batch_size : int, optional
         The number of batches to process at once. Default is 1.
     device : str | torch.device | None, optional
-        The device to be used, e.g., 'cuda' or 'cpu'. Default is None.
+        The device to be used for smashing, options are "cpu", "cuda", "mps", "accelerate". Default is None.
         If None, the best available device will be used.
     cache_dir_prefix : str, optional
         The prefix for the cache directory. If None, a default cache directory will be created.

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -73,13 +73,7 @@ def load_pruna_model(model_path: str, **kwargs) -> tuple[Any, SmashConfig]:
     if len(smash_config.load_fns) > 1:
         pruna_logger.error(f"Load functions not used: {smash_config.load_fns[1:]}")
 
-    model = LOAD_FUNCTIONS[smash_config.load_fns[0]](model_path, **kwargs)
-
-    if "device_map" not in kwargs and "device" not in kwargs:
-        try:
-            move_to_device(model, smash_config.device, device_map=smash_config.device_map)
-        except Exception as e:
-            pruna_logger.error(f"Error moving model to device: {e}")
+    model = LOAD_FUNCTIONS[smash_config.load_fns[0]](model_path, smash_config, **kwargs)
 
     # check if there are any algorithms to reapply
     if any(algorithm is not None for algorithm in smash_config.reapply_after_load.values()):
@@ -222,7 +216,7 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(path: str, **kwargs) -> Any:
+def load_transformers_model(path: str, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
@@ -230,6 +224,8 @@ def load_transformers_model(path: str, **kwargs) -> Any:
     ----------
     path : str
         The path to the model directory.
+    smash_config : SmashConfig
+        The SmashConfig object containing the device and device_map.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
 
@@ -253,10 +249,11 @@ def load_transformers_model(path: str, **kwargs) -> Any:
         architecture = config["architectures"][0]
         cls = getattr(transformers, architecture)
         # transformers discards kwargs automatically, no need for filtering
-        return cls.from_pretrained(path, **kwargs)
+        device_map = smash_config.device_map if smash_config.device == "accelerate" else smash_config.device
+        return cls.from_pretrained(path, device_map=device_map, **kwargs)
 
 
-def load_diffusers_model(path: str, **kwargs) -> Any:
+def load_diffusers_model(path: str, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
@@ -264,6 +261,8 @@ def load_diffusers_model(path: str, **kwargs) -> Any:
     ----------
     path : str
         The path to the model directory.
+    smash_config : SmashConfig
+        The SmashConfig object containing the device and device_map.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
 
@@ -293,11 +292,14 @@ def load_diffusers_model(path: str, **kwargs) -> Any:
         kwargs["torch_dtype"] = dtype
 
     cls = getattr(diffusers, model_index["_class_name"])
-    # transformers discards kwargs automatically, no need for filtering
-    return cls.from_pretrained(path, **kwargs)
+    # diffusers discards kwargs automatically, no need for filtering
+    # diffusers does not support device_maps as dicts at the moment, we load on cpu and cast it ourselves
+    model = cls.from_pretrained(path, device_map=None, **kwargs)
+    move_to_device(model, smash_config.device, device_map=smash_config.device_map)
+    return model
 
 
-def load_pickled(path: str, **kwargs) -> Any:
+def load_pickled(path: str, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a pickled model from the given model path.
 
@@ -305,6 +307,8 @@ def load_pickled(path: str, **kwargs) -> Any:
     ----------
     path : str
         The path to the model directory.
+    smash_config : SmashConfig
+        The SmashConfig object containing the device and device_map.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
 
@@ -313,12 +317,20 @@ def load_pickled(path: str, **kwargs) -> Any:
     Any
         The loaded pickled model.
     """
-    return torch.load(
-        os.path.join(path, PICKLED_FILE_NAME), weights_only=False, **filter_load_kwargs(torch.load, kwargs)
+    # torch load has a target device but no interface to reproduce an accelerate-distributed model, we first map to cpu
+    target_device = "cpu" if smash_config.device == "accelerate" else smash_config.device
+    model = torch.load(
+        os.path.join(path, PICKLED_FILE_NAME),
+        weights_only=False,
+        map_location=target_device,
+        **filter_load_kwargs(torch.load, kwargs),
     )
+    # for cpu/cuda this will just continue as its on the correct device, for accelerate it will now distribute / cast
+    move_to_device(model, target_device, device_map=smash_config.device_map)
+    return model
 
 
-def load_hqq(model_path: str, **kwargs) -> Any:
+def load_hqq(model_path: str, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a model quantized with HQQ from the given model path.
 
@@ -326,6 +338,8 @@ def load_hqq(model_path: str, **kwargs) -> Any:
     ----------
     model_path : str
         The path to the model directory.
+    smash_config : SmashConfig
+        The SmashConfig object containing the device and device_map.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
 
@@ -340,12 +354,16 @@ def load_hqq(model_path: str, **kwargs) -> Any:
 
     try:  # Try to use pipeline for HF specific HQQ quantization
         model = algorithm_packages["HQQModelForCausalLM"].from_quantized(
-            model_path, **filter_load_kwargs(algorithm_packages["HQQModelForCausalLM"].from_quantized, kwargs)
+            model_path,
+            device=smash_config.device,
+            **filter_load_kwargs(algorithm_packages["HQQModelForCausalLM"].from_quantized, kwargs),
         )
     except Exception:  # Default to generic HQQ pipeline if it fails
         pruna_logger.info("Could not load HQQ model using pipeline, trying generic HQQ pipeline...")
         model = algorithm_packages["AutoHQQHFModel"].from_quantized(
-            model_path, **filter_load_kwargs(algorithm_packages["AutoHQQHFModel"].from_quantized, kwargs)
+            model_path,
+            device=smash_config.device,
+            **filter_load_kwargs(algorithm_packages["AutoHQQHFModel"].from_quantized, kwargs),
         )
 
     return model
@@ -368,7 +386,7 @@ def load_torch_artifacts(model_path: str, **kwargs) -> None:
     torch.compiler.load_cache_artifacts(artifact_bytes)
 
 
-def load_hqq_diffusers(path: str, **kwargs) -> Any:
+def load_hqq_diffusers(path: str, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
@@ -376,6 +394,8 @@ def load_hqq_diffusers(path: str, **kwargs) -> Any:
     ----------
     path : str
         The path to the model directory.
+    smash_config : SmashConfig
+        The SmashConfig object containing the device and device_map.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
 
@@ -415,6 +435,8 @@ def load_hqq_diffusers(path: str, **kwargs) -> Any:
     else:
         # load the whole model if a pipeline wasn't saved
         model = auto_hqq_hf_diffusers_model.from_quantized(path, **kwargs)
+    # HQQ does not support direct loading on the correct device, so we move it afterwards
+    move_to_device(model, smash_config.device, device_map=smash_config.device_map)
     return model
 
 

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -76,7 +76,10 @@ def load_pruna_model(model_path: str, **kwargs) -> tuple[Any, SmashConfig]:
     model = LOAD_FUNCTIONS[smash_config.load_fns[0]](model_path, **kwargs)
 
     if "device_map" not in kwargs and "device" not in kwargs:
-        move_to_device(model, smash_config.device)
+        try:
+            move_to_device(model, smash_config.device, device_map=smash_config.device_map)
+        except Exception as e:
+            pruna_logger.error(f"Error moving model to device: {e}")
 
     # check if there are any algorithms to reapply
     if any(algorithm is not None for algorithm in smash_config.reapply_after_load.values()):

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -114,6 +114,7 @@ class PrunaModel:
         Returns
         -------
         bool
+            True if the model is an instance of the given type, False otherwise.
         """
         return isinstance(self.model, instance_type)
 

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -121,6 +121,20 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
+    def __delattr__(self, attr: str) -> None:
+        """
+        Delete an attribute from the model.
+
+        Parameters
+        ----------
+        attr : str
+            The attribute to delete.
+        """
+        if self.model is None:
+            raise ValueError("No more model available, this model is likely destroyed.")
+        else:
+            delattr(self.model, attr)
+
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -121,6 +121,20 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
+    def __delattr__(self, attr: str) -> None:
+        """
+        Delete an attribute from the model.
+
+        Parameters
+        ----------
+        attr : str
+            The name of the attribute to delete.
+        """
+        if self.model is None:
+            raise ValueError("No more model available, this model is likely destroyed.")
+        else:
+            delattr(self.model, attr)
+
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -146,10 +146,7 @@ class PrunaModel:
         attr : str
             The attribute to delete.
         """
-        if self.model is None:
-            raise ValueError("No more model available, this model is likely destroyed.")
-        else:
-            delattr(self.model, attr)
+        delattr(self.model, attr)
 
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -102,6 +102,21 @@ class PrunaModel:
         outputs = self.inference_handler.process_output(outputs)
         return outputs
 
+    def compare_model_isinstance(self, instance_type: type) -> bool:
+        """
+        Compare the model to the given instance type.
+
+        Parameters
+        ----------
+        instance_type : type
+            The type to compare the model to.
+
+        Returns
+        -------
+        bool
+        """
+        return isinstance(self.model, instance_type)
+
     def __getattr__(self, attr: str) -> Any:
         """
         Forward attribute access to the underlying model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -102,7 +102,7 @@ class PrunaModel:
         outputs = self.inference_handler.process_output(outputs)
         return outputs
 
-    def compare_model_isinstance(self, instance_type: type) -> bool:
+    def is_instance(self, instance_type: type) -> bool:
         """
         Compare the model to the given instance type.
 

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -121,20 +121,6 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
-    def __delattr__(self, attr: str) -> None:
-        """
-        Delete an attribute from the model.
-
-        Parameters
-        ----------
-        attr : str
-            The name of the attribute to delete.
-        """
-        if self.model is None:
-            raise ValueError("No more model available, this model is likely destroyed.")
-        else:
-            delattr(self.model, attr)
-
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -136,13 +136,13 @@ class PrunaModel:
         """Set the model to evaluation mode."""
         set_to_eval(self.model)
 
-    def move_to_device(self, device: str | torch.device) -> None:
+    def move_to_device(self, device: str) -> None:
         """
         Move the model to a specific device.
 
         Parameters
         ----------
-        device : str | torch.device
+        device : str
             The device to move the model to.
         """
         move_to_device(self.model, device)

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -100,7 +100,7 @@ def move_to_device(model: Any, device: str, raise_error: bool = False, device_ma
         The device map to use if the target device is "accelerate".
     """
     # sanity check for expected device types
-    if not device in ["cpu", "cuda", "mps", "accelerate"]:
+    if device not in ["cpu", "cuda", "mps", "accelerate"]:
         raise ValueError("Device must be a string in [cpu, cuda, mps, accelerate].")
 
     # do not cast if the model is already on the correct device
@@ -147,12 +147,12 @@ def cast_model_to_accelerate_device_map(model, device_map):
     - device_map is the one created by accelerate/diffusers/transformers during from_pretrained
     - No disk or CPU devices in device_map (raises ValueError if encountered)
 
-    Args:
-        model: torch.nn.Module (Transformers or Diffusers model)
-        device_map: dict mapping module names (str) to CUDA device indices (int)
-
-    Raises:
-        ValueError: if any device in device_map is not an integer CUDA index
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model to cast.
+    device_map : dict
+        A dictionary mapping module names (str) to CUDA device indices (int).
     """
     if any(not isinstance(dev, int) for dev in device_map.values()):
         raise ValueError("All devices in device_map must be CUDA device indices (integers).")
@@ -197,10 +197,7 @@ def get_device(model: Any, return_device_map: bool = False) -> str | dict[str, s
         model_device = model_device.type
 
     if hasattr(model, "hf_device_map") and model.hf_device_map is not None:
-        if return_device_map:
-            model_device = model.hf_device_map
-        else:
-            model_device = "accelerate"
+        model_device = model.hf_device_map if return_device_map else "accelerate"
 
     return model_device
 

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -155,7 +155,7 @@ def remove_all_accelerate_hooks(model: Any) -> None:
     if isinstance(model, torch.nn.Module):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
         remove_hook_from_module(model, recurse=True)
-    else:
+    elif hasattr(model, "components"):
         # diffusers pipelines e.g. are not torch modules, so we need to find all attributes that are modules
         # we only do this at the first level, recurse will take care of the rest
         for attr in model.components:

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -102,7 +102,12 @@ def move_to_device(model: Any, device: str, raise_error: bool = False, device_ma
         The device map to use if the target device is "accelerate".
     """
     if isinstance(model, Pipeline):
-        return move_to_device(model.model, device, raise_error, device_map)
+        move_to_device(model.model, device, raise_error, device_map)
+        # this is a workaround for a flaw in the transformers pipeline handling
+        # specifically for a pipeline, the model is not expected to have a hf_device_map attribute
+        if device != "accelerate":
+            delattr(model.model, "hf_device_map")
+        return
 
     # sanity check for expected device types
     if device not in ["cpu", "cuda", "mps", "accelerate"]:
@@ -120,6 +125,7 @@ def move_to_device(model: Any, device: str, raise_error: bool = False, device_ma
     else:
         if get_device(model) == "accelerate":
             remove_all_accelerate_hooks(model)
+            # transformers model maintain single-device models with a None map, diffusers does not
             model.hf_device_map = {"": "cpu" if device == "cpu" else 0}
 
         try:
@@ -159,7 +165,10 @@ def remove_all_accelerate_hooks(model: Any) -> None:
             else:
                 raise e
 
-    if isinstance(model, torch.nn.Module):
+    # avoid circular import
+    from pruna.engine.pruna_model import PrunaModel
+
+    if isinstance(model, (torch.nn.Module, PrunaModel)):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
         remove_hook_from_module(model, recurse=True)
     elif hasattr(model, "components"):

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -150,7 +150,14 @@ def remove_all_accelerate_hooks(model: Any) -> None:
     """
     if hasattr(model, "reset_device_map"):
         # remove distributed device state to be able to use ".to" for diffusers models
-        model.reset_device_map()
+        try:
+            model.reset_device_map()
+        # inside reset device map, diffusers will attempt device casting and bnb is being difficult
+        except ValueError as e:
+            if "bitsandbytes" in str(e):
+                pass
+            else:
+                raise e
 
     if isinstance(model, torch.nn.Module):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
@@ -352,9 +359,6 @@ def set_to_best_available_device(device: str | torch.device | None) -> str:
     str
         Best available device name.
     """
-    if isinstance(device, torch.device):
-        device = str(device)
-
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
         pruna_logger.info(f"Using best available device: '{device}'")

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -195,6 +195,10 @@ def remove_all_accelerate_hooks(model: Any) -> None:
         for attr in model.components:
             if isinstance(getattr(model, attr), torch.nn.Module):
                 remove_hook_from_module(getattr(model, attr), recurse=True)
+    else:
+        pruna_logger.warning(
+            f"Could not remove hooks from {type(model)}, is not a torch.nn.Module and does not have a 'components' attribute"
+        )
 
 
 def cast_model_to_accelerate_device_map(model, device_map):

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -367,6 +367,9 @@ def set_to_best_available_device(device: str | torch.device | None) -> str:
     str
         Best available device name.
     """
+    if isinstance(device, torch.device):
+        device = device.type
+
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
         pruna_logger.info(f"Using best available device: '{device}'")

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -86,6 +86,27 @@ def get_nn_modules(model: Any) -> dict[str | None, torch.nn.Module]:
         }
 
 
+def safe_is_instance(model: Any, instance_type: type) -> bool:
+    """
+    Safely check if the model is an instance of the given type.
+
+    Parameters
+    ----------
+    model : Any
+        The model to check.
+    instance_type : type
+        The type to check against.
+
+    Returns
+    -------
+    bool
+        True if the model is an instance of the given type, False otherwise.
+    """
+    if hasattr(model, "is_instance"):
+        return model.is_instance(instance_type)
+    return isinstance(model, instance_type)
+
+
 def move_to_device(model: Any, device: str, raise_error: bool = False, device_map: dict[str, str] | None = None) -> None:
     """
     Move the model to a specific device.
@@ -165,9 +186,7 @@ def remove_all_accelerate_hooks(model: Any) -> None:
             else:
                 raise e
 
-    if isinstance(model, torch.nn.Module) or (
-        hasattr(model, "compare_model_isinstance") and model.compare_model_isinstance(torch.nn.Module)
-    ):
+    if safe_is_instance(model, torch.nn.Module):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
         remove_hook_from_module(model, recurse=True)
     elif hasattr(model, "components"):

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -105,7 +105,7 @@ def move_to_device(model: Any, device: str, raise_error: bool = False, device_ma
         move_to_device(model.model, device, raise_error, device_map)
         # this is a workaround for a flaw in the transformers pipeline handling
         # specifically for a pipeline, the model is not expected to have a hf_device_map attribute
-        if device != "accelerate":
+        if device != "accelerate" and hasattr(model.model, "hf_device_map"):
             delattr(model.model, "hf_device_map")
         return
 

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -166,7 +166,6 @@ def cast_model_to_accelerate_device_map(model, device_map):
         submodule.to(device)
 
     model.hf_device_map = device_map.copy()
-    return model
 
 
 def get_device(model: Any, return_device_map: bool = False) -> str | dict[str, str]:
@@ -177,6 +176,8 @@ def get_device(model: Any, return_device_map: bool = False) -> str | dict[str, s
     ----------
     model : Any
         The model to get the device from.
+    return_device_map : bool
+        Whether to return the device map.
 
     Returns
     -------

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -165,10 +165,9 @@ def remove_all_accelerate_hooks(model: Any) -> None:
             else:
                 raise e
 
-    # avoid circular import
-    from pruna.engine.pruna_model import PrunaModel
-
-    if isinstance(model, (torch.nn.Module, PrunaModel)):
+    if isinstance(model, torch.nn.Module) or (
+        hasattr(model, "compare_model_isinstance") and model.compare_model_isinstance(torch.nn.Module)
+    ):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
         remove_hook_from_module(model, recurse=True)
     elif hasattr(model, "components"):

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -197,7 +197,7 @@ def remove_all_accelerate_hooks(model: Any) -> None:
                 remove_hook_from_module(getattr(model, attr), recurse=True)
     else:
         pruna_logger.warning(
-            f"Could not remove hooks from {type(model)}, is not a torch.nn.Module and does not have a 'components' attribute"
+            f"Could not remove hooks from {type(model)}, is not a torch.nn.Module and does not have 'components' "
         )
 
 

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -197,13 +197,10 @@ def get_device(model: Any, return_device_map: bool = False) -> str | dict[str, s
         model_device = model_device.type
 
     if hasattr(model, "hf_device_map") and model.hf_device_map is not None:
-        if list(model.hf_device_map.keys()) == [""]:
-            model_device = "cpu" if model.hf_device_map[""] == "cpu" else "cuda"
+        if return_device_map:
+            model_device = model.hf_device_map
         else:
-            if return_device_map:
-                model_device = model.hf_device_map
-            else:
-                model_device = "accelerate"
+            model_device = "accelerate"
 
     return model_device
 

--- a/src/pruna/evaluation/task.py
+++ b/src/pruna/evaluation/task.py
@@ -72,6 +72,8 @@ class Task:
         self.metrics = get_metrics(request, device)
         self.datamodule = datamodule
         self.dataloader = datamodule.test_dataloader()
+        if device not in ["cuda", "cpu", "mps"]:
+            raise ValueError(f"Unsupported device: {device}. Must be one of: cuda, cpu, mps.")
         self.device = device
 
     def get_single_stateful_metrics(self) -> List[StatefulMetric]:

--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -94,18 +94,19 @@ def ensure_device_consistency(model, smash_config):
         if model_device == smash_config.device:
             pruna_logger.debug("Device consistency check passed.")
         else:
-            if model_device != smash_config.device and model_device != "accelerate":
+            if model_device != "accelerate":
                 pruna_logger.warning(
                     (
                         f"Model and SmashConfig have different devices. Model: {model_device}, "
                         f"SmashConfig: {smash_config.device}. Casting model to {smash_config.device}."
+                        f"If this is not desired, please use SmashConfig(device='{model_device}')."
                     )
                 )
             else:
                 # in this case, the model_device is a device map and the model is on multiple GPUs
                 pruna_logger.warning(
                     (
-                        f"SmashConfig specifies {smash_config.device} but model is distributed."
+                        f"SmashConfig specifies {smash_config.device} but model is distributed. "
                         f"Casting model to {smash_config.device}. If this is not desired, please use "
                         f"SmashConfig(device='accelerate') to continue with distributed model."
                     )

--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -18,8 +18,12 @@ from typing import Any
 
 from pruna import PrunaModel, SmashConfig
 from pruna.algorithms import PRUNA_ALGORITHMS
-from pruna.config.smash_space import ALGORITHM_GROUPS, SMASH_SPACE
-from pruna.engine.utils import get_device, move_to_device
+from pruna.config.compatibility_checks import (
+    check_algorithm_availability,
+    check_model_compatibility,
+    ensure_device_consistency,
+)
+from pruna.config.smash_space import ALGORITHM_GROUPS
 from pruna.logging.logger import PrunaLoggerContext, pruna_logger
 from pruna.telemetry import track_usage
 
@@ -75,138 +79,3 @@ def smash(
         smashed_model = PrunaModel(model, smash_config=smash_config)
 
     return smashed_model
-
-
-def ensure_device_consistency(model, smash_config):
-    """
-    Ensure consistency between the device state of the model and the smash config.
-
-    Parameters
-    ----------
-    model : Any
-        The model to check for device consistency.
-    smash_config : SmashConfig
-        The smash config to check for device consistency.
-    """
-    model_device = get_device(model)
-
-    if smash_config.device in ["cpu", "cuda", "mps"]:
-        if model_device == smash_config.device:
-            pruna_logger.debug("Device consistency check passed.")
-        else:
-            if model_device != "accelerate":
-                pruna_logger.warning(
-                    (
-                        f"Model and SmashConfig have different devices. Model: {model_device}, "
-                        f"SmashConfig: {smash_config.device}. Casting model to {smash_config.device}."
-                        f"If this is not desired, please use SmashConfig(device='{model_device}')."
-                    )
-                )
-            else:
-                # in this case, the model_device is a device map and the model is on multiple GPUs
-                pruna_logger.warning(
-                    (
-                        f"SmashConfig specifies {smash_config.device} but model is distributed. "
-                        f"Casting model to {smash_config.device}. If this is not desired, please use "
-                        f"SmashConfig(device='accelerate') to continue with distributed model."
-                    )
-                )
-            move_to_device(model, smash_config.device)
-
-    elif smash_config.device == "accelerate":
-        if model_device == "accelerate":
-            pruna_logger.debug("Device consistency check passed.")
-            hf_device_map = get_device(model, return_device_map=True)
-            if not all(isinstance(v, int) for v in hf_device_map.values()):
-                raise ValueError("Device map indicates CPU offloading, this is not supported at this time.")
-            else:
-                smash_config.device_map = hf_device_map
-        else:
-            pruna_logger.warning(
-                (
-                    f"SmashConfig specifies 'accelerate' but model is not distributed and is on device {model_device}. "
-                    f"Updating SmashConfig to device='{model_device}'."
-                )
-            )
-            smash_config.device = model_device
-    else:
-        raise ValueError(f"Invalid device: {smash_config.device}")
-
-
-def check_model_compatibility(
-    model: Any,
-    smash_config: SmashConfig,
-    algorithm_dict: dict[str, Any] = PRUNA_ALGORITHMS,
-) -> None:
-    """
-    Check if the model is compatible with the given configuration.
-
-    Parameters
-    ----------
-    model : Any
-        The model to check for compatibility with the SmashConfig.
-    smash_config : SmashConfig
-        The SmashConfig to check the model against.
-    algorithm_dict : dict[str, Any]
-        The algorithm dictionary to hold all algorithm instances.
-    """
-    # algorithm groups are subject to change, make sure we have the latest version
-    from pruna.config.smash_space import ALGORITHM_GROUPS
-
-    # iterate through compiler, quantizer, ...
-    for current_group in ALGORITHM_GROUPS:
-        algorithm = smash_config[current_group]
-        if algorithm is not None:
-            check_algorithm_availability(algorithm, current_group, algorithm_dict)
-            # test if all required packages are installed, if not this will raise an ImportError
-            algorithm_dict[current_group][algorithm].import_algorithm_packages()
-            check_argument_compatibility(smash_config, algorithm)
-            # check for model-algorithm compatibility with the model_check_fn
-            if not algorithm_dict[current_group][algorithm].model_check_fn(model):
-                raise ValueError(
-                    f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
-                )
-
-
-def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str) -> None:
-    """
-    Check if the SmashConfig has the required arguments (tokenizer, processor, dataset) for an algorithm.
-
-    Parameters
-    ----------
-    smash_config : SmashConfig
-        The SmashConfig to check the argument consistency with.
-    algorithm_name : str
-        The algorithm name that is about to be activated.
-    """
-    algorithm_requirements = SMASH_SPACE.model_requirements[algorithm_name]
-    if algorithm_requirements["tokenizer_required"] and smash_config.tokenizer is None:
-        raise ValueError(f"{algorithm_name} requires a tokenizer. Please provide it with smash_config.add_tokenizer().")
-    if algorithm_requirements["processor_required"] and smash_config.processor is None:
-        raise ValueError(f"{algorithm_name} requires a processor. Please provide it with smash_config.add_processor().")
-    if algorithm_requirements["dataset_required"] and smash_config.data is None:
-        raise ValueError(f"{algorithm_name} requires a dataset. Please provide it with smash_config.add_data().")
-
-
-def check_algorithm_availability(algorithm: str, algorithm_group: str, algorithm_dict: dict[str, Any]) -> None:
-    """
-    Check if the algorithm is available in the algorithm dictionary.
-
-    Parameters
-    ----------
-    algorithm : str
-        The algorithm to check for availability.
-    algorithm_group : str
-        The algorithm group to check for availability.
-    algorithm_dict : dict[str, Any]
-        The algorithm dictionary to check for availability.
-
-    Raises
-    ------
-    ValueError
-        If the algorithm is not available in the algorithm dictionary.
-    """
-    if algorithm_group not in algorithm_dict:
-        raise RuntimeError(f"Algorithm group {algorithm_group} is unavailable with pruna.smash")
-    if algorithm not in algorithm_dict[algorithm_group]:
-        raise RuntimeError(f"Algorithm {algorithm} is unavailable with pruna.smash")

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -12,7 +12,14 @@ from ..common import (
 from . import testers
 
 
-@device_parametrized
+@pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param("cuda", marks=pytest.mark.cuda),
+            pytest.param("accelerate", marks=pytest.mark.cuda),
+            pytest.param("cpu", marks=pytest.mark.cpu),
+        ],
+    )
 @pytest.mark.parametrize(
     "algorithm_tester, model_fixture",
     get_instances_from_module(testers),

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -12,14 +12,7 @@ from ..common import (
 from . import testers
 
 
-@pytest.mark.parametrize(
-    "device",
-    [
-        pytest.param("cuda", marks=pytest.mark.cuda),
-            pytest.param("accelerate", marks=pytest.mark.cuda),
-            pytest.param("cpu", marks=pytest.mark.cpu),
-        ],
-    )
+@device_parametrized
 @pytest.mark.parametrize(
     "algorithm_tester, model_fixture",
     get_instances_from_module(testers),

--- a/tests/algorithms/testers/base_tester.py
+++ b/tests/algorithms/testers/base_tester.py
@@ -38,11 +38,6 @@ class AlgorithmTesterBase:
         pass
 
     @classmethod
-    def cast_to_device(cls, model: Any, device: str = "cpu") -> Any:
-        """Cast the model to the given device."""
-        move_to_device(model, device)
-
-    @classmethod
     def final_teardown(cls, smash_config: SmashConfig) -> None:
         """Teardown the test, remove the saved model and clean up the files in any case."""
         # reset this smash config cache dir, this should not be shared across runs

--- a/tests/algorithms/testers/base_tester.py
+++ b/tests/algorithms/testers/base_tester.py
@@ -94,6 +94,7 @@ class AlgorithmTesterBase:
         model = PrunaModel.from_pretrained(self.saving_path)
         assert isinstance(model, PrunaModel)
         self.post_smash_hook(model)
+        assert model.smash_config.device == get_device(model)
 
     def execute_smash(self, model: Any, smash_config: SmashConfig) -> PrunaModel:
         """Execute the smash operation."""

--- a/tests/algorithms/testers/base_tester.py
+++ b/tests/algorithms/testers/base_tester.py
@@ -69,7 +69,7 @@ class AlgorithmTesterBase:
     @classmethod
     def compatible_devices(cls) -> list[str]:
         """Get the compatible devices for the algorithm."""
-        return cls.algorithm_class.compatible_devices()
+        return cls.algorithm_class.runs_on
 
     @classmethod
     def get_algorithm_name(cls) -> str:

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -38,7 +38,7 @@ class TestQuanto(AlgorithmTesterBase):
 class TestLLMint8(AlgorithmTesterBase):
     """Test the LLMint8 quantizer."""
 
-    models = ["opt_tiny_random"]
+    models = ["opt_125m"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = LLMInt8Quantizer

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -38,7 +38,7 @@ class TestQuanto(AlgorithmTesterBase):
 class TestLLMint8(AlgorithmTesterBase):
     """Test the LLMint8 quantizer."""
 
-    models = ["opt_125m"]
+    models = ["opt_tiny_random"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = LLMInt8Quantizer

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ import torch
 from accelerate.utils import compute_module_sizes, infer_auto_device_map
 from docutils.core import publish_doctree
 from docutils.nodes import literal_block, section, title
+from transformers import Pipeline
 
 from pruna import SmashConfig
 from pruna.engine.utils import get_device, move_to_device, safe_memory_cleanup
@@ -98,7 +99,10 @@ def construct_device_map_manually(model: Any) -> dict:
     device_map : dict
         The device map for the model.
     """
-    assert torch.cuda.device_count()
+    assert torch.cuda.device_count() > 1, "This test requires at least 2 GPUs"
+
+    if isinstance(model, Pipeline):
+        return construct_device_map_manually(model.model)
 
     if isinstance(model, torch.nn.Module):
         # even when requesting a balanced device map, some models might be too small to be distributed

--- a/tests/common.py
+++ b/tests/common.py
@@ -15,6 +15,7 @@ from pruna import SmashConfig
 from pruna.engine.utils import get_device, move_to_device, safe_memory_cleanup
 
 EPS_MEMORY_SIZE = 1000
+NO_SPLIT_MODULES_ACCELERATE = ["OPTDecoderLayer"]
 
 
 def device_parametrized(cls: Any) -> Any:
@@ -107,6 +108,7 @@ def construct_device_map_manually(model: Any) -> dict:
         return infer_auto_device_map(
             model,
             max_memory={0: model_size - EPS_MEMORY_SIZE, 1: model_size - EPS_MEMORY_SIZE},
+            no_split_module_classes=NO_SPLIT_MODULES_ACCELERATE,
         )
     else:
         # make sure a pipelines components are distributed by putting the first half on GPU 0, second half on GPU 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ def pytest_configure(config: Any) -> None:
     """Configure the pytest markers."""
     config.addinivalue_line("markers", "cpu: mark test to run on CPU")
     config.addinivalue_line("markers", "cuda: mark test to run only on GPU machines")
+    config.addinivalue_line("markers", "distributed: mark test to run only on multi-GPU machines")
     config.addinivalue_line("markers", "high: mark test to run only on large GPUs")
     config.addinivalue_line("markers", "high_cpu: mark test to run only on large CPU systems")
     config.addinivalue_line("markers", "slow: mark test that run rather long")

--- a/tests/engine/test_device.py
+++ b/tests/engine/test_device.py
@@ -5,6 +5,7 @@ from pruna.engine.utils import move_to_device, get_device
 from diffusers import StableDiffusionPipeline, FluxTransformer2DModel, FluxPipeline
 from typing import Any
 from ..common import construct_device_map_manually
+from transformers import Pipeline
 
 DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
@@ -151,6 +152,8 @@ def move_and_verify(model: Any, target_device: str, device_map: dict[str, Any]) 
 
 def find_unique_devices(model: Any) -> list[torch.device]:
     """Find all unique devices in the model."""
+    if isinstance(model, Pipeline):
+        return find_unique_devices(model.model)
     devices = []
     targets = [model] if hasattr(model, "parameters") else [getattr(model, component) for component in model.components]
     for target in targets:

--- a/tests/engine/test_device.py
+++ b/tests/engine/test_device.py
@@ -1,7 +1,8 @@
 import pytest
 import torch
 from pruna.config.smash_config import SmashConfig
-
+from pruna.engine.utils import move_to_device, get_device
+from diffusers import StableDiffusionPipeline
 DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
 @pytest.mark.cuda
@@ -39,3 +40,35 @@ def test_device_available(device: str | torch.device, expected: str) -> None:
     smash_config = SmashConfig(device=device)
     assert smash_config.device == expected
 
+
+@pytest.mark.cuda
+@pytest.mark.parametrize(
+    "input_device,target_device",
+    [
+        ("cpu", "cuda"),
+        ("cuda", "cpu"),
+    ],
+)
+def test_device_casting(input_device: str | torch.device, target_device: str | torch.device) -> None:
+    """Test that the device can be cast to the target device."""
+    model = torch.nn.Linear(10, 10)
+    model.to(input_device)
+    move_to_device(model, target_device)
+    assert get_device(model) == target_device
+
+
+@pytest.mark.parametrize(
+    "target_device",
+    [
+        "cuda",
+        "cpu",
+    ],
+)
+def test_accelerate_to_single_casting(target_device: str | torch.device) -> None:
+    """Test that the device can be cast to the target device."""
+    model = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", device_map="balanced")
+    device_map = model.hf_device_map
+    move_to_device(model, target_device)
+    assert get_device(model) == target_device 
+    move_to_device(model, "accelerate", device_map=device_map)
+    assert get_device(model) == "accelerate" 

--- a/tests/engine/test_device.py
+++ b/tests/engine/test_device.py
@@ -2,7 +2,9 @@ import pytest
 import torch
 from pruna.config.smash_config import SmashConfig
 from pruna.engine.utils import move_to_device, get_device
-from diffusers import StableDiffusionPipeline
+from diffusers import StableDiffusionPipeline, FluxTransformer2DModel, FluxPipeline
+from typing import Any
+
 DEVICE = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
 @pytest.mark.cuda
@@ -49,26 +51,118 @@ def test_device_available(device: str | torch.device, expected: str) -> None:
         ("cuda", "cpu"),
     ],
 )
-def test_device_casting(input_device: str | torch.device, target_device: str | torch.device) -> None:
+@pytest.mark.parametrize(
+    "model_fixture", ["flux_tiny_random", "whisper_tiny_random", "opt_tiny_random"], indirect=True
+)
+def test_device_casting(input_device: str | torch.device, target_device: str | torch.device, model_fixture: Any) -> None:
     """Test that the device can be cast to the target device."""
-    model = torch.nn.Linear(10, 10)
-    model.to(input_device)
+    model, _ = model_fixture
+    move_to_device(model, input_device)
+    assert get_device(model) == input_device
     move_to_device(model, target_device)
     assert get_device(model) == target_device
 
 
-@pytest.mark.parametrize(
-    "target_device",
-    [
-        "cuda",
-        "cpu",
-    ],
-)
-def test_accelerate_to_single_casting(target_device: str | torch.device) -> None:
-    """Test that the device can be cast to the target device."""
-    model = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", device_map="balanced")
-    device_map = model.hf_device_map
+@pytest.mark.distributed
+@pytest.mark.parametrize("target_device", ["cuda", "cpu"])
+@pytest.mark.parametrize("model_fixture", ["stable_diffusion_v1_4"], indirect=True)
+def test_accelerate_diffusers_casting(target_device: str | torch.device, model_fixture: Any) -> None:
+    """Test that a diffusers pipeline can be cast to the target device."""
+    model, _ = model_fixture
+    device_map = model.hf_device_map.copy()
     move_to_device(model, target_device)
+
+    # verify that get_device works as intended
     assert get_device(model) == target_device 
+    # verify that all tensors were actually cast to the *same* device
+    assert len(find_unique_devices(model)) == 1
+    # verify functionality of forward pass
+    model("an elf on a shelf", num_inference_steps=2, width=16, height=16)
+
+    # cast back to distributed state
     move_to_device(model, "accelerate", device_map=device_map)
+    # verify that get_device works as intended and forward pass works
     assert get_device(model) == "accelerate" 
+    model("an elf on a shelf", num_inference_steps=2, width=16, height=16)
+    # verify that all tensors were actually cast to *different* devices
+    assert len(find_unique_devices(model)) > 1
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("target_device", ["cuda", "cpu"])
+@pytest.mark.parametrize("model_fixture", ["opt_125m"], indirect=True)
+def test_accelerate_autocausallm_casting(target_device: str | torch.device, model_fixture: Any) -> None:
+    """Test that a transformer AutoModel can be cast to the target device."""
+    model, config = model_fixture
+    device_map = model.hf_device_map.copy()
+    
+    move_and_verify(model, target_device, device_map)
+    dummy = config.tokenizer([""] * 10, max_length=100, padding="max_length", return_tensors="pt") 
+    dummy = dummy.to(target_device)
+    model(**dummy)   
+
+    move_and_verify(model, "accelerate", device_map)
+    model(**dummy)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("target_device", ["cuda", "cpu"])
+def test_accelerate_diffusers_model_casting(target_device: str | torch.device) -> None:
+    """Test that a diffusers model can be cast to the target device."""
+    model = FluxTransformer2DModel.from_pretrained("black-forest-labs/FLUX.1-dev", subfolder="transformer", device_map="balanced")
+    full_pipe = FluxPipeline.from_pretrained("black-forest-labs/FLUX.1-dev", device_map="balanced", transformer=None)
+    
+    device_map_model = model.hf_device_map.copy()
+    device_map_full_pipe = full_pipe.hf_device_map.copy()
+
+    move_and_verify(full_pipe, target_device, device_map_full_pipe)  
+    move_and_verify(model, target_device, device_map_model)  
+
+    full_pipe.transformer = model
+    full_pipe("an elf on a shelf", num_inference_steps=2, width=16, height=16)
+    full_pipe.transformer = None
+
+    move_and_verify(model, "accelerate", device_map_model)
+    move_and_verify(full_pipe, "accelerate", device_map_full_pipe)
+
+    full_pipe.transformer = model
+    full_pipe("an elf on a shelf", num_inference_steps=2, width=16, height=16)
+
+
+@pytest.mark.distributed
+@pytest.mark.parametrize("target_device", ["cuda", "cpu"])
+@pytest.mark.parametrize("model_fixture", ["asr_tiny_random"], indirect=True)
+def test_accelerate_transformer_pipeline_casting(target_device: str | torch.device, model_fixture: Any) -> None:
+    """Test that a diffusers model can be cast to the target device."""
+    model, _ = model_fixture
+    device_map = model.model.hf_device_map.copy()
+    move_and_verify(model, target_device, device_map)  
+    move_and_verify(model, "accelerate", device_map)
+
+    
+
+def move_and_verify(model: Any, target_device: str, device_map: dict[str, Any]) -> None:
+    """Move the model to the target device and verify that the casting was successful."""
+    unique = target_device != "accelerate"
+    move_to_device(model, target_device, device_map=device_map)
+    # verify that get_device works as intended
+    assert get_device(model) == target_device
+    # verify that all tensors were actually cast correctly
+    if unique:
+        assert len(find_unique_devices(model)) == 1
+    else:
+        assert len(find_unique_devices(model)) > 1
+    
+
+def find_unique_devices(model: Any) -> list[torch.device]:
+    """Find all unique devices in the model."""
+    devices = []
+    targets = [model] if hasattr(model, "parameters") else [getattr(model, component) for component in model.components]
+    for target in targets:
+        if not hasattr(target, "parameters"):
+            continue
+        for param in target.parameters():
+            devices.append(param.device)
+    return list(set(devices))
+
+

--- a/tests/engine/test_device.py
+++ b/tests/engine/test_device.py
@@ -72,6 +72,8 @@ def test_accelerate_diffusers_casting(target_device: str | torch.device, model_f
     """Test that a diffusers pipeline can be cast to the target device."""
     model, _ = model_fixture
     device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+    
     move_and_verify(model, target_device, device_map)
 
     # verify functionality of forward pass

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,10 +70,9 @@ def stable_diffusion_v1_4_model() -> tuple[Any, SmashConfig]:
 def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
     """Whisper tiny random model for speech recognition."""
     source_model_id = "openai/whisper-tiny"
-    model_id = "yujiepan/whisper-v3-tiny-random"
     model = pipeline(
         "automatic-speech-recognition",
-        model=model_id,
+        model=source_model_id,
         chunk_length_s=30,
         torch_dtype=torch.float16,
         device_map="balanced",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -76,7 +76,7 @@ def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
         model=model_id,
         chunk_length_s=30,
         torch_dtype=torch.float16,
-        device="cpu",
+        device_map="balanced",
     )
     smash_config = SmashConfig()
     smash_config.add_tokenizer(source_model_id)
@@ -93,7 +93,7 @@ def dummy_model() -> tuple[Any, SmashConfig]:
 
 def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get a diffusers model for image generation."""
-    model = cls.from_pretrained(model_id, **kwargs)
+    model = cls.from_pretrained(model_id, device_map="balanced", **kwargs)
     smash_config = SmashConfig()
     smash_config.add_data("LAION256")
     return model, smash_config
@@ -101,7 +101,7 @@ def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any])
 
 def get_automodel_transformers(model_id: str) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
-    model = AutoModelForCausalLM.from_pretrained(model_id)
+    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced")
     smash_config = SmashConfig()
     try:
         smash_config.add_tokenizer(model_id)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -93,7 +93,8 @@ def dummy_model() -> tuple[Any, SmashConfig]:
 
 def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get a diffusers model for image generation."""
-    model = cls.from_pretrained(model_id, device_map="balanced", **kwargs)
+    # load in distributed mode, if not intended by test this will be cast down to CPU/CUDA
+    model = cls.from_pretrained(model_id, **kwargs, device_map="balanced")
     smash_config = SmashConfig()
     smash_config.add_data("LAION256")
     return model, smash_config

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,12 +70,13 @@ def stable_diffusion_v1_4_model() -> tuple[Any, SmashConfig]:
 def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
     """Whisper tiny random model for speech recognition."""
     source_model_id = "openai/whisper-tiny"
+    model_id = "yujiepan/whisper-v3-tiny-random"
     model = pipeline(
         "automatic-speech-recognition",
-        model=source_model_id,
+        model=model_id,
         chunk_length_s=30,
         torch_dtype=torch.float16,
-        device_map="balanced",
+        device_map="cpu",
     )
     smash_config = SmashConfig()
     smash_config.add_tokenizer(source_model_id)
@@ -92,8 +93,7 @@ def dummy_model() -> tuple[Any, SmashConfig]:
 
 def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get a diffusers model for image generation."""
-    # load in distributed mode, if not intended by test this will be cast down to CPU/CUDA
-    model = cls.from_pretrained(model_id, **kwargs, device_map="balanced")
+    model = cls.from_pretrained(model_id, **kwargs)
     smash_config = SmashConfig()
     smash_config.add_data("LAION256")
     return model, smash_config
@@ -101,7 +101,7 @@ def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any])
 
 def get_automodel_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
-    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced", **kwargs)
+    model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
     smash_config = SmashConfig()
     try:
         smash_config.add_tokenizer(model_id)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -100,9 +100,9 @@ def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any])
     return model, smash_config
 
 
-def get_automodel_transformers(model_id: str) -> tuple[Any, SmashConfig]:
+def get_automodel_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
-    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced")
+    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced", **kwargs)
     smash_config = SmashConfig()
     try:
         smash_config.add_tokenizer(model_id)


### PR DESCRIPTION
## Description
This PR introduces the option to smash a distributed model. It does so by
- extending expected SmashConfig devices to "accelerate"
- extending the `move_to_device` function
- adding functionality to determine the device of a model (plus tests)
- proof of concept adjustment for two methods to adapt to distributed models
- extending the loading of a pruna model to restore the original state

I would appreciate any suggestions on extending the tests!! I feel like the device casting functionality should be monitored thoroughly so any suggestions are welcome.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Added tests for device casting functionality which pass locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Examples:
```python
import torch
from diffusers import StableDiffusionPipeline
from pruna import smash, SmashConfig
from pruna.engine.utils import get_device

pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.bfloat16, device_map="balanced")

config = SmashConfig(device="accelerate")
config["cacher"] = "deepcache"
smashed_pipe = smash(pipe, config)
get_device(smashed_pipe)
```
```bash
INFO - Starting cacher deepcache...
INFO - cacher deepcache was applied successfully.
'accelerate'
```
---------------------------
```python
import torch
from diffusers import StableDiffusionPipeline
from pruna import smash, SmashConfig
from pruna.engine.utils import get_device

pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.bfloat16, device_map="balanced")

config = SmashConfig(device="cuda")
config["cacher"] = "deepcache"
smashed_pipe = smash(pipe, config)
get_device(smashed_pipe)
```
```bash
WARNING - SmashConfig specifies cuda but model is distributed.Casting model to cuda. If this is not desired, please use SmashConfig(device='accelerate') to continue with distributed model.
INFO - Starting cacher deepcache...
INFO - cacher deepcache was applied successfully.
'cuda'
```
---------------------------
```python
import torch
from diffusers import StableDiffusionPipeline
from pruna import smash, SmashConfig
from pruna.engine.utils import get_device

pipe = StableDiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", torch_dtype=torch.bfloat16, device_map="balanced")

config = SmashConfig(device="accelerate")
config["quantizer"] = "diffusers_int8"
smashed_pipe = smash(pipe, config)
get_device(smashed_pipe)
```
```bash
INFO - Starting quantizer diffusers_int8...
INFO - quantizer diffusers_int8 was applied successfully.
'accelerate'
```
---------------------------
```python
from transformers import AutoModelForCausalLM, AutoTokenizer
from pruna import smash, SmashConfig
from pruna.engine.utils import get_device

model_id = "meta-llama/Llama-3.2-1B"
base_model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced")

config = SmashConfig(device="accelerate")
config["quantizer"] = "llm_int8"
smashed_model = smash(base_model, config)
get_device(smashed_model)
```
```bash
INFO - Starting quantizer llm_int8...
INFO - quantizer llm_int8 was applied successfully.
'accelerate'
```
---------------------------

