### PR TITLE
docs: fix note on algorithm argument checking

### DIFF
--- a/docs/user_manual/configure.rst
+++ b/docs/user_manual/configure.rst
@@ -187,12 +187,11 @@ For example, looking at the :doc:`Algorithm Overview </compression>` we see that
      - ``add_processor()``
    * - ``data``
      - Loads a dataset.
-     - ``add_dataset()``
+     - ``add_data()``
 
 .. note::
 
-  If you try to activate a algorithm that requires a dataset, tokenizer or processor and haven’t added them to the ``SmashConfig``, you will receive an error.
-  Make sure to add them before activating the algorithm! If you want to know which algorithms require a dataset, tokenizer or processor, you can look at the :doc:`Algorithm Overview </compression>`.
+  If you try to add a text dataset, you will have to specify a tokenizer first.
 
 Configure Tokenizers, Processors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
This PR fixes a "tip" in the `SmashConfig` documentation, of which the behavior has recently changed. Before, you would have to specify a tokenizer first to activate an algorithm that requires one. Now, the order does not matter as the `SmashConfig` state is checked before the smash process begins.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
None.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
