### PR TITLE
feat: extend device compatibility of algorithms

### DIFF
--- a/docs/user_manual/customize_algorithm.rst
+++ b/docs/user_manual/customize_algorithm.rst
@@ -48,8 +48,7 @@ These attributes are used to provide information about the algorithm to the user
         tokenizer_required = False
         processor_required = False
         dataset_required = False
-        run_on_cpu = True
-        run_on_cuda = True
+        runs_on = ["cpu", "cuda"]
         compatible_algorithms = dict(quantizer=["quanto"])
 
 
@@ -60,7 +59,7 @@ Step 4. Add Algorithm Attributes
 - ``algorithm_name``: Identifier used to activate the algorithm, name should be in snake case.
 - ``references``: A dictionary of any references that can be provided for the algorithm, typically a link to the GitHub repository or a paper.
 - ``tokenizer_required``, ``processor_required``, ``dataset_required``: Indicate required components.
-- ``run_on_cpu``, ``run_on_cuda``: Define hardware compatibility.
+- ``runs_on``: Define which of the hardwares listed in ``SUPPORTED_DEVICES`` are compatible with the algorithm.
 - ``compatible_algorithms``: Lists compatible algorithms, i.e. any algorithm that can be applied on the same model together with the current algorithm. This compatibility should be specified both ways; if “quanto” is compatible with “superfast”, “superfast” must also list “quanto”.
 - Additionally, you might have to specify a saving function. We provide more details on this in the section below.
 
@@ -242,8 +241,7 @@ Here’s the complete ``superfast.py`` implementation:
         tokenizer_required = False
         processor_required = False
         dataset_required = False
-        run_on_cpu = True
-        run_on_cuda = True
+        runs_on = ["cpu", "cuda"]
         compatible_algorithms = dict(quantizer=["quanto"])
 
         def get_hyperparameters(self) -> list:

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -44,7 +44,9 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}." if required_install_str else "",
+            f"| **Required install**: {required_install_str}."
+            if required_install_str
+            else "",
         ]
     )
 
@@ -80,12 +82,20 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+    header_line = (
+        "|"
+        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
+        + "|"
+    )
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+        row_line = (
+            "|"
+            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
+            + "|"
+        )
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 
@@ -133,10 +143,7 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
             "mps": "MPS",
             "accelerate": "Accelerate distributed",
         }
-        if device in name_map:
-            compatible_devices.append(name_map[device])
-        else:
-            compatible_devices.append(device)
+        compatible_devices.append(name_map[device])
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -44,9 +44,7 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}."
-            if required_install_str
-            else "",
+            f"| **Required install**: {required_install_str}." if required_install_str else "",
         ]
     )
 
@@ -82,20 +80,12 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = (
-        "|"
-        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
-        + "|"
-    )
+    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = (
-            "|"
-            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
-            + "|"
-        )
+        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 
@@ -140,7 +130,11 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
         if device == "cpu":
             compatible_devices.append("CPU")
         elif device == "cuda":
-            compatible_devices.append("GPU")
+            compatible_devices.append("CUDA")
+        elif device == "mps":
+            compatible_devices.append("MPS")
+        elif device == "accelerate":
+            compatible_devices.append("Accelerate distributed")
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -127,14 +127,16 @@ def get_compatible_devices(obj: PrunaAlgorithmBase) -> str:
     """Get the compatible devices of a Pruna algorithm."""
     compatible_devices = []
     for device in obj.compatible_devices():
-        if device == "cpu":
-            compatible_devices.append("CPU")
-        elif device == "cuda":
-            compatible_devices.append("CUDA")
-        elif device == "mps":
-            compatible_devices.append("MPS")
-        elif device == "accelerate":
-            compatible_devices.append("Accelerate distributed")
+        name_map = {
+            "cpu": "CPU",
+            "cuda": "CUDA",
+            "mps": "MPS",
+            "accelerate": "Accelerate distributed",
+        }
+        if device in name_map:
+            compatible_devices.append(name_map[device])
+        else:
+            compatible_devices.append(device)
     return ", ".join(compatible_devices) if compatible_devices else "None"
 
 

--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -36,14 +36,13 @@ class IFWBatcher(PrunaBatcher):
     batch size to a value that corresponds to your inference requirements.
     """
 
-    algorithm_name = "ifw"
-    references = {"GitHub": "https://github.com/huggingface/transformers"}
-    tokenizer_required = True
-    processor_required = True
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(quantizer=["half"])
+    algorithm_name: str = "ifw"
+    references: dict[str, str] = {"GitHub": "https://github.com/huggingface/transformers"}
+    tokenizer_required: bool = True
+    processor_required: bool = True
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/batching/ws2t.py
+++ b/src/pruna/algorithms/batching/ws2t.py
@@ -43,14 +43,15 @@ class WS2TBatcher(PrunaBatcher):
     batch size to a value that corresponds to your inference requirements.
     """
 
