### PR TITLE
fix: add size check when limiting the dataset

### DIFF
--- a/src/pruna/data/pruna_datamodule.py
+++ b/src/pruna/data/pruna_datamodule.py
@@ -189,13 +189,16 @@ class PrunaDataModule(LightningDataModule):
             train_limit, val_limit, test_limit = limit
 
         if isinstance(self.train_dataset, Dataset):
-            self.train_dataset = self.train_dataset.select(range(train_limit))
-            self.val_dataset = self.val_dataset.select(range(val_limit))  # type: ignore[union-attr]
-            self.test_dataset = self.test_dataset.select(range(test_limit))  # type: ignore[union-attr]
+            self.train_dataset = self.train_dataset.select(range(min(len(self.train_dataset), train_limit)))
+            self.val_dataset = self.val_dataset.select(range(min(len(self.val_dataset), val_limit)))  # type: ignore[union-attr]
+            self.test_dataset = self.test_dataset.select(range(min(len(self.test_dataset), test_limit)))  # type: ignore[union-attr]
         elif isinstance(self.train_dataset, IterableDataset):
-            self.train_dataset = self.train_dataset[:train_limit]
-            self.val_dataset = self.val_dataset[:val_limit]
-            self.test_dataset = self.test_dataset[:test_limit]
+            train_length = sum(1 for _ in self.train_dataset)
+            val_length = sum(1 for _ in self.val_dataset)
+            test_length = sum(1 for _ in self.test_dataset)
+            self.train_dataset = self.train_dataset[: min(train_length, train_limit)]
+            self.val_dataset = self.val_dataset[: min(val_length, val_limit)]
+            self.test_dataset = self.test_dataset[: min(test_length, test_limit)]
         elif isinstance(self.train_dataset, TorchDataset):
             train_indices = list(range(min(len(self.train_dataset), train_limit)))  # type: ignore[arg-type]
             val_indices = list(range(min(len(self.val_dataset), val_limit)))  # type: ignore[arg-type]


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
`limit_datasets` in PrunaDataModule doesn't check the size of the datasets before limiting the size, resulting in IndexErrors: 

```
E           IndexError: Index 9 out of range for dataset of size 1. 
```
## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


