### PR TITLE
build: unpin torch and torchvision version except for stable-fast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,8 @@ classifiers = [
 ]
 dependencies = [
     "wget",
-    "torch==2.7.0",
-    "torchvision==0.22.0",
+    "torch>=2.5.1",
+    "torchvision>=0.20.1",
     "torchmetrics[image]",
     "requests>=2.31.0",
     "transformers",
@@ -94,6 +94,7 @@ dependencies = [
 
 [project.optional-dependencies]
 stable-fast = [
+    "torch==2.7.0",
     "xformers==0.0.30",
     "stable-fast-pruna==1.0.7",
 ]
@@ -108,6 +109,7 @@ gptq = [
     "gptqmodel; sys_platform == 'darwin' and platform_machine == 'arm64'",
 ]
 full = [
+    "torch==2.7.0",
     "xformers==0.0.30",
     "stable-fast-pruna==1.0.7",
 ]


### PR DESCRIPTION
## Description
Change the pruna dependencies on torch and torchvision to increase compatibility
- when installing with `pip install pruna[stable-fast]` or `pip install pruna[full]`, torch version remains pinned to 2.7.0
- in all other cases, torch version can now be >=2.5.1

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Installed pruna with fixed versions of torch starting at 2.5.1 and fixing the version of torchvision accordingly, checking if install is done correctly
- installed pruna[stable-fast] with the dependency declared in this new way in optional-dependencies and making sure the code from the "quick start" section of the readme (using stable-fast) runs correctly.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