-    algorithm_name = "whisper_s2t"
-    references = {"GitHub": "https://github.com/shashikg/WhisperS2T"}
-    tokenizer_required = True
-    processor_required = True
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(compiler=["c_translate", "c_generate", "c_whisper"], quantizer=["half"])
+    algorithm_name: str = "whisper_s2t"
+    references: dict[str, str] = {"GitHub": "https://github.com/shashikg/WhisperS2T"}
+    tokenizer_required: bool = True
+    processor_required: bool = True
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(
+        compiler=["c_translate", "c_generate", "c_whisper"], quantizer=["half"]
+    )
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/caching/deepcache.py
+++ b/src/pruna/algorithms/caching/deepcache.py
@@ -30,14 +30,16 @@ class DeepCacheCacher(PrunaCacher):
     features.
     """
 
-    algorithm_name = "deepcache"
-    references = {"GitHub": "https://github.com/horseee/DeepCache", "Paper": "https://arxiv.org/abs/2312.00858"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(
+    algorithm_name: str = "deepcache"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/horseee/DeepCache",
+        "Paper": "https://arxiv.org/abs/2312.00858",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
         compiler=["stable_fast", "torch_compile"],
         quantizer=["half", "hqq_diffusers", "diffusers_int8", "quanto"],

--- a/src/pruna/algorithms/caching/fastercache.py
+++ b/src/pruna/algorithms/caching/fastercache.py
@@ -44,14 +44,16 @@ class FasterCacheCacher(PrunaCacher):
     https://github.com/huggingface/diffusers/pull/9562.
     """
 
