### PR TITLE
refactor: update function signatures to accept both str and Path types

### DIFF
--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import atexit
 import json
 import os
-from pathlib import Path
 import shutil
 import tempfile
 from functools import singledispatchmethod
+from pathlib import Path
 from typing import Any, Union
 from warnings import warn
 
@@ -143,7 +143,7 @@ class SmashConfig:
         self.cleanup_cache_dir()
         self.cache_dir = tempfile.mkdtemp(dir=self.cache_dir_prefix)
 
-    def load_from_json(self, path: Union[str,Path]) -> None:
+    def load_from_json(self, path: Union[str, Path]) -> None:
         """
         Load a SmashConfig from a JSON file.
 
@@ -214,7 +214,7 @@ class SmashConfig:
         if os.path.exists(os.path.join(path, PROCESSOR_SAVE_PATH)):
             self.processor = AutoProcessor.from_pretrained(os.path.join(path, PROCESSOR_SAVE_PATH))
 
-    def save_to_json(self, path: Union[str,Path]) -> None:
+    def save_to_json(self, path: Union[str, Path]) -> None:
         """
         Save the SmashConfig to a JSON file, including additional keys.
 

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -143,13 +143,13 @@ class SmashConfig:
         self.cleanup_cache_dir()
         self.cache_dir = tempfile.mkdtemp(dir=self.cache_dir_prefix)
 
-    def load_from_json(self, path: Union[str, Path]) -> None:
+    def load_from_json(self, path: str | Path) -> None:
         """
         Load a SmashConfig from a JSON file.
 
         Parameters
         ----------
-        path : str
+        path : str| Path
             The file path to the JSON file containing the configuration.
         """
         with open(os.path.join(path, SMASH_CONFIG_FILE_NAME), "r") as f:
@@ -214,13 +214,13 @@ class SmashConfig:
         if os.path.exists(os.path.join(path, PROCESSOR_SAVE_PATH)):
             self.processor = AutoProcessor.from_pretrained(os.path.join(path, PROCESSOR_SAVE_PATH))
 
-    def save_to_json(self, path: Union[str, Path]) -> None:
+    def save_to_json(self, path: str | Path) -> None:
         """
         Save the SmashConfig to a JSON file, including additional keys.
 
         Parameters
         ----------
-        path : Union[str,Path]
+        path : str| Path]
             The file path where the JSON file will be saved.
         """
         config_dict = dict(self._configuration)

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import atexit
 import json
 import os
+from pathlib import Path
 import shutil
 import tempfile
 from functools import singledispatchmethod
@@ -142,7 +143,7 @@ class SmashConfig:
         self.cleanup_cache_dir()
         self.cache_dir = tempfile.mkdtemp(dir=self.cache_dir_prefix)
 
-    def load_from_json(self, path: str) -> None:
+    def load_from_json(self, path: Union[str,Path]) -> None:
         """
         Load a SmashConfig from a JSON file.
 
@@ -213,13 +214,13 @@ class SmashConfig:
         if os.path.exists(os.path.join(path, PROCESSOR_SAVE_PATH)):
             self.processor = AutoProcessor.from_pretrained(os.path.join(path, PROCESSOR_SAVE_PATH))
 
-    def save_to_json(self, path: str) -> None:
+    def save_to_json(self, path: Union[str,Path]) -> None:
         """
         Save the SmashConfig to a JSON file, including additional keys.
 
         Parameters
         ----------
-        path : str
+        path : Union[str,Path]
             The file path where the JSON file will be saved.
         """
         config_dict = dict(self._configuration)

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -39,13 +39,13 @@ SAVE_BEFORE_SMASH_CACHE_DIR = "save_before_smash"
 PIPELINE_INFO_FILE_NAME = "pipeline_info.json"
 
 
-def load_pruna_model(model_path: Union[str, Path], **kwargs) -> tuple[Any, SmashConfig]:
+def load_pruna_model(model_path: str | Path, **kwargs) -> tuple[Any, SmashConfig]:
     """
     Load a Pruna model from the given model path.
 
     Parameters
     ----------
