### PR TITLE
fix: device of FID torch metric

### DIFF
--- a/tests/evaluation/test_torch_metrics.py
+++ b/tests/evaluation/test_torch_metrics.py
@@ -31,6 +31,7 @@ def test_perplexity(dataloader_fixture: Any) -> None:
 def test_fid(dataloader_fixture: Any) -> None:
     """Test the fid."""
     metric = TorchMetricWrapper("fid")
+    metric.metric.to("cpu")
 
     dataloader_iter = iter(dataloader_fixture)
 


### PR DESCRIPTION
## Description
This PR fixes the `torch_metrics` test for FID, which fails currently as the metric (when the tests run on CPU) is cast to CUDA but the inputs are on CPU.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