-    algorithm_name = "fastercache"
-    references = {"GitHub": "https://github.com/Vchitect/FasterCache", "Paper": "https://arxiv.org/abs/2410.19355"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
+    algorithm_name: str = "fastercache"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/Vchitect/FasterCache",
+        "Paper": "https://arxiv.org/abs/2410.19355",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
 
     def get_hyperparameters(self) -> list:
         """
@@ -126,7 +128,7 @@ class FasterCacheCacher(PrunaCacher):
         spatial_attention_block_identifiers: Tuple[str, ...] = (
             "blocks.*attn1",
             "transformer_blocks.*attn1",
-            "single_transformer_blocks.*attn1"
+            "single_transformer_blocks.*attn1",
         )
         temporal_attention_block_identifiers: Tuple[str, ...] = ("temporal_transformer_blocks.*attn1",)
         attention_weight_callback = lambda _: 0.5  # noqa: E731
@@ -143,12 +145,18 @@ class FasterCacheCacher(PrunaCacher):
             attention_weight_callback = lambda _: 0.3  # noqa: E731
         elif is_flux_pipeline(model):
             spatial_attention_timestep_skip_range = (-1, 961)
-            spatial_attention_block_identifiers = ("transformer_blocks", "single_transformer_blocks",)
+            spatial_attention_block_identifiers = (
+                "transformer_blocks",
+                "single_transformer_blocks",
+            )
             tensor_format = "BCHW"
             is_guidance_distilled = True
         elif is_hunyuan_pipeline(model):
             spatial_attention_timestep_skip_range = (99, 941)
-            spatial_attention_block_identifiers = ("transformer_blocks", "single_transformer_blocks",)
+            spatial_attention_block_identifiers = (
+                "transformer_blocks",
+                "single_transformer_blocks",
+            )
             tensor_format = "BCFHW"
             is_guidance_distilled = True
         elif is_latte_pipeline(model):

--- a/src/pruna/algorithms/caching/fora.py
+++ b/src/pruna/algorithms/caching/fora.py
@@ -37,8 +37,7 @@ class FORACacher(PrunaCacher):
     references: dict[str, str] = {"Paper": "https://arxiv.org/abs/2407.01425"}
     tokenizer_required: bool = False
     processor_required: bool = False
-    run_on_cpu: bool = True
-    run_on_cuda: bool = True
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         compiler=["stable_fast", "torch_compile"],

--- a/src/pruna/algorithms/caching/pab.py
+++ b/src/pruna/algorithms/caching/pab.py
@@ -40,14 +40,16 @@ class PABCacher(PrunaCacher):
     reduces the number of tunable parameters by setting pipeline specific parameters according to https://github.com/huggingface/diffusers/pull/9562.
     """
 
-    algorithm_name = "pab"
-    references = {"Paper": "https://arxiv.org/abs/2408.12588", "HuggingFace": "https://huggingface.co/docs/diffusers/main/api/cache#pyramid-attention-broadcast"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    compatible_algorithms = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
+    algorithm_name: str = "pab"
+    references: dict[str, str] = {
+        "Paper": "https://arxiv.org/abs/2408.12588",
+        "HuggingFace": "https://huggingface.co/docs/diffusers/main/api/cache#pyramid-attention-broadcast",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["hqq_diffusers", "diffusers_int8"])
 
     def get_hyperparameters(self) -> list:
         """
@@ -90,7 +92,7 @@ class PABCacher(PrunaCacher):
             is_flux_pipeline,
             is_hunyuan_pipeline,
             is_mochi_pipeline,
-            is_wan_pipeline
+            is_wan_pipeline,
         ]
         return any(is_pipeline(model) for is_pipeline in pipeline_check_fns)
 
@@ -117,9 +119,15 @@ class PABCacher(PrunaCacher):
         spatial_attention_timestep_skip_range: Tuple[int, int] = (100, 800)
         temporal_attention_timestep_skip_range: Tuple[int, int] = (100, 800)
         cross_attention_timestep_skip_range: Tuple[int, int] = (100, 800)
-        spatial_attention_block_identifiers: Tuple[str, ...] = ("blocks", "transformer_blocks",)
+        spatial_attention_block_identifiers: Tuple[str, ...] = (
+            "blocks",
+            "transformer_blocks",
+        )
         temporal_attention_block_identifiers: Tuple[str, ...] = ("temporal_transformer_blocks",)
-        cross_attention_block_identifiers: Tuple[str, ...] = ("blocks", "transformer_blocks",)
+        cross_attention_block_identifiers: Tuple[str, ...] = (
+            "blocks",
+            "transformer_blocks",
+        )
 
         # set configs according to https://github.com/huggingface/diffusers/pull/9562
         if is_allegro_pipeline(model):
@@ -130,9 +138,15 @@ class PABCacher(PrunaCacher):
             spatial_attention_block_identifiers = ("transformer_blocks",)
         elif is_flux_pipeline(model):
             spatial_attention_timestep_skip_range = (100, 950)
-            spatial_attention_block_identifiers = ("transformer_blocks", "single_transformer_blocks",)
+            spatial_attention_block_identifiers = (
+                "transformer_blocks",
+                "single_transformer_blocks",
+            )
         elif is_hunyuan_pipeline(model):
-            spatial_attention_block_identifiers = ("transformer_blocks", "single_transformer_blocks",)
+            spatial_attention_block_identifiers = (
+                "transformer_blocks",
+                "single_transformer_blocks",
+            )
         elif is_latte_pipeline(model):
             temporal_attention_block_skip_range = None
             cross_attention_block_skip_range = None
@@ -155,7 +169,7 @@ class PABCacher(PrunaCacher):
             spatial_attention_block_identifiers=spatial_attention_block_identifiers,
             temporal_attention_block_identifiers=temporal_attention_block_identifiers,
             cross_attention_block_identifiers=cross_attention_block_identifiers,
-            current_timestep_callback=lambda: model.current_timestep
+            current_timestep_callback=lambda: model.current_timestep,
         )
         model.transformer.enable_cache(pab_config)
         return model

--- a/src/pruna/algorithms/compilation/c_translate.py
+++ b/src/pruna/algorithms/compilation/c_translate.py
@@ -57,8 +57,7 @@ class CTranslateCompiler(PrunaCompiler):
     references = {"GitHub": "https://github.com/OpenNMT/CTranslate2"}
     tokenizer_required: bool = True
     processor_required: bool = False
-    run_on_cpu: bool = False
-    run_on_cuda: bool = True
+    runs_on: list[str] = ["cuda"]
     dataset_required: bool = False
     compatible_algorithms = dict(batcher=["whisper_s2t"], quantizer=["half"])
 

--- a/src/pruna/algorithms/compilation/stable_fast.py
+++ b/src/pruna/algorithms/compilation/stable_fast.py
@@ -28,15 +28,14 @@ class StableFastCompiler(PrunaCompiler):
     into optimized kernels and converting diffusion pipelines into efficient TorchScript graphs.
     """
 
-    algorithm_name = "stable_fast"
-    references = {"GitHub": "https://github.com/chengzeyi/stable-fast"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(cacher=["deepcache", "fora"], quantizer=["half"])
-    required_install = "``pip install pruna[stable-fast]``"
+    algorithm_name: str = "stable_fast"
+    references: dict[str, str] = {"GitHub": "https://github.com/chengzeyi/stable-fast"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(cacher=["deepcache", "fora"], quantizer=["half"])
+    required_install: str = "``pip install pruna[stable-fast]``"
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -42,16 +42,15 @@ class TorchCompileCompiler(PrunaCompiler):
     Optimizes given model or function using various backends and is compatible with any model containing PyTorch modules.
     """
 
-    algorithm_name = "torch_compile"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    algorithm_name: str = "torch_compile"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
-        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq"],
         cacher=["deepcache", "fora"],
     )
 

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -46,7 +46,7 @@ class TorchCompileCompiler(PrunaCompiler):
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -50,7 +50,7 @@ class TorchCompileCompiler(PrunaCompiler):
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         factorizer=["qkv_diffusers"],
-        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq"],
+        quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
         cacher=["deepcache", "fora"],
     )
 

--- a/src/pruna/algorithms/factorizing/qkv_diffusers.py
+++ b/src/pruna/algorithms/factorizing/qkv_diffusers.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from pruna.algorithms.factorizing import PrunaFactorizer
 from pruna.config.smash_config import SmashConfigPrefixWrapper
@@ -29,18 +29,17 @@ class QKVDiffusers(PrunaFactorizer):
     all at once: the matrix multiplication involve a larger matrix but we compute one operation instead of three.
     """
 
-    algorithm_name = "qkv_diffusers"
-    references = {
+    algorithm_name: str = "qkv_diffusers"
+    references: dict[str, str] = {
         "BFL": "https://github.com/black-forest-labs/flux/",
         "Github": "https://github.com/huggingface/diffusers/pull/9185",
     }
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         quantizer=["diffusers_int8", "hqq_diffusers", "quanto", "torchao"],
         cacher=["deepcache", "fora"],
         compiler=["torch_compile"],

--- a/src/pruna/algorithms/pruna_base.py
+++ b/src/pruna/algorithms/pruna_base.py
@@ -18,7 +18,7 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Dict
 
-from pruna.config.smash_config import SmashConfig, SmashConfigPrefixWrapper
+from pruna.config.smash_config import SUPPORTED_DEVICES, SmashConfig, SmashConfigPrefixWrapper
 from pruna.config.smash_space import SMASH_SPACE
 from pruna.engine.save import (
     SAVE_BEFORE_SMASH_CACHE_DIR,
@@ -50,17 +50,12 @@ class PrunaAlgorithmBase(ABC):
             processor_required=self.processor_required,
         )
 
+        assert all(device in SUPPORTED_DEVICES for device in self.compatible_devices())
+
     @classmethod
     def compatible_devices(cls) -> list[str]:
         """Return the compatible devices for the algorithm."""
-        compatible_devices = []
-        if cls.run_on_cpu:  # type: ignore
-            compatible_devices.append("cpu")
-        if cls.run_on_cuda:  # type: ignore
-            compatible_devices.append("cuda")
-        if not compatible_devices:
-            raise ValueError(f"Algorithm {cls.algorithm_name} is not compatible with any device.")
-        return compatible_devices
+        return cls.runs_on
 
     @property
     @abstractmethod
@@ -81,14 +76,8 @@ class PrunaAlgorithmBase(ABC):
 
     @property
     @abstractmethod
-    def run_on_cpu(self) -> bool:
-        """Subclasses need to provide a boolean indicating if the algorithm can be applied on cpu."""
-        pass
-
-    @property
-    @abstractmethod
-    def run_on_cuda(self) -> bool:
-        """Subclasses need to provide a boolean indicating if the algorithm can be applied on cuda."""
+    def runs_on(self) -> list[str]:
+        """Subclasses need to provide a list of devices the algorithm can be applied on."""
         pass
 
     @property

--- a/src/pruna/algorithms/pruning/torch_structured.py
+++ b/src/pruna/algorithms/pruning/torch_structured.py
@@ -49,16 +49,15 @@ class TorchStructuredPruner(PrunaPruner):
     and computationally efficient model while preserving a regular structure that standard hardware can easily optimize.
     """
 
-    algorithm_name = "torch_structured"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "torch_structured"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # when performing structured pruning, the tensor sizes can change and disrupt normal saving
     save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict(quantizer=["half"])
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/pruning/torch_unstructured.py
+++ b/src/pruna/algorithms/pruning/torch_unstructured.py
@@ -36,7 +36,7 @@ class TorchUnstructuredPruner(PrunaPruner):
     save_fn = None
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 

--- a/src/pruna/algorithms/pruning/torch_unstructured.py
+++ b/src/pruna/algorithms/pruning/torch_unstructured.py
@@ -30,16 +30,15 @@ class TorchUnstructuredPruner(PrunaPruner):
     exploit the efficiency gains.
     """
 
-    algorithm_name = "torch_unstructured"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "torch_unstructured"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # original model-saving can be retained as is, only parameter values are modified
     save_fn = None
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(quantizer=["half"])
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(quantizer=["half"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/gptq_model.py
+++ b/src/pruna/algorithms/quantization/gptq_model.py
@@ -35,15 +35,14 @@ class GPTQQuantizer(PrunaQuantizer):
     advantage of the lower precision.
     """
 
-    algorithm_name = "gptq"
-    references = {"GitHub": "https://github.com/ModelCloud/GPTQModel"}
-    tokenizer_required = True
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict(compiler=["torch_compile"])
-    required_install = (
+    algorithm_name: str = "gptq"
+    references: dict[str, str] = {"GitHub": "https://github.com/ModelCloud/GPTQModel"}
+    tokenizer_required: bool = True
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
+    required_install: str = (
         "You must first install the base package with ``pip install pruna`` "
         "before installing the GPTQ extension with ``pip install pruna[gptq]``"
     )
@@ -142,6 +141,9 @@ class GPTQQuantizer(PrunaQuantizer):
         Dict[str, Any]
             The algorithm packages.
         """
-        from gptqmodel import GPTQModel, QuantizeConfig
+        try:
+            from gptqmodel import GPTQModel, QuantizeConfig
+        except ImportError:
+            raise ImportError(f"gptqmodel is not installed. Please install it using {self.required_install}.")
 
         return dict(GPTQModel=GPTQModel, QuantizeConfig=QuantizeConfig)

--- a/src/pruna/algorithms/quantization/half.py
+++ b/src/pruna/algorithms/quantization/half.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 
@@ -29,16 +29,15 @@ class HalfQuantizer(PrunaQuantizer):
     that support it.
     """
 
-    algorithm_name = "half"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
+    algorithm_name: str = "half"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
     # the half-helper is not saved with the model but is fast to reattach
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         batcher=["ifw", "whisper_s2t"],
         cacher=["deepcache"],
         compiler=[

--- a/src/pruna/algorithms/quantization/half.py
+++ b/src/pruna/algorithms/quantization/half.py
@@ -35,7 +35,7 @@ class HalfQuantizer(PrunaQuantizer):
     save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict(
         batcher=["ifw", "whisper_s2t"],

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -14,7 +14,7 @@
 
 import shutil
 import tempfile
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
@@ -37,15 +37,17 @@ class HQQQuantizer(PrunaQuantizer):
     eliminating the need for calibration data.
     """
 
-    algorithm_name = "hqq"
-    references = {"GitHub": "https://github.com/mobiusml/hqq", "Article": "https://mobiusml.github.io/hqq_blog/"}
-    save_fn = SAVE_FUNCTIONS.hqq
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(compiler=["torch_compile"])
+    algorithm_name: str = "hqq"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/mobiusml/hqq",
+        "Article": "https://mobiusml.github.io/hqq_blog/",
+    }
+    save_fn: Callable = SAVE_FUNCTIONS.hqq
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/hqq_diffusers.py
+++ b/src/pruna/algorithms/quantization/hqq_diffusers.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, Type
+from typing import Any, Callable, Dict, Type
 
 import torch
 from ConfigSpace import OrdinalHyperparameter
@@ -38,18 +38,18 @@ class HQQDiffusersQuantizer(PrunaQuantizer):
     adapted for diffusers models.
     """
 
-    algorithm_name = "hqq_diffusers"
-    references = {"GitHub": "https://github.com/mobiusml/hqq", "Article": "https://mobiusml.github.io/hqq_blog/"}
-    save_fn = SAVE_FUNCTIONS.hqq_diffusers
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache", "fastercache", "fora", "pab"],
-        compiler=["torch_compile"],
+    algorithm_name: str = "hqq_diffusers"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/mobiusml/hqq",
+        "Article": "https://mobiusml.github.io/hqq_blog/",
+    }
+    save_fn: Callable = SAVE_FUNCTIONS.hqq_diffusers
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
+        factorizer=["qkv_diffusers"], cacher=["deepcache", "fastercache", "fora", "pab"], compiler=["torch_compile"]
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/quantization/huggingface_awq.py
+++ b/src/pruna/algorithms/quantization/huggingface_awq.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import tempfile
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from ConfigSpace import Constant, OrdinalHyperparameter
 
@@ -34,16 +34,15 @@ class AWQQuantizer(PrunaQuantizer):
     allowing models to operate at 4-bit precision without significantly sacrificing accuracy.
     """
 
-    algorithm_name = "awq"
-    references = {"GitHub": "https://github.com/casper-hansen/AutoAWQ"}
-    save_fn = SAVE_FUNCTIONS.awq_quantized
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict()
-    required_install = "``pip install pruna[autoawq]``"
+    algorithm_name: str = "awq"
+    references: dict[str, str] = {"GitHub": "https://github.com/casper-hansen/AutoAWQ"}
+    save_fn: Callable = SAVE_FUNCTIONS.awq_quantized
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict()
+    required_install: str = "``pip install pruna[autoawq]``"
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_diffusers_int8.py
@@ -39,17 +39,14 @@ class DiffusersInt8Quantizer(PrunaQuantizer):
     This algorithm is specifically adapted for diffusers models.
     """
 
-    algorithm_name = "diffusers_int8"
-    references = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache", "fastercache", "fora", "pab"],
-        compiler=["torch_compile"],
+    algorithm_name: str = "diffusers_int8"
+    references: dict[str, str] = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda", "accelerate"]
+    compatible_algorithms: dict[str, list[str]] = dict(
+        factorizer=["qkv_diffusers"], cacher=["deepcache", "fastercache", "fora", "pab"], compiler=["torch_compile"]
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/quantization/huggingface_llm_int8.py
+++ b/src/pruna/algorithms/quantization/huggingface_llm_int8.py
@@ -35,14 +35,13 @@ class LLMInt8Quantizer(PrunaQuantizer):
     while 4-bit quantization further compresses the model and is often used with QLoRA for fine-tuning.
     """
 
-    algorithm_name = "llm_int8"
-    references = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict(compiler=["torch_compile"])
+    algorithm_name: str = "llm_int8"
+    references: dict[str, str] = {"GitHub": "https://github.com/bitsandbytes-foundation/bitsandbytes"}
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda", "accelerate"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -129,7 +129,7 @@ class QuantoQuantizer(PrunaQuantizer):
                         calibrate(
                             working_model,
                             smash_config.val_dataloader(),
-                            smash_config["device"],
+                            model.device,  # only e.g. CUDA here is not enough, we need also the correct device index
                             batch_size=smash_config.batch_size,
                             samples=smash_config["calibration_samples"],
                         )

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import Constant, OrdinalHyperparameter
@@ -35,18 +35,14 @@ class QuantoQuantizer(PrunaQuantizer):
     and device memory usage is roughly reduced in proportion to the bitwidth ratio.
     """
 
-    algorithm_name = "quanto"
-    references = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
-    save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    dataset_required = False
-    run_on_cpu = False
-    run_on_cuda = True
-    compatible_algorithms = dict(
-        factorizer=["qkv_diffusers"],
-        cacher=["deepcache"],
-    )
+    algorithm_name: str = "quanto"
+    references: dict[str, str] = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
+    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    dataset_required: bool = False
+    runs_on: list[str] = ["cuda"]
+    compatible_algorithms: dict[str, list[str]] = dict(factorizer=["qkv_diffusers"], cacher=["deepcache"])
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/torch_dynamic.py
+++ b/src/pruna/algorithms/quantization/torch_dynamic.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import inspect
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import OrdinalHyperparameter
@@ -33,14 +33,13 @@ class TorchDynamicQuantizer(PrunaQuantizer):
     """
 
     algorithm_name = "torch_dynamic"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = False
-    compatible_algorithms = dict()
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
+    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict()
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/torch_dynamic.py
+++ b/src/pruna/algorithms/quantization/torch_dynamic.py
@@ -37,7 +37,7 @@ class TorchDynamicQuantizer(PrunaQuantizer):
     save_fn: Callable = SAVE_FUNCTIONS.pickled
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = False
     compatible_algorithms: dict[str, list[str]] = dict()
 

--- a/src/pruna/algorithms/quantization/torch_static.py
+++ b/src/pruna/algorithms/quantization/torch_static.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
@@ -32,15 +32,14 @@ class TorchStaticQuantizer(PrunaQuantizer):
     requires additional steps during model preparation.
     """
 
-    algorithm_name = "torch_static"
-    references = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn = SAVE_FUNCTIONS.pickled
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu = True
-    run_on_cuda = True
-    dataset_required = True
-    compatible_algorithms = dict()
+    algorithm_name: str = "torch_static"
+    references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
+    save_fn: Callable = SAVE_FUNCTIONS.pickled
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    dataset_required: bool = True
+    compatible_algorithms: dict[str, list[str]] = dict()
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/quantization/torch_static.py
+++ b/src/pruna/algorithms/quantization/torch_static.py
@@ -37,7 +37,7 @@ class TorchStaticQuantizer(PrunaQuantizer):
     save_fn: Callable = SAVE_FUNCTIONS.pickled
     tokenizer_required: bool = False
     processor_required: bool = False
-    runs_on: list[str] = ["cpu", "cuda", "mps"]
+    runs_on: list[str] = ["cpu", "cuda"]
     dataset_required: bool = True
     compatible_algorithms: dict[str, list[str]] = dict()
 

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import importlib
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 import torch
 
@@ -73,15 +73,14 @@ class TorchaoQuantizer(PrunaQuantizer):
     full-precision model.
     """
 
-    algorithm_name = "torchao"
-    references = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
-    save_fn = SAVE_FUNCTIONS.save_before_apply
-    tokenizer_required = False
-    processor_required = False
-    run_on_cpu: bool = True
-    run_on_cuda: bool = True
-    dataset_required = False
-    compatible_algorithms = dict(
+    algorithm_name: str = "torchao"
+    references: dict[str, str] = {"GitHub": "https://huggingface.co/docs/diffusers/quantization/torchao"}
+    save_fn: Callable = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cpu", "cuda"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(
         cacher=["fora"],
         compiler=["torch_compile"],
         factorizer=["qkv_diffusers"],

--- a/src/pruna/config/compatibility_checks.py
+++ b/src/pruna/config/compatibility_checks.py
@@ -110,6 +110,11 @@ def check_model_compatibility(
                 raise ValueError(
                     f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
                 )
+            if get_device(model) not in algorithm_dict[current_group][algorithm].runs_on:
+                raise ValueError(
+                    f"{algorithm} is not compatible with device {get_device(model)}, "
+                    f"compatible devices are {algorithm_dict[current_group][algorithm].runs_on}"
+                )
 
 
 def check_argument_compatibility(smash_config: SmashConfig, algorithm_name: str) -> None:

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -48,6 +48,7 @@ ADDITIONAL_ARGS = [
 TOKENIZER_SAVE_PATH = "tokenizer/"
 PROCESSOR_SAVE_PATH = "processor/"
 SMASH_CONFIG_FILE_NAME = "smash_config.json"
+SUPPORTED_DEVICES = ["cpu", "cuda", "mps", "accelerate"]
 
 
 class SmashConfig:
@@ -61,7 +62,7 @@ class SmashConfig:
     batch_size : int, optional
         The number of batches to process at once. Default is 1.
     device : str | torch.device | None, optional
-        The device to be used for smashing, e.g., 'cuda' or 'cpu'. Default is None.
+        The device to be used for smashing, options are "cpu", "cuda", "mps", "accelerate". Default is None.
         If None, the best available device will be used.
     cache_dir_prefix : str, optional
         The prefix for the cache directory. If None, a default cache directory will be created.
@@ -92,6 +93,8 @@ class SmashConfig:
         else:
             self.batch_size = batch_size
         self.device = check_device_compatibility(device)
+        if self.device not in SUPPORTED_DEVICES:
+            raise ValueError(f"Device '{self.device}' not supported. Supported devices are: {SUPPORTED_DEVICES}")
         self.device_map = None
 
         self.cache_dir_prefix = cache_dir_prefix

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -76,7 +76,10 @@ def load_pruna_model(model_path: str, **kwargs) -> tuple[Any, SmashConfig]:
     model = LOAD_FUNCTIONS[smash_config.load_fns[0]](model_path, **kwargs)
 
     if "device_map" not in kwargs and "device" not in kwargs:
-        move_to_device(model, smash_config.device)
+        try:
+            move_to_device(model, smash_config.device, device_map=smash_config.device_map)
+        except Exception as e:
+            pruna_logger.error(f"Error moving model to device: {e}")
 
     # check if there are any algorithms to reapply
     if any(algorithm is not None for algorithm in smash_config.reapply_after_load.values()):

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -118,20 +118,6 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
-    def __delattr__(self, attr: str) -> None:
-        """
-        Delete an attribute from the model.
-
-        Parameters
-        ----------
-        attr : str
-            The name of the attribute to delete.
-        """
-        if self.model is None:
-            raise ValueError("No more model available, this model is likely destroyed.")
-        else:
-            delattr(self.model, attr)
-
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -118,6 +118,20 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
+    def __delattr__(self, attr: str) -> None:
+        """
+        Delete an attribute from the model.
+
+        Parameters
+        ----------
+        attr : str
+            The name of the attribute to delete.
+        """
+        if self.model is None:
+            raise ValueError("No more model available, this model is likely destroyed.")
+        else:
+            delattr(self.model, attr)
+
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -118,6 +118,20 @@ class PrunaModel:
         else:
             return getattr(self.model, attr)
 
+    def __delattr__(self, attr: str) -> None:
+        """
+        Delete an attribute from the model.
+
+        Parameters
+        ----------
+        attr : str
+            The attribute to delete.
+        """
+        if self.model is None:
+            raise ValueError("No more model available, this model is likely destroyed.")
+        else:
+            delattr(self.model, attr)
+
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -99,6 +99,21 @@ class PrunaModel:
         outputs = self.inference_handler.process_output(outputs)
         return outputs
 
+    def compare_model_isinstance(self, instance_type: type) -> bool:
+        """
+        Compare the model to the given instance type.
+
+        Parameters
+        ----------
+        instance_type : type
+            The type to compare the model to.
+
+        Returns
+        -------
+        bool
+        """
+        return isinstance(self.model, instance_type)
+
     def __getattr__(self, attr: str) -> Any:
         """
         Forward attribute access to the underlying model.

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -165,10 +165,9 @@ def remove_all_accelerate_hooks(model: Any) -> None:
             else:
                 raise e
 
-    # avoid circular import
-    from pruna.engine.pruna_model import PrunaModel
-
-    if isinstance(model, (torch.nn.Module, PrunaModel)):
+    if isinstance(model, torch.nn.Module) or (
+        hasattr(model, "compare_model_isinstance") and model.compare_model_isinstance(torch.nn.Module)
+    ):
         # transformers models are all torch.nn.Module, which is what the hook removal expects
         remove_hook_from_module(model, recurse=True)
     else:

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -12,7 +12,14 @@ from ..common import (
 from . import testers
 
 
-@device_parametrized
+@pytest.mark.parametrize(
+    "device",
+    [
+        pytest.param("cuda", marks=pytest.mark.cuda),
+            pytest.param("accelerate", marks=pytest.mark.cuda),
+            pytest.param("cpu", marks=pytest.mark.cpu),
+        ],
+    )
 @pytest.mark.parametrize(
     "algorithm_tester, model_fixture",
     get_instances_from_module(testers),

--- a/tests/algorithms/test_algorithms.py
+++ b/tests/algorithms/test_algorithms.py
@@ -12,14 +12,7 @@ from ..common import (
 from . import testers
 
 
-@pytest.mark.parametrize(
-    "device",
-    [
-        pytest.param("cuda", marks=pytest.mark.cuda),
-            pytest.param("accelerate", marks=pytest.mark.cuda),
-            pytest.param("cpu", marks=pytest.mark.cpu),
-        ],
-    )
+@device_parametrized
 @pytest.mark.parametrize(
     "algorithm_tester, model_fixture",
     get_instances_from_module(testers),

--- a/tests/algorithms/testers/base_tester.py
+++ b/tests/algorithms/testers/base_tester.py
@@ -38,11 +38,6 @@ class AlgorithmTesterBase:
         pass
 
     @classmethod
-    def cast_to_device(cls, model: Any, device: str = "cpu") -> Any:
-        """Cast the model to the given device."""
-        move_to_device(model, device)
-
-    @classmethod
     def final_teardown(cls, smash_config: SmashConfig) -> None:
         """Teardown the test, remove the saved model and clean up the files in any case."""
         # reset this smash config cache dir, this should not be shared across runs

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -48,7 +48,7 @@ class TestQuanto(AlgorithmTesterBase):
 class TestLLMint8(AlgorithmTesterBase):
     """Test the LLMint8 quantizer."""
 
-    models = ["opt_tiny_random"]
+    models = ["opt_125m"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = LLMInt8Quantizer

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -70,10 +70,9 @@ def stable_diffusion_v1_4_model() -> tuple[Any, SmashConfig]:
 def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
     """Whisper tiny random model for speech recognition."""
     source_model_id = "openai/whisper-tiny"
-    model_id = "yujiepan/whisper-v3-tiny-random"
     model = pipeline(
         "automatic-speech-recognition",
-        model=model_id,
+        model=source_model_id,
         chunk_length_s=30,
         torch_dtype=torch.float16,
         device_map="balanced",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -93,7 +93,8 @@ def dummy_model() -> tuple[Any, SmashConfig]:
 
 def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get a diffusers model for image generation."""
-    model = cls.from_pretrained(model_id, device_map="balanced", **kwargs)
+    # load in distributed mode, if not intended by test this will be cast down to CPU/CUDA
+    model = cls.from_pretrained(model_id, **kwargs, device_map="balanced")
     smash_config = SmashConfig()
     smash_config.add_data("LAION256")
     return model, smash_config

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -100,9 +100,9 @@ def get_diffusers_model(cls: type[Any], model_id: str, **kwargs: dict[str, Any])
     return model, smash_config
 
 
-def get_automodel_transformers(model_id: str) -> tuple[Any, SmashConfig]:
+def get_automodel_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
-    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced")
+    model = AutoModelForCausalLM.from_pretrained(model_id, device_map="balanced", **kwargs)
     smash_config = SmashConfig()
     try:
         smash_config.add_tokenizer(model_id)


### PR DESCRIPTION
## Description
Following up on #128 this PR extends the algorithms in `pruna` with specifications on whether distributed base models are supported or not. As a consequence of this the following adjustments have been made:
- updating the Pruna base class
- updating the documentation generation
- additionally to the device consistency checks (model == smashconfig) we now also give guidance on whether an algorithm is applicable to a model in a certain device state
- extend the tests with checks on the model device state.

## Related Issue
Closes #147 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Ran all algorithm tests locally, only known failures occured.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Additionally to this PR and #128 there will be one more PR tackling the saving and loading for models in a distributed state.
