### PR TITLE
ci: add mission permission set to `package_build.yaml`

### DIFF
--- a/.github/workflows/package_build.yaml
+++ b/.github/workflows/package_build.yaml
@@ -1,5 +1,9 @@
 name: Package Build
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
## Description
As per GitHub security guideline, each workflow file should explicitly specify the permissions for the workflow.

## Related Issue
Fixes code scanning warning in GitHub security tab.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
None

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None
