### PR TITLE
fix: move import check after availability checks

### DIFF
--- a/src/pruna/smash.py
+++ b/src/pruna/smash.py
@@ -95,9 +95,9 @@ def check_model_compatibility(
     for current_group in ALGORITHM_GROUPS:
         algorithm = smash_config[current_group]
         if algorithm is not None:
+            check_algorithm_availability(algorithm, current_group, algorithm_dict)
             # test if all required packages are installed, if not this will raise an ImportError
             algorithm_dict[current_group][algorithm].import_algorithm_packages()
-            check_algorithm_availability(algorithm, current_group, algorithm_dict)
             check_argument_compatibility(smash_config, algorithm)
             # check for model-algorithm compatibility with the model_check_fn
             if not algorithm_dict[current_group][algorithm].model_check_fn(model):


### PR DESCRIPTION
## Description
This PR adjusts the order of compatibility checks in the smash function. The order should be that first, we check that the user has chosen the right interface (might need pruna_pro for some algorithms) and then attempt the import of required packages.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Ran compatibility tests locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
None.
