### PR TITLE
fix: pin hqq dependency to avoid model re-loading bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ optimum-quanto = ">=0.2.5"
 optimum = "*"
 ctranslate2 = "==4.5.0"
 whisper-s2t = "==1.3.0"
-hqq = "*"
+hqq = "<0.2.7" # pinned to 0.2.6 to avoid re-loading model bug introduced in 0.2.7
 torchao = "*"
 llmcompressor = "*"
 # Added Optional Dependencies from Extras


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
HQQ models can't be reloaded after the 0.2.7 release of HQQ, so we pinned the version for now.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Does not directly fix the issue #173 but serves as a hot fix.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
