### PR TITLE
fix: fix fp8dqrow setting

### DIFF
--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -267,6 +267,10 @@ class TorchaoQuantizer(PrunaQuantizer):
             int8wo=int8_weight_only(),
             fp8wo=float8_weight_only(),
             fp8dq=float8_dynamic_activation_float8_weight(),
-            fp8dqrow=float8_dynamic_activation_float8_weight(PerRow()),
+            fp8dqrow=float8_dynamic_activation_float8_weight(
+                activation_dtype=torch.float8_e4m3fn,
+                weight_dtype=torch.float8_e4m3fn,
+                granularity=PerRow(),
+            ),
             _is_linear=_is_linear,
         )


### PR DESCRIPTION
## Description
The quant type "fp8dqrow" was not working. This fix makes this option work for GPUs with CUDA Compute Capability >= 8.9 (e.g., L40S, H100). 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Run the algorithms with quant type "fp8dqrow" and "int8dq". Tested the combination with torch.compile and without it. 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
