### PR TITLE
fix: rewrapping pruna model bug

### DIFF
--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -346,7 +346,11 @@ class PrunaModel:
             local_dir_use_symlinks=local_dir_use_symlinks,
             resume_download=resume_download,
         )
-        return PrunaModel(model=model, smash_config=smash_config)
+        if not isinstance(model, PrunaModel):
+            model = PrunaModel(model=model, smash_config=smash_config)
+        else:
+            model.smash_config = smash_config
+        return model
 
     def destroy(self) -> None:
         """Destroy model."""


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Added a check to prevent wrapping an already existing PrunaModel, which was causing the model to be wrapped in a PrunaModel twice, and assign the wrong inference handler. 

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #172 
## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