-    model_path : Union[str, Path]
+    model_path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -219,13 +219,13 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(path: Union[str, Path], **kwargs) -> Any:
+def load_transformers_model(path: str | Path, **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
     Parameters
     ----------
-    path : Union[str, Path]
+    path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -253,13 +253,13 @@ def load_transformers_model(path: Union[str, Path], **kwargs) -> Any:
         return cls.from_pretrained(path, **kwargs)
 
 
-def load_diffusers_model(path: Union[str, Path], **kwargs) -> Any:
+def load_diffusers_model(path: str | Path, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : Union[str, Path]
+    path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -294,13 +294,13 @@ def load_diffusers_model(path: Union[str, Path], **kwargs) -> Any:
     return cls.from_pretrained(path, **kwargs)
 
 
-def load_pickled(path: Union[str, Path], **kwargs) -> Any:
+def load_pickled(path: str | Path, **kwargs) -> Any:
     """
     Load a pickled model from the given model path.
 
     Parameters
     ----------
-    path : Union[str, Path]
+    path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -315,13 +315,13 @@ def load_pickled(path: Union[str, Path], **kwargs) -> Any:
     )
 
 
-def load_hqq(model_path: Union[str, Path], **kwargs) -> Any:
+def load_hqq(model_path: str | Path, **kwargs) -> Any:
     """
     Load a model quantized with HQQ from the given model path.
 
     Parameters
     ----------
-    model_path : Union[str, Path]
+    model_path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -348,13 +348,13 @@ def load_hqq(model_path: Union[str, Path], **kwargs) -> Any:
     return model
 
 
-def load_torch_artifacts(model_path: Union[str, Path], **kwargs) -> None:
+def load_torch_artifacts(model_path: str | Path, **kwargs) -> None:
     """
     Load a torch artifacts from the given model path.
 
     Parameters
     ----------
-    model_path : str
+    model_path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -365,13 +365,13 @@ def load_torch_artifacts(model_path: Union[str, Path], **kwargs) -> None:
     torch.compiler.load_cache_artifacts(artifact_bytes)
 
 
-def load_hqq_diffusers(path: Union[str, Path], **kwargs) -> Any:
+def load_hqq_diffusers(path: str | Path, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : Union[str, Path]
+    path : str | Path
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -39,13 +39,13 @@ SAVE_BEFORE_SMASH_CACHE_DIR = "save_before_smash"
 PIPELINE_INFO_FILE_NAME = "pipeline_info.json"
 
 
-def load_pruna_model(model_path: str, **kwargs) -> tuple[Any, SmashConfig]:
+def load_pruna_model(model_path: Union[str,Path], **kwargs) -> tuple[Any, SmashConfig]:
     """
     Load a Pruna model from the given model path.
 
     Parameters
     ----------
-    model_path : str
+    model_path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -219,13 +219,13 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(path: str, **kwargs) -> Any:
+def load_transformers_model(path: Union[str,Path], **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
     Parameters
     ----------
-    path : str
+    path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -253,13 +253,13 @@ def load_transformers_model(path: str, **kwargs) -> Any:
         return cls.from_pretrained(path, **kwargs)
 
 
-def load_diffusers_model(path: str, **kwargs) -> Any:
+def load_diffusers_model(path: Union[str,Path], **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : str
+    path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -294,13 +294,13 @@ def load_diffusers_model(path: str, **kwargs) -> Any:
     return cls.from_pretrained(path, **kwargs)
 
 
-def load_pickled(path: str, **kwargs) -> Any:
+def load_pickled(path: Union[str,Path], **kwargs) -> Any:
     """
     Load a pickled model from the given model path.
 
     Parameters
     ----------
-    path : str
+    path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -315,13 +315,13 @@ def load_pickled(path: str, **kwargs) -> Any:
     )
 
 
-def load_hqq(model_path: str, **kwargs) -> Any:
+def load_hqq(model_path: Union[str,Path], **kwargs) -> Any:
     """
     Load a model quantized with HQQ from the given model path.
 
     Parameters
     ----------
-    model_path : str
+    model_path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -348,7 +348,7 @@ def load_hqq(model_path: str, **kwargs) -> Any:
     return model
 
 
-def load_torch_artifacts(model_path: str, **kwargs) -> None:
+def load_torch_artifacts(model_path: Union[str,Path], **kwargs) -> None:
     """
     Load a torch artifacts from the given model path.
 
@@ -365,13 +365,13 @@ def load_torch_artifacts(model_path: str, **kwargs) -> None:
     torch.compiler.load_cache_artifacts(artifact_bytes)
 
 
-def load_hqq_diffusers(path: str, **kwargs) -> Any:
+def load_hqq_diffusers(path: Union[str,Path], **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : str
+    path : Union[str,Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -243,7 +243,7 @@ def load_transformers_model(path: str | Path, **kwargs) -> Any:
         with open(os.path.join(path, PIPELINE_INFO_FILE_NAME), "r") as f:
             pipeline_info = json.load(f)
         # transformers discards kwargs automatically, no need for filtering
-        return pipeline(pipeline_info["task"], path, **kwargs)
+        return pipeline(pipeline_info["task"], str(path), **kwargs)
     else:
         with open(os.path.join(path, "config.json"), "r") as f:
             config = json.load(f)

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -39,13 +39,13 @@ SAVE_BEFORE_SMASH_CACHE_DIR = "save_before_smash"
 PIPELINE_INFO_FILE_NAME = "pipeline_info.json"
 
 
-def load_pruna_model(model_path: Union[str,Path], **kwargs) -> tuple[Any, SmashConfig]:
+def load_pruna_model(model_path: Union[str, Path], **kwargs) -> tuple[Any, SmashConfig]:
     """
     Load a Pruna model from the given model path.
 
     Parameters
     ----------
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -219,13 +219,13 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(path: Union[str,Path], **kwargs) -> Any:
+def load_transformers_model(path: Union[str, Path], **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
     Parameters
     ----------
-    path : Union[str,Path]
+    path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -253,13 +253,13 @@ def load_transformers_model(path: Union[str,Path], **kwargs) -> Any:
         return cls.from_pretrained(path, **kwargs)
 
 
-def load_diffusers_model(path: Union[str,Path], **kwargs) -> Any:
+def load_diffusers_model(path: Union[str, Path], **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : Union[str,Path]
+    path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -294,13 +294,13 @@ def load_diffusers_model(path: Union[str,Path], **kwargs) -> Any:
     return cls.from_pretrained(path, **kwargs)
 
 
-def load_pickled(path: Union[str,Path], **kwargs) -> Any:
+def load_pickled(path: Union[str, Path], **kwargs) -> Any:
     """
     Load a pickled model from the given model path.
 
     Parameters
     ----------
-    path : Union[str,Path]
+    path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -315,13 +315,13 @@ def load_pickled(path: Union[str,Path], **kwargs) -> Any:
     )
 
 
-def load_hqq(model_path: Union[str,Path], **kwargs) -> Any:
+def load_hqq(model_path: Union[str, Path], **kwargs) -> Any:
     """
     Load a model quantized with HQQ from the given model path.
 
     Parameters
     ----------
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.
@@ -348,7 +348,7 @@ def load_hqq(model_path: Union[str,Path], **kwargs) -> Any:
     return model
 
 
-def load_torch_artifacts(model_path: Union[str,Path], **kwargs) -> None:
+def load_torch_artifacts(model_path: Union[str, Path], **kwargs) -> None:
     """
     Load a torch artifacts from the given model path.
 
@@ -365,13 +365,13 @@ def load_torch_artifacts(model_path: Union[str,Path], **kwargs) -> None:
     torch.compiler.load_cache_artifacts(artifact_bytes)
 
 
-def load_hqq_diffusers(path: Union[str,Path], **kwargs) -> Any:
+def load_hqq_diffusers(path: Union[str, Path], **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
     Parameters
     ----------
-    path : Union[str,Path]
+    path : Union[str, Path]
         The path to the model directory.
     **kwargs : Any
         Additional keyword arguments to pass to the model loading function.

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -253,7 +253,7 @@ def load_transformers_model(path: str | Path, smash_config: SmashConfig, **kwarg
         return cls.from_pretrained(path, device_map=device_map, **kwargs)
 
 
-def load_diffusers_model(path: path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
+def load_diffusers_model(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
@@ -330,7 +330,7 @@ def load_pickled(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
     return model
 
 
-def load_hqq(model_path: path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
+def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a model quantized with HQQ from the given model path.
 
@@ -386,7 +386,7 @@ def load_torch_artifacts(model_path: str | Path, **kwargs) -> None:
     torch.compiler.load_cache_artifacts(artifact_bytes)
 
 
-def load_hqq_diffusers(path: path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
+def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -20,7 +20,7 @@ import tempfile
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Any, List, Union
+from typing import Any, List
 
 import torch
 import transformers
@@ -38,7 +38,7 @@ from pruna.engine.utils import determine_dtype
 from pruna.logging.logger import pruna_logger
 
 
-def save_pruna_model(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_pruna_model(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -46,7 +46,7 @@ def save_pruna_model(model: Any, model_path: Union[str, Path], smash_config: Sma
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -93,7 +93,7 @@ def save_pruna_model_to_hub(
     model: Any,
     smash_config: SmashConfig,
     repo_id: str,
-    model_path: Union[str, Path, None] = None,
+    model_path: str | Path | None = None,
     *,
     revision: str | None = None,
     private: bool = False,
@@ -114,7 +114,7 @@ def save_pruna_model_to_hub(
         The SmashConfig object containing the save and load functions.
     repo_id : str
         The repository ID.
-    model_path : Union[str,Path,None], optional
+    model_path : str | Path| None, optional
         The path to the directory where the model will be saved.
     revision : str | None, optional
         The revision of the model.
@@ -180,7 +180,7 @@ def save_pruna_model_to_hub(
         )
 
 
-def original_save_fn(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def original_save_fn(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -188,7 +188,7 @@ def original_save_fn(model: Any, model_path: Union[str, Path], smash_config: Sma
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -219,7 +219,7 @@ def original_save_fn(model: Any, model_path: Union[str, Path], smash_config: Sma
         smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str, Path]) -> None:
+def save_pipeline_info(pipeline_obj: Any, save_directory: str | Path) -> None:
     """
     Save pipeline information to a JSON file in the specified directory for easy loading.
 
@@ -227,7 +227,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str, Path]) -> N
     ----------
     pipeline_obj : Any
         The pipeline object to save.
-    save_directory : Union[str, Path]
+    save_directory : str | Path
         The directory to save the pipeline information to.
     """
     pruna_logger.info(f"Detected pipeline, saving info to {PIPELINE_INFO_FILE_NAME}")
@@ -242,7 +242,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str, Path]) -> N
         json.dump(info, f)
 
 
-def save_before_apply(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_before_apply(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model by moving already saved, temporary files into the model path.
 
@@ -250,7 +250,7 @@ def save_before_apply(model: Any, model_path: Union[str, Path], smash_config: Sm
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -270,7 +270,7 @@ def save_before_apply(model: Any, model_path: Union[str, Path], smash_config: Sm
         shutil.move(os.path.join(save_dir, file), os.path.join(model_path, file))
 
 
-def save_pickled(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_pickled(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model by pickling it.
 
@@ -278,7 +278,7 @@ def save_pickled(model: Any, model_path: Union[str, Path], smash_config: SmashCo
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -291,7 +291,7 @@ def save_pickled(model: Any, model_path: Union[str, Path], smash_config: SmashCo
     smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_model_hqq(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_model_hqq(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model with HQQ functionality.
 
@@ -299,7 +299,7 @@ def save_model_hqq(model: Any, model_path: Union[str, Path], smash_config: Smash
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -315,7 +315,7 @@ def save_model_hqq(model: Any, model_path: Union[str, Path], smash_config: Smash
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq.name)
 
 
-def save_model_hqq_diffusers(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_model_hqq_diffusers(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the pipeline by saving the quantized model with HQQ, and rest of the pipeline with diffusers.
 
@@ -323,7 +323,7 @@ def save_model_hqq_diffusers(model: Any, model_path: Union[str, Path], smash_con
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -356,7 +356,7 @@ def save_model_hqq_diffusers(model: Any, model_path: Union[str, Path], smash_con
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq_diffusers.name)
 
 
-def save_torch_artifacts(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def save_torch_artifacts(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Save the model by saving the torch artifacts.
 
@@ -364,7 +364,7 @@ def save_torch_artifacts(model: Any, model_path: Union[str, Path], smash_config:
     ----------
     model : Any
         The model to save.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -386,7 +386,7 @@ def save_torch_artifacts(model: Any, model_path: Union[str, Path], smash_config:
     smash_config.load_fns.append(LOAD_FUNCTIONS.torch_artifacts.name)
 
 
-def reapply(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
+def reapply(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
     """
     Reapply the model.
 
@@ -394,7 +394,7 @@ def reapply(model: Any, model_path: Union[str, Path], smash_config: SmashConfig)
     ----------
     model : Any
         The model to reapply.
-    model_path : Union[str, Path]
+    model_path : str | Path
         The directory to reapply the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -114,7 +114,7 @@ def save_pruna_model_to_hub(
         The SmashConfig object containing the save and load functions.
     repo_id : str
         The repository ID.
-    model_path : str | Path| None, optional
+    model_path : str | Path | None, optional
         The path to the directory where the model will be saved.
     revision : str | None, optional
         The revision of the model.

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -310,7 +310,7 @@ def save_model_hqq(model: Any, model_path: str | Path, smash_config: SmashConfig
     if isinstance(model, algorithm_packages["HQQModelForCausalLM"]):
         model.save_quantized(model_path)
     else:
-        algorithm_packages["AutoHQQHFModel"].save_quantized(model, model_path)
+        algorithm_packages["AutoHQQHFModel"].save_quantized(model, str(model_path))
 
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq.name)
 

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -20,7 +20,7 @@ import tempfile
 from enum import Enum
 from functools import partial
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Union
 
 import torch
 import transformers
@@ -38,7 +38,7 @@ from pruna.engine.utils import determine_dtype
 from pruna.logging.logger import pruna_logger
 
 
-def save_pruna_model(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_pruna_model(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -46,7 +46,7 @@ def save_pruna_model(model: Any, model_path: str, smash_config: SmashConfig) -> 
     ----------
     model : Any
         The model to save.
-    model_path : str | None
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -93,7 +93,7 @@ def save_pruna_model_to_hub(
     model: Any,
     smash_config: SmashConfig,
     repo_id: str,
-    model_path: str | None = None,
+    model_path: Union[str,Path,None] = None,
     *,
     revision: str | None = None,
     private: bool = False,
@@ -114,7 +114,7 @@ def save_pruna_model_to_hub(
         The SmashConfig object containing the save and load functions.
     repo_id : str
         The repository ID.
-    model_path : str | None, optional
+    model_path : Union[str,Path,None], optional
         The path to the directory where the model will be saved.
     revision : str | None, optional
         The revision of the model.
@@ -180,7 +180,7 @@ def save_pruna_model_to_hub(
         )
 
 
-def original_save_fn(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def original_save_fn(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -188,7 +188,7 @@ def original_save_fn(model: Any, model_path: str, smash_config: SmashConfig) -> 
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -219,7 +219,7 @@ def original_save_fn(model: Any, model_path: str, smash_config: SmashConfig) -> 
         smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_pipeline_info(pipeline_obj: Any, save_directory: str) -> None:
+def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str,Path]) -> None:
     """
     Save pipeline information to a JSON file in the specified directory for easy loading.
 
@@ -227,7 +227,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: str) -> None:
     ----------
     pipeline_obj : Any
         The pipeline object to save.
-    save_directory : str
+    save_directory : Union[str,Path]
         The directory to save the pipeline information to.
     """
     pruna_logger.info(f"Detected pipeline, saving info to {PIPELINE_INFO_FILE_NAME}")
@@ -242,7 +242,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: str) -> None:
         json.dump(info, f)
 
 
-def save_before_apply(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_before_apply(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model by moving already saved, temporary files into the model path.
 
@@ -250,7 +250,7 @@ def save_before_apply(model: Any, model_path: str, smash_config: SmashConfig) ->
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -270,7 +270,7 @@ def save_before_apply(model: Any, model_path: str, smash_config: SmashConfig) ->
         shutil.move(os.path.join(save_dir, file), os.path.join(model_path, file))
 
 
-def save_pickled(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_pickled(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model by pickling it.
 
@@ -278,7 +278,7 @@ def save_pickled(model: Any, model_path: str, smash_config: SmashConfig) -> None
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -291,7 +291,7 @@ def save_pickled(model: Any, model_path: str, smash_config: SmashConfig) -> None
     smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_model_hqq(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_model_hqq(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model with HQQ functionality.
 
@@ -299,7 +299,7 @@ def save_model_hqq(model: Any, model_path: str, smash_config: SmashConfig) -> No
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -315,7 +315,7 @@ def save_model_hqq(model: Any, model_path: str, smash_config: SmashConfig) -> No
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq.name)
 
 
-def save_model_hqq_diffusers(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_model_hqq_diffusers(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the pipeline by saving the quantized model with HQQ, and rest of the pipeline with diffusers.
 
@@ -323,7 +323,7 @@ def save_model_hqq_diffusers(model: Any, model_path: str, smash_config: SmashCon
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -356,7 +356,7 @@ def save_model_hqq_diffusers(model: Any, model_path: str, smash_config: SmashCon
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq_diffusers.name)
 
 
-def save_torch_artifacts(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def save_torch_artifacts(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Save the model by saving the torch artifacts.
 
@@ -364,7 +364,7 @@ def save_torch_artifacts(model: Any, model_path: str, smash_config: SmashConfig)
     ----------
     model : Any
         The model to save.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -386,7 +386,7 @@ def save_torch_artifacts(model: Any, model_path: str, smash_config: SmashConfig)
     smash_config.load_fns.append(LOAD_FUNCTIONS.torch_artifacts.name)
 
 
-def reapply(model: Any, model_path: str, smash_config: SmashConfig) -> None:
+def reapply(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
     """
     Reapply the model.
 
@@ -394,7 +394,7 @@ def reapply(model: Any, model_path: str, smash_config: SmashConfig) -> None:
     ----------
     model : Any
         The model to reapply.
-    model_path : str
+    model_path : Union[str,Path]
         The directory to reapply the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -38,7 +38,7 @@ from pruna.engine.utils import determine_dtype
 from pruna.logging.logger import pruna_logger
 
 
-def save_pruna_model(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_pruna_model(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -46,7 +46,7 @@ def save_pruna_model(model: Any, model_path: Union[str,Path], smash_config: Smas
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -93,7 +93,7 @@ def save_pruna_model_to_hub(
     model: Any,
     smash_config: SmashConfig,
     repo_id: str,
-    model_path: Union[str,Path,None] = None,
+    model_path: Union[str, Path, None] = None,
     *,
     revision: str | None = None,
     private: bool = False,
@@ -180,7 +180,7 @@ def save_pruna_model_to_hub(
         )
 
 
-def original_save_fn(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def original_save_fn(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model to the specified directory.
 
@@ -188,7 +188,7 @@ def original_save_fn(model: Any, model_path: Union[str,Path], smash_config: Smas
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -219,7 +219,7 @@ def original_save_fn(model: Any, model_path: Union[str,Path], smash_config: Smas
         smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str,Path]) -> None:
+def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str, Path]) -> None:
     """
     Save pipeline information to a JSON file in the specified directory for easy loading.
 
@@ -227,7 +227,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str,Path]) -> No
     ----------
     pipeline_obj : Any
         The pipeline object to save.
-    save_directory : Union[str,Path]
+    save_directory : Union[str, Path]
         The directory to save the pipeline information to.
     """
     pruna_logger.info(f"Detected pipeline, saving info to {PIPELINE_INFO_FILE_NAME}")
@@ -242,7 +242,7 @@ def save_pipeline_info(pipeline_obj: Any, save_directory: Union[str,Path]) -> No
         json.dump(info, f)
 
 
-def save_before_apply(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_before_apply(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model by moving already saved, temporary files into the model path.
 
@@ -250,7 +250,7 @@ def save_before_apply(model: Any, model_path: Union[str,Path], smash_config: Sma
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -270,7 +270,7 @@ def save_before_apply(model: Any, model_path: Union[str,Path], smash_config: Sma
         shutil.move(os.path.join(save_dir, file), os.path.join(model_path, file))
 
 
-def save_pickled(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_pickled(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model by pickling it.
 
@@ -278,7 +278,7 @@ def save_pickled(model: Any, model_path: Union[str,Path], smash_config: SmashCon
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -291,7 +291,7 @@ def save_pickled(model: Any, model_path: Union[str,Path], smash_config: SmashCon
     smash_config.load_fns.append(LOAD_FUNCTIONS.pickled.name)
 
 
-def save_model_hqq(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_model_hqq(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model with HQQ functionality.
 
@@ -299,7 +299,7 @@ def save_model_hqq(model: Any, model_path: Union[str,Path], smash_config: SmashC
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -315,7 +315,7 @@ def save_model_hqq(model: Any, model_path: Union[str,Path], smash_config: SmashC
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq.name)
 
 
-def save_model_hqq_diffusers(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_model_hqq_diffusers(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the pipeline by saving the quantized model with HQQ, and rest of the pipeline with diffusers.
 
@@ -323,7 +323,7 @@ def save_model_hqq_diffusers(model: Any, model_path: Union[str,Path], smash_conf
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -356,7 +356,7 @@ def save_model_hqq_diffusers(model: Any, model_path: Union[str,Path], smash_conf
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq_diffusers.name)
 
 
-def save_torch_artifacts(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def save_torch_artifacts(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Save the model by saving the torch artifacts.
 
@@ -364,7 +364,7 @@ def save_torch_artifacts(model: Any, model_path: Union[str,Path], smash_config: 
     ----------
     model : Any
         The model to save.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to save the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.
@@ -386,7 +386,7 @@ def save_torch_artifacts(model: Any, model_path: Union[str,Path], smash_config: 
     smash_config.load_fns.append(LOAD_FUNCTIONS.torch_artifacts.name)
 
 
-def reapply(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) -> None:
+def reapply(model: Any, model_path: Union[str, Path], smash_config: SmashConfig) -> None:
     """
     Reapply the model.
 
@@ -394,7 +394,7 @@ def reapply(model: Any, model_path: Union[str,Path], smash_config: SmashConfig) 
     ----------
     model : Any
         The model to reapply.
-    model_path : Union[str,Path]
+    model_path : Union[str, Path]
         The directory to reapply the model to.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -20,7 +20,7 @@ import inspect
 import json
 import os
 from pathlib import Path
-from typing import Any, Union
+from typing import Any
 
 import torch
 import torch.nn as nn
@@ -35,7 +35,7 @@ def safe_memory_cleanup() -> None:
     torch.cuda.empty_cache()
 
 
-def load_json_config(path: Union[str, Path], json_name: str) -> dict:
+def load_json_config(path: str | Path, json_name: str) -> dict:
     """
     Load and parse a JSON configuration file.
 

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -19,7 +19,8 @@ import gc
 import inspect
 import json
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, Union
 
 import torch
 import torch.nn as nn
@@ -34,7 +35,7 @@ def safe_memory_cleanup() -> None:
     torch.cuda.empty_cache()
 
 
-def load_json_config(path: str, json_name: str) -> dict:
+def load_json_config(path: Union[str,Path], json_name: str) -> dict:
     """
     Load and parse a JSON configuration file.
 

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -35,7 +35,7 @@ def safe_memory_cleanup() -> None:
     torch.cuda.empty_cache()
 
 
-def load_json_config(path: Union[str,Path], json_name: str) -> dict:
+def load_json_config(path: Union[str, Path], json_name: str) -> dict:
     """
     Load and parse a JSON configuration file.
 

--- a/tests/engine/test_load.py
+++ b/tests/engine/test_load.py
@@ -36,21 +36,21 @@ def test_load_pruna_model_path_types(tmp_path, path_type: str) -> None:
     """Test loading PrunaModel with different path types (str vs Path)."""
     model_path = tmp_path / "test_model"
     model_path.mkdir()
-    
+
     config = SmashConfig()
     config.load_fns = ["pickled"]
     config.save_to_json(model_path)
-    
+
     dummy_model = torch.nn.Linear(10, 5)
     torch.save(dummy_model, model_path / "optimized_model.pt")
-    
+
     if path_type == "string":
         test_path = str(model_path)
-    else: 
+    else:
         test_path = Path(model_path)
-    
+
     loaded_model, loaded_config = load_pruna_model(test_path)
-    
+
     assert isinstance(loaded_model, torch.nn.Linear)
     assert loaded_model.in_features == 10
     assert loaded_model.out_features == 5
@@ -65,55 +65,16 @@ def test_load_functions_path_types(tmp_path, path_type: str) -> None:
     """Test individual load functions with different path types."""
     model_path = tmp_path / "pickled_test"
     model_path.mkdir()
-    
+
     dummy_model = torch.nn.Linear(5, 3)
     torch.save(dummy_model, model_path / "optimized_model.pt")
-    
+
     if path_type == "string":
         test_path = str(model_path)
-    else:  
+    else:
         test_path = Path(model_path)
-    
+
     loaded_model = LOAD_FUNCTIONS.pickled(test_path)
     assert isinstance(loaded_model, torch.nn.Linear)
     assert loaded_model.in_features == 5
     assert loaded_model.out_features == 3
-
-
-@pytest.mark.cpu
-def test_deprecation_load_string_only_behavior(tmp_path) -> None:
-    """Test that old string-only behavior still works (deprecation test)."""
-    model_path = tmp_path / "deprecation_test"
-    model_path.mkdir()
-    
-    config = SmashConfig()
-    config.load_fns = ["pickled"]
-    config.save_to_json(model_path)
-    
-    dummy_model = torch.nn.Linear(8, 4)
-    torch.save(dummy_model, model_path / "optimized_model.pt")
-    
-    string_path = str(model_path) 
-    loaded_model, loaded_config = load_pruna_model(string_path)
-    
-    assert isinstance(loaded_model, torch.nn.Linear)
-    assert loaded_model.in_features == 8
-    assert loaded_model.out_features == 4
-    assert isinstance(loaded_config, SmashConfig)
-
-
-@pytest.mark.cpu 
-def test_deprecation_load_functions_string_behavior(tmp_path) -> None:
-    """Test that individual load functions maintain string-only backward compatibility."""
-    model_path = tmp_path / "load_func_deprecation"
-    model_path.mkdir()
-    
-    dummy_model = torch.nn.Linear(6, 2)
-    torch.save(dummy_model, model_path / "optimized_model.pt")
-    
-    string_path = str(model_path)
-    loaded_model = LOAD_FUNCTIONS.pickled(string_path)
-    
-    assert isinstance(loaded_model, torch.nn.Linear)
-    assert loaded_model.in_features == 6
-    assert loaded_model.out_features == 2

--- a/tests/engine/test_load.py
+++ b/tests/engine/test_load.py
@@ -41,7 +41,7 @@ def test_load_functions_path_types(tmp_path, path_type: str) -> None:
         test_path = str(model_path)
     else:
         test_path = Path(model_path)
-    loaded_model = LOAD_FUNCTIONS.pickled(test_path)
+    loaded_model = LOAD_FUNCTIONS.pickled(test_path, SmashConfig())
     assert isinstance(loaded_model, torch.nn.Linear)
     assert loaded_model.in_features == 5
     assert loaded_model.out_features == 3

--- a/tests/engine/test_load.py
+++ b/tests/engine/test_load.py
@@ -79,3 +79,41 @@ def test_load_functions_path_types(tmp_path, path_type: str) -> None:
     assert loaded_model.in_features == 5
     assert loaded_model.out_features == 3
 
+
+@pytest.mark.cpu
+def test_deprecation_load_string_only_behavior(tmp_path) -> None:
+    """Test that old string-only behavior still works (deprecation test)."""
+    model_path = tmp_path / "deprecation_test"
+    model_path.mkdir()
+    
+    config = SmashConfig()
+    config.load_fns = ["pickled"]
+    config.save_to_json(model_path)
+    
+    dummy_model = torch.nn.Linear(8, 4)
+    torch.save(dummy_model, model_path / "optimized_model.pt")
+    
+    string_path = str(model_path) 
+    loaded_model, loaded_config = load_pruna_model(string_path)
+    
+    assert isinstance(loaded_model, torch.nn.Linear)
+    assert loaded_model.in_features == 8
+    assert loaded_model.out_features == 4
+    assert isinstance(loaded_config, SmashConfig)
+
+
+@pytest.mark.cpu 
+def test_deprecation_load_functions_string_behavior(tmp_path) -> None:
+    """Test that individual load functions maintain string-only backward compatibility."""
+    model_path = tmp_path / "load_func_deprecation"
+    model_path.mkdir()
+    
+    dummy_model = torch.nn.Linear(6, 2)
+    torch.save(dummy_model, model_path / "optimized_model.pt")
+    
+    string_path = str(model_path)
+    loaded_model = LOAD_FUNCTIONS.pickled(string_path)
+    
+    assert isinstance(loaded_model, torch.nn.Linear)
+    assert loaded_model.in_features == 6
+    assert loaded_model.out_features == 2

--- a/tests/engine/test_load.py
+++ b/tests/engine/test_load.py
@@ -1,6 +1,12 @@
 import pytest
+import torch
+from pathlib import Path
 
 from pruna.engine.pruna_model import PrunaModel
+from pruna.engine.load import LOAD_FUNCTIONS
+from pruna.engine.load import load_pruna_model
+from pruna.config.smash_config import SmashConfig
+
 
 @pytest.mark.parametrize(
     "model_name, expected_output, should_raise",
@@ -19,4 +25,57 @@ def test_pruna_model_from_hub(model_name: str, expected_output: str, should_rais
     else:
         model = PrunaModel.from_hub(model_name, force_download=True)
         assert model.__class__.__name__ == expected_output
+
+
+@pytest.mark.parametrize(
+    "path_type",
+    ["string", "pathlib"],
+)
+@pytest.mark.cpu
+def test_load_pruna_model_path_types(tmp_path, path_type: str) -> None:
+    """Test loading PrunaModel with different path types (str vs Path)."""
+    model_path = tmp_path / "test_model"
+    model_path.mkdir()
+    
+    config = SmashConfig()
+    config.load_fns = ["pickled"]
+    config.save_to_json(model_path)
+    
+    dummy_model = torch.nn.Linear(10, 5)
+    torch.save(dummy_model, model_path / "optimized_model.pt")
+    
+    if path_type == "string":
+        test_path = str(model_path)
+    else: 
+        test_path = Path(model_path)
+    
+    loaded_model, loaded_config = load_pruna_model(test_path)
+    
+    assert isinstance(loaded_model, torch.nn.Linear)
+    assert loaded_model.in_features == 10
+    assert loaded_model.out_features == 5
+
+
+@pytest.mark.parametrize(
+    "path_type",
+    ["string", "pathlib"],
+)
+@pytest.mark.cpu
+def test_load_functions_path_types(tmp_path, path_type: str) -> None:
+    """Test individual load functions with different path types."""
+    model_path = tmp_path / "pickled_test"
+    model_path.mkdir()
+    
+    dummy_model = torch.nn.Linear(5, 3)
+    torch.save(dummy_model, model_path / "optimized_model.pt")
+    
+    if path_type == "string":
+        test_path = str(model_path)
+    else:  
+        test_path = Path(model_path)
+    
+    loaded_model = LOAD_FUNCTIONS.pickled(test_path)
+    assert isinstance(loaded_model, torch.nn.Linear)
+    assert loaded_model.in_features == 5
+    assert loaded_model.out_features == 3
 

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -7,8 +7,9 @@ from transformers import AutoModelForCausalLM
 from pruna.config.smash_config import SmashConfig
 from pruna import smash
 from pruna.engine.save import save_pruna_model
-from pruna.engine.load import load_pruna_model
 from pruna.engine.save import save_pruna_model_to_hub
+from pruna.engine.save import SAVE_FUNCTIONS
+from pruna.engine.load import load_pruna_model
 from pruna.config.smash_config import SmashConfig
 from diffusers import DiffusionPipeline
 
@@ -73,9 +74,6 @@ def test_save_pruna_model_path_types(tmp_path, path_type: str) -> None:
 @pytest.mark.cpu
 def test_save_functions_path_types(tmp_path, path_type: str) -> None:
     """Test individual save functions with different path types."""
-    from pruna.engine.save import SAVE_FUNCTIONS
-    from pruna.config.smash_config import SmashConfig
-    import torch
     
     dummy_model = torch.nn.Linear(5, 3)
     config = SmashConfig()
@@ -85,14 +83,8 @@ def test_save_functions_path_types(tmp_path, path_type: str) -> None:
         test_path = str(model_path)
     else: 
         test_path = Path(model_path)
-    
-
     os.makedirs(test_path, exist_ok=True)
-    
-
     SAVE_FUNCTIONS.pickled(dummy_model, test_path, config)
-    
-
     expected_file = os.path.join(test_path, "optimized_model.pt")
     assert os.path.exists(expected_file)
 

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -1,8 +1,15 @@
 import os
 import pytest
+import torch
+from pathlib import Path
+from unittest.mock import patch
 from transformers import AutoModelForCausalLM
 from pruna.config.smash_config import SmashConfig
 from pruna import smash
+from pruna.engine.save import save_pruna_model
+from pruna.engine.load import load_pruna_model
+from pruna.engine.save import save_pruna_model_to_hub
+from pruna.config.smash_config import SmashConfig
 from diffusers import DiffusionPipeline
 
 
@@ -35,3 +42,127 @@ def test_save_diffusers_to_hub() -> None:
         model=model,
         smash_config=smash_config,
     ).save_to_hub(upload_repo_id, private=False)
+
+
+@pytest.mark.parametrize(
+    "path_type",
+    ["string", "pathlib"],
+)
+@pytest.mark.cpu
+def test_save_pruna_model_path_types(tmp_path, path_type: str) -> None:
+    """Test saving PrunaModel with different path types (str vs Path)."""
+    dummy_model = torch.nn.Linear(10, 5)
+    config = SmashConfig()
+    config.save_fns = []  
+    model_path = tmp_path / "test_model"
+    if path_type == "string":
+        test_path = str(model_path)
+    else:
+        test_path = Path(model_path)
+    
+    save_pruna_model(dummy_model, test_path, config)
+    
+    assert os.path.exists(test_path)
+    assert os.path.exists(os.path.join(test_path, "smash_config.json"))
+
+
+@pytest.mark.parametrize(
+    "path_type",
+    ["string", "pathlib"],
+)
+@pytest.mark.cpu
+def test_save_functions_path_types(tmp_path, path_type: str) -> None:
+    """Test individual save functions with different path types."""
+    from pruna.engine.save import SAVE_FUNCTIONS
+    from pruna.config.smash_config import SmashConfig
+    import torch
+    
+    dummy_model = torch.nn.Linear(5, 3)
+    config = SmashConfig()
+    
+    model_path = tmp_path / "pickled_test"
+    if path_type == "string":
+        test_path = str(model_path)
+    else: 
+        test_path = Path(model_path)
+    
+
+    os.makedirs(test_path, exist_ok=True)
+    
+
+    SAVE_FUNCTIONS.pickled(dummy_model, test_path, config)
+    
+
+    expected_file = os.path.join(test_path, "optimized_model.pt")
+    assert os.path.exists(expected_file)
+
+
+@pytest.mark.parametrize(
+    "save_path_type,load_path_type",
+    [
+        ("string", "string"),
+        ("string", "pathlib"),
+        ("pathlib", "string"),
+        ("pathlib", "pathlib"),
+    ],
+)
+@pytest.mark.cpu
+def test_save_load_integration_path_types(tmp_path, save_path_type: str, load_path_type: str) -> None:
+    """Test integration between save and load with different path types."""
+    original_model = torch.nn.Linear(8, 4)
+    original_model.weight.data.fill_(1.0) 
+    original_model.bias.data.fill_(0.5)
+    original_model = original_model.cpu()
+    
+    config = SmashConfig()
+    config.save_fns = []  
+    
+    model_path = tmp_path / "integration_test"
+    if save_path_type == "string":
+        save_path = str(model_path)
+    else:  
+        save_path = Path(model_path)
+    
+    if load_path_type == "string":
+        load_path = str(model_path)
+    else:
+        load_path = Path(model_path)
+    save_pruna_model(original_model, save_path, config)
+    loaded_model, loaded_config = load_pruna_model(load_path)
+    loaded_model = loaded_model.cpu()
+    assert isinstance(loaded_model, torch.nn.Linear)
+    assert loaded_model.in_features == 8
+    assert loaded_model.out_features == 4
+    assert torch.allclose(loaded_model.weight.cpu(), original_model.weight.cpu())
+    assert torch.allclose(loaded_model.bias.cpu(), original_model.bias.cpu())
+
+
+@pytest.mark.cpu
+def test_save_to_hub_path_types(tmp_path) -> None:
+    """Test save_to_hub with different path types for local model_path."""
+
+    dummy_model = torch.nn.Linear(3, 2)
+    config = SmashConfig()
+    string_path = str(tmp_path / "string_test")
+    pathlib_path = Path(tmp_path / "pathlib_test")
+    
+    with patch('pruna.engine.save.upload_large_folder') as mock_upload:
+        save_pruna_model_to_hub(
+            model=dummy_model,
+            smash_config=config,
+            repo_id="test/repo",
+            model_path=string_path,
+            private=True
+        )
+        assert mock_upload.called
+        
+        mock_upload.reset_mock()
+        
+        save_pruna_model_to_hub(
+            model=dummy_model,
+            smash_config=config,
+            repo_id="test/repo2",
+            model_path=pathlib_path,
+            private=True
+        )
+        assert mock_upload.called

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -54,15 +54,15 @@ def test_save_pruna_model_path_types(tmp_path, path_type: str) -> None:
     """Test saving PrunaModel with different path types (str vs Path)."""
     dummy_model = torch.nn.Linear(10, 5)
     config = SmashConfig()
-    config.save_fns = []  
+    config.save_fns = []
     model_path = tmp_path / "test_model"
     if path_type == "string":
         test_path = str(model_path)
     else:
         test_path = Path(model_path)
-    
+
     save_pruna_model(dummy_model, test_path, config)
-    
+
     assert os.path.exists(test_path)
     assert os.path.exists(os.path.join(test_path, "smash_config.json"))
 
@@ -74,14 +74,14 @@ def test_save_pruna_model_path_types(tmp_path, path_type: str) -> None:
 @pytest.mark.cpu
 def test_save_functions_path_types(tmp_path, path_type: str) -> None:
     """Test individual save functions with different path types."""
-    
+
     dummy_model = torch.nn.Linear(5, 3)
     config = SmashConfig()
-    
+
     model_path = tmp_path / "pickled_test"
     if path_type == "string":
         test_path = str(model_path)
-    else: 
+    else:
         test_path = Path(model_path)
     os.makedirs(test_path, exist_ok=True)
     SAVE_FUNCTIONS.pickled(dummy_model, test_path, config)
@@ -102,19 +102,19 @@ def test_save_functions_path_types(tmp_path, path_type: str) -> None:
 def test_save_load_integration_path_types(tmp_path, save_path_type: str, load_path_type: str) -> None:
     """Test integration between save and load with different path types."""
     original_model = torch.nn.Linear(8, 4)
-    original_model.weight.data.fill_(1.0) 
+    original_model.weight.data.fill_(1.0)
     original_model.bias.data.fill_(0.5)
     original_model = original_model.cpu()
-    
+
     config = SmashConfig()
-    config.save_fns = []  
-    
+    config.save_fns = []
+
     model_path = tmp_path / "integration_test"
     if save_path_type == "string":
         save_path = str(model_path)
-    else:  
+    else:
         save_path = Path(model_path)
-    
+
     if load_path_type == "string":
         load_path = str(model_path)
     else:
@@ -137,7 +137,7 @@ def test_save_to_hub_path_types(tmp_path) -> None:
     config = SmashConfig()
     string_path = str(tmp_path / "string_test")
     pathlib_path = Path(tmp_path / "pathlib_test")
-    
+
     with patch('pruna.engine.save.upload_large_folder') as mock_upload:
         save_pruna_model_to_hub(
             model=dummy_model,
@@ -147,9 +147,9 @@ def test_save_to_hub_path_types(tmp_path) -> None:
             private=True
         )
         assert mock_upload.called
-        
+
         mock_upload.reset_mock()
-        
+
         save_pruna_model_to_hub(
             model=dummy_model,
             smash_config=config,
@@ -159,98 +159,3 @@ def test_save_to_hub_path_types(tmp_path) -> None:
         )
         assert mock_upload.called
 
-
-@pytest.mark.cpu
-def test_deprecation_save_string_only_behavior(tmp_path) -> None:
-    """Test that old string-only save behavior still works (deprecation test)."""
-    dummy_model = torch.nn.Linear(12, 6)
-    config = SmashConfig()
-    config.save_fns = []
-    
-    model_path = str(tmp_path / "deprecation_save")
-    save_pruna_model(dummy_model, model_path, config)
-    
-    assert os.path.exists(model_path)
-    assert os.path.exists(os.path.join(model_path, "smash_config.json"))
-    assert os.path.exists(os.path.join(model_path, "optimized_model.pt"))
-
-
-@pytest.mark.cpu
-def test_deprecation_save_functions_string_behavior(tmp_path) -> None:
-    """Test that individual save functions maintain string backward compatibility."""
-    dummy_model = torch.nn.Linear(7, 3)
-    config = SmashConfig()
-    
-    save_path = str(tmp_path / "save_func_deprecation")
-    os.makedirs(save_path, exist_ok=True)
-    
-    SAVE_FUNCTIONS.pickled(dummy_model, save_path, config)
-    
-    expected_file = os.path.join(save_path, "optimized_model.pt")
-    assert os.path.exists(expected_file)
-
-
-@pytest.mark.cpu
-def test_deprecation_save_to_hub_string_behavior(tmp_path) -> None:
-    """Test save_to_hub maintains backward compatibility with string paths."""
-    dummy_model = torch.nn.Linear(5, 2)  
-    config = SmashConfig()
-    
-    string_path = str(tmp_path / "hub_deprecation")
-    
-    with patch('pruna.engine.save.upload_large_folder') as mock_upload:
-        save_pruna_model_to_hub(
-            model=dummy_model,
-            smash_config=config, 
-            repo_id="test/deprecation-repo",
-            model_path=string_path,
-            private=True
-        )
-        assert mock_upload.called
-
-
-@pytest.mark.cpu
-def test_deprecation_backward_compatibility_complete_workflow(tmp_path) -> None:
-    """Test complete save/load workflow using old string-only methods."""
-    original_model = torch.nn.Linear(10, 5)
-    original_model.weight.data.fill_(2.0)
-    original_model.bias.data.fill_(1.0)
-    
-    config = SmashConfig()
-    config.save_fns = []
-    
-    model_path_str = str(tmp_path / "complete_workflow")
-    
-    save_pruna_model(original_model, model_path_str, config)
-    
-    loaded_model, loaded_config = load_pruna_model(model_path_str)
-    loaded_model = loaded_model.cpu()
-
-    assert isinstance(loaded_model, torch.nn.Linear)
-    assert torch.allclose(loaded_model.weight, original_model.weight)
-    assert torch.allclose(loaded_model.bias, original_model.bias)
-    assert isinstance(loaded_config, SmashConfig)
-
-
-@pytest.mark.cpu
-def test_deprecation_no_breaking_changes(tmp_path) -> None:
-    """Ensure no breaking changes were introduced with Path support."""
-    models_and_paths = []
-    
-    for i in range(3):
-        model = torch.nn.Linear(4, 2)
-        path = str(tmp_path / f"no_breaking_{i}")
-        models_and_paths.append((model, path))
-    
-    config = SmashConfig()
-    config.save_fns = []
-    
-    for model, path in models_and_paths:
-        save_pruna_model(model, path, config)
-        assert os.path.exists(path)
-    
-    for original_model, path in models_and_paths:
-        loaded_model, _ = load_pruna_model(path)
-        assert isinstance(loaded_model, torch.nn.Linear)
-        assert loaded_model.in_features == original_model.in_features
-        assert loaded_model.out_features == original_model.out_features


### PR DESCRIPTION
## Description

This pull request enhances type flexibility across multiple files by replacing `str` with `Union[str, Path]` for file path parameters. This change enables functions to accept both string-based paths and `Path` objects from the `pathlib` module, improving compatibility and usability. The `pathlib.Path` module has also been imported wherever necessary.

## Related Issue

Fixes #49

Linked Pruna Pro PR: https://github.com/PrunaAI/prunatree/pull/129

## Type of Change

<!-- Mark the appropriate options with an "x" (no spaces around the "x") -->

* [x] Added type flexibility to support both `Path` and `str` for file-related parameters in `save` and `load` functions
* [x] Modified type annotations in files such as `save.py`, `load.py`, `smash_config.py`, and `utils.py`

## How Has This Been Tested?

* Unit tests run:

  * `test_save.py`
  * `test_load.py`

## Checklist

<!-- Mark items with an "x" (no spaces around the "x") -->

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes

