### PR TITLE
fix: `gptq` and `llmcompressor` tests

### DIFF
--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -41,7 +41,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("sd_tiny_random", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
         ("flux_tiny_random", dict(quantizer="hqq_diffusers", compiler="torch_compile"), False),
         ("sd_tiny_random", dict(quantizer="diffusers_int8", compiler="torch_compile", torch_compile_fullgraph=False), False),
-        ("llama_3_2_1b", dict(quantizer="gptq", compiler="torch_compile"), True),
+        pytest.param("llama_3_2_1b", dict(quantizer="gptq", compiler="torch_compile"), True, marks=pytest.mark.high),
         ("llama_3_tiny_random", dict(quantizer="llm_int8", compiler="torch_compile", torch_compile_fullgraph=False), True),
         ("flux_tiny_random", dict(cacher="pab", quantizer="hqq_diffusers"), False),
         ("flux_tiny_random", dict(cacher="pab", quantizer="diffusers_int8"), False),

--- a/tests/algorithms/testers/quantization.py
+++ b/tests/algorithms/testers/quantization.py
@@ -90,6 +90,7 @@ class TestTorchao(AlgorithmTesterBase):
 
 
 @pytest.mark.slow
+@pytest.mark.high
 class TestGPTQ(AlgorithmTesterBase):
     """Test the GPTQ quantizer."""
 
@@ -111,7 +112,7 @@ class TestGPTQ(AlgorithmTesterBase):
 class TestLLMCompressor(AlgorithmTesterBase):
     """Test the LLM Compressor quantizer."""
 
-    models = ["llama_3_2_1b"]
+    models = ["noref_llama_3_2_1b"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = LLMCompressorQuantizer


### PR DESCRIPTION
## Description
This PR attempts to fix failing `gptq` and `llmcompressor` tests. 
GPTQ: `RuntimeError: CUDA error: no kernel image is available for execution on the device` --> indicates that the device for the nightly tests might not be compatible with this method and we should mark it as "high"
LLMCompressor: `TypeError: unhashable type: 'weakref.CallableProxyType'` --> fixed by not wrapping input model into weakref

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Ran tests locally

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
