### PR TITLE
feat: evaluation agent on multiGPU

### DIFF
--- a/docs/user_manual/customize_metric.rst
+++ b/docs/user_manual/customize_metric.rst
@@ -40,9 +40,13 @@ Create a new class that inherits from ``BaseMetric`` and implements the ``comput
 
 Your metric should have a ``metric_name`` and a ``higher_is_better`` attribute. Higher is better is a boolean value that indicates if a higher metric value is better.
 
-Every metric has a ``runs_on`` attribute that should be a list that contains the device(s) the metric can run on. For base metrics it is by default ``["cuda", "cpu", "mps"]``.
+Every metric has a ``runs_on`` attribute that specifies the device(s) it supports.
 
-Please update the ``runs_on`` if you want to change the default devices. For instance, you can also include ``accelerate`` if your metric logic works on multiple devices. Inference with ``accelerate`` should work out of the box, and some of |pruna|'s metrics already use it!
+For custom metrics, you should explicitly set this list. If not specified, the default is ``["cuda", "cpu", "mps"]``.
+
+You can extend this list as needed. For example, include ``accelerate`` if your metric logic is compatible with multiple devices.
+
+Inference with accelerate works out of the box, and some of |pruna|’s built-in metrics already make use of it.
 
 ``compute()`` takes two parameters: ``model`` and ``dataloader``.
 
@@ -81,9 +85,13 @@ To implement a ``StatefulMetric``, create a class that inherits from ``StatefulM
 
 Your metric should have a ``metric_name`` and a ``higher_is_better`` attribute. Higher is better is a boolean value that indicates if a higher metric value is better.
 
-Every metric has a ``runs_on`` attribute that should be a list that contains the device(s) the metric can run on. For base metrics it is by default ``["cuda", "cpu", "mps"]``.
+Every metric has a ``runs_on`` attribute that specifies the device(s) it supports.
 
-Please update the ``runs_on`` if you want to change the default devices.
+For custom metrics, you should explicitly set this list. If not specified, the default is ``["cuda", "cpu", "mps"]``.
+
+You can extend this list as needed. For example, include ``accelerate`` if your metric logic is compatible with multiple devices.
+
+Inference with accelerate works out of the box, and some of |pruna|’s built-in metrics already make use of it.
 
 Use ``add_state()`` method to define internal state variables that will accumulate data across batches. For example, you might track totals and counts to compute an average.
 

--- a/docs/user_manual/customize_metric.rst
+++ b/docs/user_manual/customize_metric.rst
@@ -42,7 +42,7 @@ Your metric should have a ``metric_name`` and a ``higher_is_better`` attribute. 
 
 Every metric has a ``runs_on`` attribute that should be a list that contains the device(s) the metric can run on. For base metrics it is by default ``["cuda", "cpu", "mps"]``.
 
-Please update the ``runs_on`` if you want to change the default devices.
+Please update the ``runs_on`` if you want to change the default devices. For instance, you can also include ``accelerate`` if your metric logic works on multiple devices. Inference with ``accelerate`` should work out of the box, and some of |pruna|'s metrics already use it!
 
 ``compute()`` takes two parameters: ``model`` and ``dataloader``.
 

--- a/docs/user_manual/customize_metric.rst
+++ b/docs/user_manual/customize_metric.rst
@@ -1,5 +1,5 @@
 Customize a Metric
-===============================
+==================
 
 This guide will walk you through the process of adding a new metric to Pruna's evaluation system.
 
@@ -168,7 +168,7 @@ Understanding Call Types
 | `pairwise_y_gt`    | Base model's output first, then subsequent model's output   |
 +--------------------+-------------------------------------------------------------+
 | `pairwise_gt_y`    | Subsequent model's output first, then base model's output   |
-+--------------------+-------------------------------------------------------------+ 
++--------------------+-------------------------------------------------------------+
 | `y`                | Only the output is used, the metric has an internal dataset |
 +--------------------+-------------------------------------------------------------+
 

--- a/docs/user_manual/customize_metric.rst
+++ b/docs/user_manual/customize_metric.rst
@@ -13,9 +13,11 @@ If anything is unclear or you want to discuss your contribution before opening a
 ------------------------------------
 
 |pruna|'s evaluation system supports two types of metrics, located under ``pruna/evaluation/metrics``: ``BaseMetric`` and ``StatefulMetric``.
+|pruna|'s evaluation system supports two types of metrics, located under ``pruna/evaluation/metrics``: ``BaseMetric`` and ``StatefulMetric``.
 
 These two types are designed to accommodate different use cases.
 
+- **BaseMetric**: Inherit from ``BaseMetric`` and compute values directly without maintaining state.
 - **BaseMetric**: Inherit from ``BaseMetric`` and compute values directly without maintaining state.
     - Used when isolated inference is required (e.g., ``latency``, ``disk_memory``, etc.)
 - **StatefulMetric**: Inherit from ``StatefulMetric`` and accumulate state across multiple batches.
@@ -30,6 +32,7 @@ These two types are designed to accommodate different use cases.
 Create a new file in ``pruna/evaluation/metrics`` with a descriptive name for your metric. (e.g, ``your_new_metric.py``)
 
 We use snake_case for the file names (e.g., ``your_new_metric.py``), PascalCase for the class names (e.g, ``YourNewMetric``) and NumPy style docstrings for documentation.
+We use snake_case for the file names (e.g., ``your_new_metric.py``), PascalCase for the class names (e.g, ``YourNewMetric``) and NumPy style docstrings for documentation.
 
 Both  ``BaseMetric`` and ``StatefulMetric`` return a ``MetricResult`` object, which contains the metric name, result value and other metadata.
 
@@ -43,12 +46,14 @@ Your metric should have a ``metric_name`` attribute and a ``higher_is_better`` a
 ``compute()`` takes two parameters: ``model`` and ``dataloader``.
 
 Inside ``compute()``, you are responsible for running inference manually.
+Inside ``compute()``, you are responsible for running inference manually.
 
 Your method should return a ``MetricResult`` object with the metric name, result value and other metadata. The result value should be a float or int.
 
 .. code-block:: python
 
     from pruna.evaluation.metrics.metric_base import BaseMetric
+    from pruna.evaluation.metrics.result import MetricResult
     from pruna.evaluation.metrics.result import MetricResult
 
     class YourNewMetric(BaseMetric):
@@ -107,6 +112,7 @@ Here's a complete example implementing a ``StatefulMetric`` with a single ``call
             self.param1 = param1
             self.param2 = param2
             self.call_type = get_call_type_for_single_metric(call_type, self.default_call_type) # Call the correct helper function to get the correct call_type
+
 
             # Initialize state variables
             self.add_state("total", torch.zeros(1))
@@ -190,7 +196,9 @@ In this case, you can pass ``pairwise`` to the ``call_type`` parameter of the ``
 
     from pruna.evaluation.metrics.your_metric_file import YourNewStatefulMetric
 
+
     # Initialize your metric from the instance
+    YourNewStatefulMetric(param1='value1', param2='value2', call_type="pairwise")
     YourNewStatefulMetric(param1='value1', param2='value2', call_type="pairwise")
 
 If you have implemented your metric using the correct ``get_call_type_for_metric`` function and ``metric_data_processor`` function, this will work as expected.
@@ -243,6 +251,7 @@ Thanks to this registry system, everyone using |pruna| can now refer to your met
     from pruna.evaluation.metrics.your_metric_file import YourNewMetric
 
     # Classic way: Initialize your metric from the instance
+    YourNewMetric(param1='value1', param2='value2')
     YourNewMetric(param1='value1', param2='value2')
 
 .. code-block:: python
@@ -298,6 +307,7 @@ Once you've implemented your metric, everyone can use it in Pruna's evaluation p
 
     from pruna.evaluation.metrics.metric_torch import TorchMetricWrapper
     from pruna.evaluation.metrics.your_metric_file import YourNewMetric
+
 
     metrics = [
         'clip_score',

--- a/src/pruna/config/pre_smash_routines.py
+++ b/src/pruna/config/pre_smash_routines.py
@@ -14,12 +14,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pruna import SmashConfig
 from pruna.algorithms import PRUNA_ALGORITHMS
 from pruna.config.smash_space import SMASH_SPACE
-from pruna.engine.utils import get_device, get_device_map, move_to_device
+from pruna.engine.utils import get_device, get_device_map, move_to_device, split_device
 from pruna.logging.logger import pruna_logger
 
 
@@ -36,12 +36,13 @@ def ensure_device_consistency(model, smash_config):
     """
     _device_options = ["cpu", "cuda", "mps"]
     model_device = get_device(model)
+    model_device_kind = split_device(model_device)[0]
 
     # model and smash config devices match
-    if model_device == smash_config.device:
+    if model_device_kind == split_device(smash_config.device)[0]:
         pruna_logger.debug("Device consistency check passed.")
         # in case of accelerate, we need to store the device map
-        if model_device == "accelerate":
+        if model_device_kind == "accelerate":
             pruna_logger.debug("Device consistency check passed.")
             hf_device_map = get_device_map(model)
             if not all(isinstance(v, int) for v in hf_device_map.values()):
@@ -49,9 +50,7 @@ def ensure_device_consistency(model, smash_config):
             else:
                 smash_config.device_map = hf_device_map
     # Check if the device or device index (e.g., 'cuda:0', 'cpu:1', 'mps:0') matches any of the valid device options
-    elif any(smash_config.device.startswith(device) for device in _device_options) and any(
-        model_device.startswith(device) for device in _device_options
-    ):
+    elif split_device(smash_config.device)[0] in _device_options and model_device_kind in _device_options:
         pruna_logger.warning(
             (
                 f"Model and SmashConfig have different devices. Model: {model_device}, "
@@ -60,14 +59,15 @@ def ensure_device_consistency(model, smash_config):
             )
         )
         move_to_device(model, smash_config.device)
-    elif smash_config.device == "accelerate" or model_device == "accelerate":
+
+    elif split_device(smash_config.device)[0] == "accelerate" or model_device_kind == "accelerate":
         pruna_logger.warning(
             (
                 f"Model and SmashConfig have different devices. Model: {model_device}, "
                 f"SmashConfig: {smash_config.device}. Updating SmashConfig to device='{model_device}'."
             )
         )
-        smash_config.device = model_device
+        smash_config.device = model_device_kind
     else:
         raise ValueError(f"Invalid device: {smash_config.device}")
 
@@ -105,7 +105,7 @@ def check_model_compatibility(
                 raise ValueError(
                     f"Model is not compatible with {algorithm_dict[current_group][algorithm].algorithm_name}"
                 )
-            if not any(device in get_device(model) for device in algorithm_dict[current_group][algorithm].runs_on):
+            if split_device(cast(str, get_device(model)))[0] not in algorithm_dict[current_group][algorithm].runs_on:
                 raise ValueError(
                     f"{algorithm} is not compatible with device {get_device(model)}, "
                     f"compatible devices are {algorithm_dict[current_group][algorithm].runs_on}"

--- a/src/pruna/config/pre_smash_routines.py
+++ b/src/pruna/config/pre_smash_routines.py
@@ -38,14 +38,14 @@ def ensure_device_consistency(model, smash_config):
     model_device = get_device(model)
 
     # to handle the device cases like "cuda:0 and cuda, cuda:1"
-    model_device_kind, model_device_index = split_device(model_device)
-    smash_config_device_kind, smash_config_device_index = split_device(smash_config.device)
+    model_device_type, model_device_index = split_device(model_device)
+    smash_config_device_type, smash_config_device_index = split_device(smash_config.device)
 
     # model and smash config devices match
-    if (model_device_kind == smash_config_device_kind) and (model_device_index == smash_config_device_index):
+    if (model_device_type == smash_config_device_type) and (model_device_index == smash_config_device_index):
         pruna_logger.debug("Device consistency check passed.")
         # in case of accelerate, we need to store the device map
-        if model_device_kind == "accelerate":
+        if model_device_type == "accelerate":
             pruna_logger.debug("Device consistency check passed.")
             hf_device_map = get_device_map(model)
             if not all(isinstance(v, int) for v in hf_device_map.values()):
@@ -53,7 +53,7 @@ def ensure_device_consistency(model, smash_config):
             else:
                 smash_config.device_map = hf_device_map
     # Check if the device or device index (e.g., 'cuda:0', 'cpu:1', 'mps:0') matches any of the valid device options
-    elif smash_config_device_kind in _device_options and model_device_kind in _device_options:
+    elif smash_config_device_type in _device_options and model_device_type in _device_options:
         pruna_logger.warning(
             (
                 f"Model and SmashConfig have different devices. Model: {model_device}, "
@@ -63,7 +63,7 @@ def ensure_device_consistency(model, smash_config):
         )
         move_to_device(model, smash_config.device)
 
-    elif (smash_config_device_kind == "accelerate") or (model_device_kind == "accelerate"):
+    elif (smash_config_device_type == "accelerate") or (model_device_type == "accelerate"):
         pruna_logger.warning(
             (
                 f"Model and SmashConfig have different devices. Model: {model_device}, "

--- a/src/pruna/data/utils.py
+++ b/src/pruna/data/utils.py
@@ -125,7 +125,7 @@ def move_batch_to_device(batch: Any, device: Union[torch.device, str]) -> Any:
     elif isinstance(batch, dict):
         return {k: move_batch_to_device(v, device) for k, v in batch.items()}
     elif isinstance(batch, (list, tuple)):
-        return [move_batch_to_device(v, device) for v in batch]
+        return type(batch)(move_batch_to_device(v, device) for v in batch)
     else:
         return batch
 

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -88,33 +88,6 @@ class InferenceHandler(ABC):
         List[str] | torch.Tensor
             The prepared inputs.
         """
-        if isinstance(inputs, dict):
-            for key, value in inputs.items():
-                if isinstance(value, torch.Tensor):
-                    inputs[key] = value.to(device)
-        if isinstance(inputs, torch.Tensor):
-            return inputs.to(device)
-        elif isinstance(inputs, tuple):
-            return tuple(self.move_inputs_to_device(item, device) for item in inputs)  # type: ignore
-        else:
-            return inputs
-
-    def set_correct_dtype(
-        self, batch: List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...] | dict, dtype: torch.dtype
-    ) -> List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...] | dict:
-        """Set the correct dtype for the batch."""
-        if isinstance(batch, torch.Tensor):
-            return batch.to(dtype)
-
-        if isinstance(batch, list) and all(isinstance(x, str) for x in batch):
-            return batch  # don't touch list of strings
-
-        if isinstance(batch, tuple):
-            return tuple(self.set_correct_dtype(item, dtype) for item in batch)  # type: ignore
-
-        if isinstance(batch, dict):
-            return {
-                k: self.set_correct_dtype(v, dtype) if isinstance(v, (torch.Tensor, list, tuple, dict)) else v
-                for k, v in batch.items()
-            }
-        return batch
+        if isinstance(device, dict):
+            device = min(device.values())  # If we have a device map, we should move to the first device.
+        return move_batch_to_device(inputs, device)

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -82,12 +82,17 @@ class InferenceHandler(ABC):
             The inputs to prepare.
         device : torch.device | str
             The device to move the inputs to.
+        device_map : dict[str, str] | None
+            The device map to use.
 
         Returns
         -------
         List[str] | torch.Tensor
             The prepared inputs.
         """
-        if isinstance(device, dict):
-            device = min(device.values())  # If we have a device map, we should move to the first device.
+        if device == "accelerate":
+            if device_map is None:
+                raise ValueError("Device map is required for accelerate device.")
+            device = min(device_map.values())  # If we have a device map, we should move to the first device
+        # Using the utility function from the data module
         return move_batch_to_device(inputs, device)

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Tuple
 import torch
 
 from pruna.data.utils import move_batch_to_device
+from pruna.engine.utils import set_to_best_available_device
 
 
 class InferenceHandler(ABC):
@@ -70,9 +71,9 @@ class InferenceHandler(ABC):
 
     def move_inputs_to_device(
         self,
-        inputs: List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...] | Dict[str, Any],
-        device: torch.device | str | dict[str, str],
-    ) -> List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor | Dict[str, Any], ...] | Dict[str, Any]:
+        inputs: List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...],
+        device: torch.device | str,
+    ) -> List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...]:
         """
         Recursively move inputs to device.
 
@@ -82,8 +83,6 @@ class InferenceHandler(ABC):
             The inputs to prepare.
         device : torch.device | str
             The device to move the inputs to.
-        device_map : dict[str, str] | None
-            The device map to use.
 
         Returns
         -------
@@ -91,8 +90,6 @@ class InferenceHandler(ABC):
             The prepared inputs.
         """
         if device == "accelerate":
-            if device_map is None:
-                raise ValueError("Device map is required for accelerate device.")
-            device = min(device_map.values())  # If we have a device map, we should move to the first device
+            device = set_to_best_available_device(None)
         # Using the utility function from the data module
         return move_batch_to_device(inputs, device)

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -92,4 +92,7 @@ class InferenceHandler(ABC):
         if device == "accelerate":
             device = set_to_best_available_device(None)
         # Using the utility function from the data module
-        return move_batch_to_device(inputs, device)
+        try:
+            return move_batch_to_device(inputs, device)
+        except torch.cuda.OutOfMemoryError as e:
+            raise e

--- a/src/pruna/engine/handler/handler_inference.py
+++ b/src/pruna/engine/handler/handler_inference.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Tuple
 
 import torch
 
+from pruna.data.utils import move_batch_to_device
+
 
 class InferenceHandler(ABC):
     """
@@ -69,7 +71,7 @@ class InferenceHandler(ABC):
     def move_inputs_to_device(
         self,
         inputs: List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor, ...] | Dict[str, Any],
-        device: torch.device | str = "cuda",
+        device: torch.device | str | dict[str, str],
     ) -> List[str] | torch.Tensor | Tuple[List[str] | torch.Tensor | Dict[str, Any], ...] | Dict[str, Any]:
         """
         Recursively move inputs to device.

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -24,9 +24,9 @@ from tqdm.auto import tqdm as base_tqdm
 
 from pruna.config.smash_config import SmashConfig
 from pruna.engine.handler.handler_utils import register_inference_handler
-from pruna.engine.load import filter_load_kwargs, load_pruna_model, load_pruna_model_from_pretrained
+from pruna.engine.load import load_pruna_model, load_pruna_model_from_pretrained
 from pruna.engine.save import save_pruna_model, save_pruna_model_to_hub
-from pruna.engine.utils import get_device, get_device_map, get_nn_modules, move_to_device, set_to_eval
+from pruna.engine.utils import get_device, get_nn_modules, set_to_eval
 from pruna.logging.filter import apply_warning_filter
 from pruna.telemetry import increment_counter, track_usage
 
@@ -91,12 +91,10 @@ class PrunaModel:
         """
         if self.model is None:
             raise ValueError("No more model available, this model is likely destroyed.")
-
         # Rather than giving a device to the inference call,
         # we should run the inference on the device of the model.
         model_device = get_device(self.model)
-        batch = self.inference_handler.move_inputs_to_device(batch, model_device)
-
+        batch = self.inference_handler.move_inputs_to_device(batch, model_device)  # type: ignore
         if not isinstance(batch, tuple):
             batch = (batch, {})
         prepared_inputs = self.inference_handler.prepare_inputs(batch)
@@ -156,40 +154,6 @@ class PrunaModel:
         """
         delattr(self.model, attr)
 
-    def get_device(self, **kwargs: Any) -> str:
-        """
-        Get the device of the model.
-
-        Parameters
-        ----------
-        **kwargs : Any
-            Additional keyword arguments to pass to the get_device function.
-
-        Returns
-        -------
-        str | dict[str, str]
-            The device of the model.
-        """
-        # Passing kwargs here just in case the utility function changes later on.
-        return get_device(self.model, **filter_load_kwargs(get_device, kwargs))
-
-    def get_device_map(self, **kwargs: Any) -> dict[str, str]:
-        """
-        Get the device map of the model.
-
-        Parameters
-        ----------
-        **kwargs : Any
-            Additional keyword arguments to pass to the get_device_map function.
-
-        Returns
-        -------
-        dict[str, str]
-            The device map of the model.
-        """
-        # Passing kwargs here just in case the utility function changes later on.
-        return get_device_map(self.model, **filter_load_kwargs(get_device_map, kwargs))
-
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
         Get the nn.Module instances in the model.
@@ -204,22 +168,6 @@ class PrunaModel:
     def set_to_eval(self) -> None:
         """Set the model to evaluation mode."""
         set_to_eval(self.model)
-
-    def move_to_device(self, device: str, device_map: dict[str, str] | None = None, **kwargs: Any) -> None:
-        """
-        Move the model to a specific device.
-
-        Parameters
-        ----------
-        device : str
-            The device to move the model to.
-        device_map : dict[str, str] | None
-            The device map to use to move the model to the device.
-        **kwargs : Any
-            Additional keyword arguments to pass to the move_to_device function.
-        """
-        # Passing kwargs here just in case the utility function changes later on.
-        move_to_device(self.model, device, device_map=device_map, **filter_load_kwargs(move_to_device, kwargs))
 
     def save_pretrained(self, model_path: str) -> None:
         """

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -24,7 +24,7 @@ from tqdm.auto import tqdm as base_tqdm
 
 from pruna.config.smash_config import SmashConfig
 from pruna.engine.handler.handler_utils import register_inference_handler
-from pruna.engine.load import load_pruna_model, load_pruna_model_from_pretrained
+from pruna.engine.load import filter_load_kwargs, load_pruna_model, load_pruna_model_from_pretrained
 from pruna.engine.save import save_pruna_model, save_pruna_model_to_hub
 from pruna.engine.utils import get_device, get_nn_modules, move_to_device, set_to_eval
 from pruna.logging.filter import apply_warning_filter
@@ -75,7 +75,7 @@ class PrunaModel:
             with torch.no_grad():
                 return self.model.__call__(*args, **kwargs)
 
-    def run_inference(self, batch: Any, device: torch.device | str | None = None) -> Any:
+    def run_inference(self, batch: Any) -> Any:
         """
         Run inference on the model.
 
@@ -83,8 +83,6 @@ class PrunaModel:
         ----------
         batch : Any
             The batch to run inference on.
-        device : torch.device | str | None
-            The device to run inference on. If None, the best available device will be used.
 
         Returns
         -------
@@ -157,6 +155,17 @@ class PrunaModel:
             The attribute to delete.
         """
         delattr(self.model, attr)
+
+    def get_device(self, **kwargs: Any) -> str | dict[str, str]:
+        """
+        Get the device of the model.
+
+        Returns
+        -------
+        str
+            The device of the model.
+        """
+        return get_device(self.model, **filter_load_kwargs(get_device, kwargs))
 
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -91,10 +91,12 @@ class PrunaModel:
         """
         if self.model is None:
             raise ValueError("No more model available, this model is likely destroyed.")
+
         # Rather than giving a device to the inference call,
         # we should run the inference on the device of the model.
         model_device = get_device(self.model)
-        batch = self.inference_handler.move_inputs_to_device(batch, model_device)  # type: ignore
+        batch = self.inference_handler.move_inputs_to_device(batch, model_device)
+
         if not isinstance(batch, tuple):
             batch = (batch, {})
         prepared_inputs = self.inference_handler.prepare_inputs(batch)
@@ -105,6 +107,7 @@ class PrunaModel:
             outputs = self(**prepared_inputs, **self.inference_handler.model_args)
         else:
             outputs = self(prepared_inputs, **self.inference_handler.model_args)
+
         outputs = self.inference_handler.process_output(outputs)
         return outputs
 

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -160,9 +160,14 @@ class PrunaModel:
         """
         Get the device of the model.
 
+        Parameters
+        ----------
+        **kwargs : Any
+            Additional keyword arguments to pass to the get_device function.
+
         Returns
         -------
-        str
+        str | dict[str, str]
             The device of the model.
         """
         return get_device(self.model, **filter_load_kwargs(get_device, kwargs))
@@ -182,7 +187,7 @@ class PrunaModel:
         """Set the model to evaluation mode."""
         set_to_eval(self.model)
 
-    def move_to_device(self, device: str) -> None:
+    def move_to_device(self, device: str, device_map: dict[str, str] | None = None, **kwargs: Any) -> None:
         """
         Move the model to a specific device.
 
@@ -190,8 +195,12 @@ class PrunaModel:
         ----------
         device : str
             The device to move the model to.
+        device_map : dict[str, str] | None
+            The device map to use to move the model to the device.
+        **kwargs : Any
+            Additional keyword arguments to pass to the move_to_device function.
         """
-        move_to_device(self.model, device)
+        move_to_device(self.model, device, device_map=device_map, **filter_load_kwargs(move_to_device, kwargs))
 
     def save_pretrained(self, model_path: str) -> None:
         """

--- a/src/pruna/engine/pruna_model.py
+++ b/src/pruna/engine/pruna_model.py
@@ -26,7 +26,7 @@ from pruna.config.smash_config import SmashConfig
 from pruna.engine.handler.handler_utils import register_inference_handler
 from pruna.engine.load import filter_load_kwargs, load_pruna_model, load_pruna_model_from_pretrained
 from pruna.engine.save import save_pruna_model, save_pruna_model_to_hub
-from pruna.engine.utils import get_device, get_nn_modules, move_to_device, set_to_eval
+from pruna.engine.utils import get_device, get_device_map, get_nn_modules, move_to_device, set_to_eval
 from pruna.logging.filter import apply_warning_filter
 from pruna.telemetry import increment_counter, track_usage
 
@@ -156,7 +156,7 @@ class PrunaModel:
         """
         delattr(self.model, attr)
 
-    def get_device(self, **kwargs: Any) -> str | dict[str, str]:
+    def get_device(self, **kwargs: Any) -> str:
         """
         Get the device of the model.
 
@@ -170,7 +170,25 @@ class PrunaModel:
         str | dict[str, str]
             The device of the model.
         """
+        # Passing kwargs here just in case the utility function changes later on.
         return get_device(self.model, **filter_load_kwargs(get_device, kwargs))
+
+    def get_device_map(self, **kwargs: Any) -> dict[str, str]:
+        """
+        Get the device map of the model.
+
+        Parameters
+        ----------
+        **kwargs : Any
+            Additional keyword arguments to pass to the get_device_map function.
+
+        Returns
+        -------
+        dict[str, str]
+            The device map of the model.
+        """
+        # Passing kwargs here just in case the utility function changes later on.
+        return get_device_map(self.model, **filter_load_kwargs(get_device_map, kwargs))
 
     def get_nn_modules(self) -> dict[str | None, torch.nn.Module]:
         """
@@ -200,6 +218,7 @@ class PrunaModel:
         **kwargs : Any
             Additional keyword arguments to pass to the move_to_device function.
         """
+        # Passing kwargs here just in case the utility function changes later on.
         move_to_device(self.model, device, device_map=device_map, **filter_load_kwargs(move_to_device, kwargs))
 
     def save_pretrained(self, model_path: str) -> None:

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -154,7 +154,9 @@ def move_to_device(
     if str(get_device(model)) == device_str:
         return
 
-    if device_str == "accelerate":
+    if device == "accelerate":
+        if hasattr(model, "smash_config") and device_map is None:
+            device_map = model.smash_config.device_map
         if device_map is None:
             raise ValueError("Device map is required when moving to accelerate.")
         cast_model_to_accelerate_device_map(model, device_map)

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -141,6 +141,17 @@ def move_to_device(
             delattr(model.model, "hf_device_map")
         return
 
+    device = device_to_string(device)
+    kind, idx = split_device(device)
+
+    # sanity check for expected device types
+    if device == "accelerate":
+        pass  # Handle accelerate separately
+    elif kind in ["cpu", "cuda", "mps"]:
+        device = torch.device(f"{kind}:{idx}" if idx is not None else kind)
+    else:
+        raise ValueError("Device must be a string starting with [cpu, cuda, mps, accelerate].")
+
     # do not cast if the model is already on the correct device
     if str(get_device(model)) == device_str:
         return
@@ -352,18 +363,15 @@ def get_device(model: Any) -> str:
     # when casting a model like this with "to" the device map is not maintained, so we rely on the model.device attribute
     if hasattr(model, "hf_device_map") and model.hf_device_map is not None and list(model.hf_device_map.keys()) != [""]:
         model_device = "accelerate"
-
     elif hasattr(model, "device"):
         model_device = model.device
-
     else:
         try:
             model_device = next(model.parameters()).device
         except StopIteration:
             raise ValueError("Could not determine device of model, model has no device attribute.")
 
-    if isinstance(model_device, torch.device):
-        model_device = model_device.type
+    model_device = device_to_string(model_device)
 
     return model_device
 
@@ -505,7 +513,8 @@ def determine_dtype(pipeline: Any) -> torch.dtype:
     return torch.float32
 
 
-def _resolve_cuda_device(device: str) -> str:
+
+def _resolve_cuda_device(device: str, bytes_free_per_gpu: dict[int, int] | None = None) -> str:
     """
     Resolve CUDA device string to a valid CUDA device.
 
@@ -517,26 +526,46 @@ def _resolve_cuda_device(device: str) -> str:
     Returns
     -------
     str
-        Valid CUDA device string with index (e.g. "cuda:0")
+        Valid CUDA device string
     """
-    # If just "cuda", return "cuda:0" for consistency
-    if device == "cuda":
-        return "cuda:0"
+    kind, idx = split_device(device)
+    if not torch.cuda.is_available():
+        pruna_logger.warning("'cuda' requested but not available.")
+        return set_to_best_available_device(device=None)
 
-    # Try to extract device index for "cuda:N" format
-    try:
-        if ":" in device:
-            device_idx = int(device.split(":")[-1])
-            # Check if this CUDA device exists
-            torch.cuda.get_device_properties(device_idx)
-            return device
-        return "cuda:0"  # Default to "cuda:0" if no index specified
-    except (ValueError, AssertionError, RuntimeError):
-        pruna_logger.warning(f"Invalid CUDA device index: {device}. Using 'cuda:0' instead.")
-        return "cuda:0"
+    if bytes_free_per_gpu is not None:
+        if idx != 0:  # Not the default device
+            pruna_logger.warning(
+                "You're requesting a specific CUDA device, "
+                "but the function will return the device with the most free memory."
+            )
+        biggest_free_gpu = max(bytes_free_per_gpu, key=lambda x: bytes_free_per_gpu[x])
+        return f"cuda:{biggest_free_gpu}"
+
+    if idx is None or idx >= torch.cuda.device_count():
+        pruna_logger.warning(f"CUDA device {idx} not available, using device 0")
+        idx = 0
+    return f"cuda:{idx}"
 
 
-def set_to_best_available_device(device: str | torch.device | None) -> str:
+def find_bytes_free_per_gpu() -> dict[int, int]:
+    """
+    Compute the number of bytes free per GPU.
+
+    Returns
+    -------
+    dict[int, int]
+        The number of bytes free per GPU.
+    """
+    if torch.cuda.is_available():
+        return {i: torch.cuda.mem_get_info(i)[0] for i in range(torch.cuda.device_count())}
+    else:
+        return {}
+
+
+def set_to_best_available_device(
+    device: str | torch.device | None, bytes_free_per_gpu: dict[int, int] | None = None
+) -> str:
     """
     Set the device to the best available device.
 
@@ -553,34 +582,86 @@ def set_to_best_available_device(device: str | torch.device | None) -> str:
     str
         Best available device name.
     """
-    if isinstance(device, dict):
-        raise ValueError("Device cannot be a device map in `set_to_best_available_device`")
-
-    # check basic string cases
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
         pruna_logger.info(f"Using best available device: '{device}'")
         return device
 
-    device_str = str(device)
-    if device_str == "cpu":
+    device = device_to_string(device)
+    kind, idx = split_device(device)
+
+    if kind == "cpu":
         return "cpu"
-    elif device_str == "accelerate":
+    elif kind == "accelerate":
         if not torch.cuda.is_available() and not torch.backends.mps.is_available():
             raise ValueError("'accelerate' requested but neither CUDA nor MPS is available.")
         return "accelerate"
-    elif device_str.startswith("cuda"):
-        if not torch.cuda.is_available():
-            pruna_logger.warning("'cuda' requested but not available.")
-            return set_to_best_available_device(device=None)
-        return _resolve_cuda_device(device_str)
-    elif device_str.startswith("mps"):
+    elif kind == "cuda":
+        return _resolve_cuda_device(f"cuda:{idx}" if idx is not None else "cuda", bytes_free_per_gpu)
+    elif kind == "mps":
         if not torch.backends.mps.is_available():
             pruna_logger.warning("'mps' requested but not available.")
             return set_to_best_available_device(device=None)
-        return device_str
+        return "mps"
+
+    raise ValueError(f"Device not supported: '{device}'")
+
+def device_to_string(device: str | torch.device) -> str:
+    """
+    Convert a device to a string.
+
+    Parameters
+    ----------
+    device : str | torch.device
+        The device to convert.
+
+    Returns
+    -------
+    str
+        The device as a string.
+    """
+    if isinstance(device, torch.device):
+        return device.type
+    elif isinstance(device, str):
+        return device
     else:
-        raise ValueError(f"Device not supported: '{device_str}'")
+        raise ValueError(f"Unsupported device type: {type(device)}")
+
+
+def split_device(device: str, strict: bool = True) -> tuple[str, int | None]:
+    """
+    Split a device string into a kind and index.
+
+    Parameters
+    ----------
+    device : str
+        The device to split.
+    strict : bool
+        Whether to raise an error if the device is not in allowed devices
+
+    Returns
+    -------
+    tuple[str, int | None]
+        The kind and index of the device.
+    """
+    device = device.lower()
+    if ":" in device:
+        kind, idx_str = device.split(":", 1)
+        if kind not in ("cuda", "mps") and strict:
+            raise ValueError(f"Unsupported device kind '{kind}'.")
+        try:
+            idx = int(idx_str)
+        except ValueError:
+            raise ValueError("Device index must be an integer.")
+        return kind, idx
+    if device in ("cuda", "mps"):
+        return device, 0  # treat bare cuda and mps as first device
+    if device in ("cpu", "accelerate"):
+        return device, None
+    if strict:
+        raise ValueError(f"Unsupported device: '{device}'.")
+    return device, None
+
 
 
 class ModelContext(AbstractContextManager):

--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -576,6 +576,8 @@ def set_to_best_available_device(
     ----------
     device : str | torch.device | None
         Device to validate (e.g. 'cuda', 'mps', 'cpu').
+    bytes_free_per_gpu : dict[int, int] | None
+        The number of bytes free per GPU.
 
     Returns
     -------
@@ -621,7 +623,7 @@ def device_to_string(device: str | torch.device) -> str:
         The device as a string.
     """
     if isinstance(device, torch.device):
-        return device.type
+        return f"{device.type}:{device.index}" if device.index is not None else device.type
     elif isinstance(device, str):
         return device
     else:

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -24,7 +24,7 @@ from pruna.config.utils import is_empty_config
 from pruna.data.pruna_datamodule import PrunaDataModule
 from pruna.data.utils import move_batch_to_device
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import safe_memory_cleanup, set_to_best_available_device
+from pruna.engine.utils import move_to_device, safe_memory_cleanup, set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.result import MetricResult
@@ -109,7 +109,7 @@ class EvaluationAgent:
         results.extend(self.compute_stateless_metrics(model, stateless_metrics))
 
         # Move model back to the original device.
-        model.move_to_device(self.device, device_map=self.device_map)
+        move_to_device(model, self.device, device_map=self.device_map)
         pruna_logger.info(f"Evaluation run has finished. Moved model to {self.device}")
 
         safe_memory_cleanup()
@@ -203,7 +203,7 @@ class EvaluationAgent:
         if not single_stateful_metrics and not pairwise_metrics:
             return
 
-        model.move_to_device(self.device, self.device_map)
+        move_to_device(model, self.device, device_map=self.device_map)
         for batch_idx, batch in enumerate(self.task.dataloader):
             processed_outputs = model.run_inference(batch)
 

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -110,9 +110,7 @@ class EvaluationAgent:
 
         # Move model back to the original device.
         model.move_to_device(self.device, device_map=self.device_map)
-        pruna_logger.info(
-            f"Evaluation run has finished. Moved model to device {self.device} with device map {self.device_map}."
-        )
+        pruna_logger.info(f"Evaluation run has finished. Moved model to {self.device}")
 
         safe_memory_cleanup()
         if self.evaluation_for_first_model:

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -108,7 +108,12 @@ class EvaluationAgent:
         pruna_logger.info("Evaluating isolated inference metrics.")
         results.extend(self.compute_stateless_metrics(model, stateless_metrics))
 
-        model.move_to_device("cpu")
+        # Move model back to the original device.
+        model.move_to_device(self.device, device_map=self.device_map)
+        pruna_logger.info(
+            f"Evaluation run has finished. Moved model to device {self.device} with device map {self.device_map}."
+        )
+
         safe_memory_cleanup()
         if self.evaluation_for_first_model:
             self.first_model_results = results
@@ -171,6 +176,7 @@ class EvaluationAgent:
 
         ensure_device_consistency(model, self.task)
         self.device = self.task.device
+        self.device_map = model.get_device(return_device_map=True) if self.device == "accelerate" else None
         return model
 
     def update_stateful_metrics(

--- a/src/pruna/evaluation/evaluation_agent.py
+++ b/src/pruna/evaluation/evaluation_agent.py
@@ -28,7 +28,7 @@ from pruna.engine.utils import safe_memory_cleanup, set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.result import MetricResult
-from pruna.evaluation.metrics.utils import ensure_device_consistency, group_metrics_by_inheritance
+from pruna.evaluation.metrics.utils import ensure_device_consistency, get_device_map, group_metrics_by_inheritance
 from pruna.evaluation.task import Task
 from pruna.logging.logger import pruna_logger
 
@@ -176,7 +176,8 @@ class EvaluationAgent:
 
         ensure_device_consistency(model, self.task)
         self.device = self.task.device
-        self.device_map = model.get_device(return_device_map=True) if self.device == "accelerate" else None
+        # Keeping the device map to move model back to the original device, when the agent is finished.
+        self.device_map = get_device_map(model)
         return model
 
     def update_stateful_metrics(
@@ -204,7 +205,7 @@ class EvaluationAgent:
         if not single_stateful_metrics and not pairwise_metrics:
             return
 
-        model.move_to_device(self.device)
+        model.move_to_device(self.device, self.device_map)
         for batch_idx, batch in enumerate(self.task.dataloader):
             processed_outputs = model.run_inference(batch)
 

--- a/src/pruna/evaluation/metrics/metric_base.py
+++ b/src/pruna/evaluation/metrics/metric_base.py
@@ -28,6 +28,7 @@ class BaseMetric(ABC):
     metric_name: str
     metric_units: str
     higher_is_better: bool
+    device: str
 
     @abstractmethod
     def compute(

--- a/src/pruna/evaluation/metrics/metric_base.py
+++ b/src/pruna/evaluation/metrics/metric_base.py
@@ -35,7 +35,7 @@ class BaseMetric(ABC):
     @property
     def device(self) -> str:
         """Return the current device."""
-        return getattr(self, "_device", "cpu")
+        return getattr(self, "_device", "cuda")
 
     @device.setter
     def device(self, dvc: str | torch.device):
@@ -46,6 +46,7 @@ class BaseMetric(ABC):
         value : str | torch.device
             The device to set.
         """
+        # To prevent the user from setting an unsupported device.
         if not self.is_device_supported(dvc):
             raise ValueError(
                 f"Metric {getattr(self, 'metric_name', self.__class__.__name__)} "

--- a/src/pruna/evaluation/metrics/metric_base.py
+++ b/src/pruna/evaluation/metrics/metric_base.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+import torch
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
+from pruna.engine.utils import device_to_string, split_device
 
 
 class BaseMetric(ABC):
@@ -28,7 +30,32 @@ class BaseMetric(ABC):
     metric_name: str
     metric_units: str
     higher_is_better: bool
-    device: str
+    runs_on: list[str] = ["cuda", "cpu", "mps"]
+
+    @property
+    def device(self) -> str:
+        """Return the current device."""
+        return getattr(self, "_device", "cpu")
+
+    @device.setter
+    def device(self, dvc: str | torch.device):
+        """Validate and store the device.
+
+        Parameters
+        ----------
+        value : str | torch.device
+            The device to set.
+        """
+        if not self.is_device_supported(dvc):
+            raise ValueError(
+                f"Metric {getattr(self, 'metric_name', self.__class__.__name__)} "
+                f"doesn't support device '{dvc}'. Must be one of {self.runs_on}."
+            )
+
+        object.__setattr__(self, "_device", dvc)
+
+        if hasattr(self, "metric"):  # For memory metrics that internally use the GPUMemoryStats.
+            object.__setattr__(self.metric, "_device", dvc)
 
     @abstractmethod
     def compute(
@@ -52,3 +79,20 @@ class BaseMetric(ABC):
             The computed metric value.
         """
         pass
+
+    def is_device_supported(self, device: str | torch.device) -> bool:
+        """
+        Check if the metric is compatible with the device.
+
+        Parameters
+        ----------
+        device : str | torch.device | None, optional
+            The device to check. If None, the metric is compatible with all devices.
+
+        Returns
+        -------
+        bool
+            True if the metric is compatible with the device, False otherwise.
+        """
+        dvc, _ = split_device(device_to_string(device))
+        return dvc in self.runs_on

--- a/src/pruna/evaluation/metrics/metric_cmmd.py
+++ b/src/pruna/evaluation/metrics/metric_cmmd.py
@@ -21,7 +21,7 @@ from huggingface_hub import model_info
 from huggingface_hub.utils import EntryNotFoundError
 from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
 
-from pruna.engine.utils import device_to_string, set_to_best_available_device
+from pruna.engine.utils import device_to_string
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -67,14 +67,7 @@ class CMMD(StatefulMetric):
         call_type: str = SINGLE,
         **kwargs,
     ) -> None:
-        super().__init__(*args, **kwargs)
-        self.device = set_to_best_available_device(device)
-        # For stateful metrics we can't have a device a general device property,
-        # because of wrapper metrics. We check case by case.
-        if not self.is_device_supported(self.device):
-            raise ValueError(
-                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
-            )
+        super().__init__(device=device)
         try:
             model_info(clip_model_name)
         except EntryNotFoundError:

--- a/src/pruna/evaluation/metrics/metric_cmmd.py
+++ b/src/pruna/evaluation/metrics/metric_cmmd.py
@@ -69,6 +69,10 @@ class CMMD(StatefulMetric):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.device = set_to_best_available_device(device)
+        if not self.is_device_supported(self.device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
         try:
             model_info(clip_model_name)
         except EntryNotFoundError:
@@ -193,6 +197,10 @@ class CMMD(StatefulMetric):
         device : str | torch.device
             The device to move the metric to.
         """
+        if not self.is_device_supported(device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
         self.device = device_to_string(device)
         self.clip_model = self.clip_model.to(device)
         self.ground_truth_embeddings = [embedding.to(device) for embedding in self.ground_truth_embeddings]

--- a/src/pruna/evaluation/metrics/metric_cmmd.py
+++ b/src/pruna/evaluation/metrics/metric_cmmd.py
@@ -69,6 +69,8 @@ class CMMD(StatefulMetric):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.device = set_to_best_available_device(device)
+        # For stateful metrics we can't have a device a general device property,
+        # because of wrapper metrics. We check case by case.
         if not self.is_device_supported(self.device):
             raise ValueError(
                 f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."

--- a/src/pruna/evaluation/metrics/metric_elapsed_time.py
+++ b/src/pruna/evaluation/metrics/metric_elapsed_time.py
@@ -92,7 +92,7 @@ class InferenceTimeStats(BaseMetric):
         c = 0
         while c < iterations:
             for batch in dataloader:
-                batch = model.inference_handler.move_inputs_to_device(batch, model.get_device(return_device_map=True))
+                batch = model.inference_handler.move_inputs_to_device(batch, model.get_device(), model.get_device_map())
                 x = model.inference_handler.prepare_inputs(batch)
                 measure_fn(model, x)
                 c += 1
@@ -112,7 +112,7 @@ class InferenceTimeStats(BaseMetric):
         if device_type == "cuda":
             torch.cuda.synchronize(device_idx)
         elif device_type == "accelerate":
-            device_map = cast(Dict[str, str], model.get_device(return_device_map=True))
+            device_map = model.get_device_map()
             for device in device_map.values():
                 torch.cuda.synchronize(device)
         else:

--- a/src/pruna/evaluation/metrics/metric_elapsed_time.py
+++ b/src/pruna/evaluation/metrics/metric_elapsed_time.py
@@ -21,7 +21,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import _resolve_cuda_device, set_to_best_available_device
+from pruna.engine.utils import _resolve_cuda_device, device_to_string, set_to_best_available_device, split_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -61,6 +61,8 @@ class InferenceTimeStats(BaseMetric):
         The type of timing to use.
     """
 
+    runs_on: list[str] = ["accelerate", "cuda", "cpu"]
+
     def __init__(
         self,
         n_iterations: int = 100,
@@ -90,12 +92,31 @@ class InferenceTimeStats(BaseMetric):
         c = 0
         while c < iterations:
             for batch in dataloader:
-                batch = model.inference_handler.move_inputs_to_device(batch, self.device)
+                batch = model.inference_handler.move_inputs_to_device(batch, model.get_device(return_device_map=True))
                 x = model.inference_handler.prepare_inputs(batch)
                 measure_fn(model, x)
                 c += 1
                 if c >= iterations:
                     break
+
+    def sync_all_cuda_devices(self, model: PrunaModel):
+        """
+        Synchronize all devices.
+
+        Parameters
+        ----------
+        model : PrunaModel
+            The model to get the device map from.
+        """
+        device_type, device_idx = split_device(device_to_string(self.device))
+        if device_type == "cuda":
+            torch.cuda.synchronize(device_idx)
+        elif device_type == "accelerate":
+            device_map = cast(Dict[str, str], model.get_device(return_device_map=True))
+            for device in device_map.values():
+                torch.cuda.synchronize(device)
+        else:
+            raise ValueError(f"Device {self.device} not supported for sync timing.")
 
     def _time_inference(self, model: PrunaModel, x: Any) -> float:
         """
@@ -114,26 +135,16 @@ class InferenceTimeStats(BaseMetric):
             The elapsed time in milliseconds.
         """
         if self.timing_type == "async" or self.device == "cpu":
-            startevent_time = time.time()
-            model.run_inference(x)
-            endevent_time = time.time()
+            startevent_time = time.perf_counter()
+            _ = model.run_inference(x)
+            endevent_time = time.perf_counter()
             return (endevent_time - startevent_time) * 1000  # in ms
         elif self.timing_type == "sync":
-            try:
-                device_normalized = torch.device(_resolve_cuda_device(self.device))
-                torch_device_attr = getattr(torch, device_normalized.type)
-            except AttributeError:
-                raise ValueError(f"Device {self.device} not supported for sync timing. Use async timing instead.")
-            startevent = torch_device_attr.Event(enable_timing=True)
-            endevent = torch_device_attr.Event(enable_timing=True)
-            startevent.record()
-            if isinstance(x, dict):
-                _ = model(**x, **model.inference_handler.model_args)
-            else:
-                _ = model(x, **model.inference_handler.model_args)
-            endevent.record()
-            torch_device_attr.synchronize()
-            return startevent.elapsed_time(endevent)  # in ms
+            self.sync_all_cuda_devices(model)
+            t0 = time.perf_counter()
+            _ = model.run_inference(x)
+            self.sync_all_cuda_devices(model)
+            return (time.perf_counter() - t0) * 1_000  # ms
         else:
             raise ValueError(f"Timing type {self.timing_type} not supported.")
 

--- a/src/pruna/evaluation/metrics/metric_elapsed_time.py
+++ b/src/pruna/evaluation/metrics/metric_elapsed_time.py
@@ -21,7 +21,14 @@ import torch
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import device_to_string, get_device, set_to_best_available_device, split_device
+from pruna.engine.utils import (
+    device_to_string,
+    get_device,
+    get_device_map,
+    move_to_device,
+    set_to_best_available_device,
+    split_device,
+)
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -116,7 +123,7 @@ class InferenceTimeStats(BaseMetric):
         if device_type == "cuda":
             torch.cuda.synchronize(device_idx)  # block until all work on this GPU is done
         elif device_type == "accelerate":
-            device_map = model.get_device_map()
+            device_map = get_device_map(model)
             for device in device_map.values():  # iterate over all devices
                 torch.cuda.synchronize(device)
         else:
@@ -173,7 +180,7 @@ class InferenceTimeStats(BaseMetric):
             pruna_logger.warning("Async timing is not supported on CPU. Using sync timing instead.")
 
         model.set_to_eval()
-        model.move_to_device(self.device)
+        move_to_device(model, self.device)
 
         # Warmup
         self._measure(

--- a/src/pruna/evaluation/metrics/metric_energy.py
+++ b/src/pruna/evaluation/metrics/metric_energy.py
@@ -22,7 +22,7 @@ from codecarbon import EmissionsTracker
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import set_to_best_available_device
+from pruna.engine.utils import move_to_device, set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -97,7 +97,7 @@ class EnvironmentalImpactStats(BaseMetric):
         del temp_model
 
         model.set_to_eval()
-        model.move_to_device(self.device)
+        move_to_device(model, self.device)
 
         batch = next(iter(dataloader))
         batch = model.inference_handler.move_inputs_to_device(batch, self.device)

--- a/src/pruna/evaluation/metrics/metric_energy.py
+++ b/src/pruna/evaluation/metrics/metric_energy.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from typing import Any, Dict, cast
-from warnings import warn
 
 import torch
 from codecarbon import EmissionsTracker
@@ -229,28 +228,3 @@ class CO2EmissionsMetric(EnvironmentalImpactStats):
         # Use EvaluationAgent to share computation across environmental impact metrics.
         raw_results = super().compute(model, dataloader)
         return MetricResult.from_results_dict(self.metric_name, self.__dict__.copy(), cast(Dict[str, Any], raw_results))
-
-
-class EnergyMetric:
-    """
-    Deprecated class.
-
-    Parameters
-    ----------
-    *args : Any
-        Arguments for EnvironmentalImpactStats.
-    **kwargs : Any
-        Keyword arguments for EnvironmentalImpactStats.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        """Forwards to EnvironmentalImpactStats."""
-        warn(
-            "Class EnergyMetric is deprecated and will be removed in 'v0.2.8' release. \n"
-            "It has been replaced by EnvironmentalImpactStats, \n"
-            "which is a shared parent class for 'EnergyConsumedMetric' and 'CO2EmissionsMetric'. \n"
-            "In the future please use 'EnergyConsumedMetric' or 'CO2EmissionsMetric' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return EnvironmentalImpactStats(*args, **kwargs)

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -345,7 +345,7 @@ class GPUMemoryStats(BaseMetric):
         """
         with torch.no_grad() if self.mode == INFERENCE_MEMORY else torch.enable_grad():
             batch = next(iter(dataloader))
-            model.run_inference(batch=batch, device=set_to_best_available_device(None))
+            model.run_inference(batch=batch)
 
 
 @MetricRegistry.register(DISK_MEMORY)

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -191,7 +191,7 @@ class GPUMemoryStats(BaseMetric):
             pruna_logger.error("Multiple GPUs detected, but no device map found. Please check the model configuration.")
             raise
         else:
-            model.move_to_device("cuda")
+            move_to_device(model, "cuda")
         return MetricResult(self.mode, self.__dict__.copy(), peak_memory)
 
     def _detect_model_gpus(self, model: PrunaModel) -> List[int]:

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -22,7 +22,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import safe_memory_cleanup, set_to_best_available_device, set_to_train
+from pruna.engine.utils import get_device, safe_memory_cleanup, set_to_best_available_device, set_to_train
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -138,7 +138,7 @@ class GPUMemoryStats(BaseMetric):
         MetricResult
             The peak GPU memory usage in MB.
         """
-        model_device = model.get_device()
+        model_device = get_device(model)
         if not self.is_device_supported(model_device):
             raise ValueError(f"Memory metrics does not support device {model_device}. Must be one of {self.runs_on}.")
         save_path = model.smash_config.cache_dir / "metrics_save"

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -22,7 +22,13 @@ import torch
 from torch.utils.data import DataLoader
 
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import get_device, safe_memory_cleanup, set_to_best_available_device, set_to_train
+from pruna.engine.utils import (
+    get_device,
+    move_to_device,
+    safe_memory_cleanup,
+    set_to_best_available_device,
+    set_to_train,
+)
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -148,7 +154,7 @@ class GPUMemoryStats(BaseMetric):
             pruna_logger.warning("No GPUs found.")
             raise ValueError("No GPUs detected for the model. Memory metric is designed to measure the GPU usage.")
         model.save_pretrained(str(save_path))
-        model.move_to_device("cpu")
+        move_to_device(model, "cpu")
 
         gpu_manager = GPUManager(self.gpu_indices)
         with gpu_manager.manage_resources():
@@ -330,7 +336,7 @@ class GPUMemoryStats(BaseMetric):
             The loaded and prepared model.
         """
         model = model_cls.from_pretrained(model_path)
-        model.move_to_device(set_to_best_available_device(None))
+        move_to_device(model, set_to_best_available_device(None))
         if self.mode in {DISK_MEMORY, INFERENCE_MEMORY}:
             model.set_to_eval()
         elif self.mode == TRAINING_MEMORY:

--- a/src/pruna/evaluation/metrics/metric_model_architecture.py
+++ b/src/pruna/evaluation/metrics/metric_model_architecture.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 
 from pruna.engine.call_sequence_tracker import CallSequenceTracker
 from pruna.engine.pruna_model import PrunaModel
-from pruna.engine.utils import set_to_best_available_device
+from pruna.engine.utils import move_to_device, set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -78,7 +78,7 @@ class ModelArchitectureStats(BaseMetric):
             The MACs and number of parameters of the model during inference.
         """
         model.set_to_eval()
-        model.move_to_device(self.device)
+        move_to_device(model, self.device)
         # wrap the forward method of the model.
         # the wrapper will track the call sequence and input stats for the nn.Modules of the model.
         self.call_tracker.wrap(model)

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -51,10 +51,6 @@ class PairwiseClipScore(CLIPScore, StatefulMetric):
     def __init__(self, **kwargs: Any) -> None:
         device = kwargs.pop("device", None)
         device = set_to_best_available_device(device)
-        if not self.is_device_supported(device):
-            raise ValueError(
-                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
-            )
         if "call_type" in kwargs:
             pruna_logger.error(f"Call type is not supported for {self.metric_name}. Using default call type {PAIRWISE}")
             kwargs.pop("call_type")

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -31,7 +31,7 @@ from pruna.logging.logger import pruna_logger
 
 
 @MetricRegistry.register("pairwise_clip_score")
-class PairwiseClipScore(CLIPScore, StatefulMetric):
+class PairwiseClipScore(CLIPScore, StatefulMetric):  # type: ignore[misc]
     """
     Pairwise CLIP Score metric.
 

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -51,6 +51,10 @@ class PairwiseClipScore(CLIPScore, StatefulMetric):
     def __init__(self, **kwargs: Any) -> None:
         device = kwargs.pop("device", None)
         device = set_to_best_available_device(device)
+        if not self.is_device_supported(device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
         if "call_type" in kwargs:
             pruna_logger.error(f"Call type is not supported for {self.metric_name}. Using default call type {PAIRWISE}")
             kwargs.pop("call_type")
@@ -107,6 +111,10 @@ class PairwiseClipScore(CLIPScore, StatefulMetric):
         device : str | torch.device
             The device to move the metric to.
         """
+        if not self.is_device_supported(device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
         self.to(device)
 
 

--- a/src/pruna/evaluation/metrics/metric_sharpness.py
+++ b/src/pruna/evaluation/metrics/metric_sharpness.py
@@ -21,7 +21,6 @@ import numpy as np
 import torch
 from torch import Tensor
 
-from pruna.engine.utils import device_to_string
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -156,18 +155,3 @@ class SharpnessMetric(StatefulMetric):
         # Otherwise, compute the mean sharpness score over all accumulated samples.
         mean_val = float(np.mean(self.scores))
         return MetricResult(self.metric_name, self.__dict__, mean_val)
-
-    def move_to_device(self, device: str | torch.device) -> None:
-        """
-        Move the metric to a specific device.
-
-        Parameters
-        ----------
-        device : str | torch.device
-            The device to move the metric to.
-        """
-        if not self.is_device_supported(device):
-            raise ValueError(
-                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
-            )
-        self.device = device_to_string(device)

--- a/src/pruna/evaluation/metrics/metric_stateful.py
+++ b/src/pruna/evaluation/metrics/metric_stateful.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List
 import torch
 from torch import Tensor
 
+from pruna.engine.utils import device_to_string, split_device
 from pruna.logging.logger import pruna_logger
 
 
@@ -36,6 +37,7 @@ class StatefulMetric(ABC):
 
     metric_name: str
     call_type: str
+    runs_on: list[str] = ["cuda", "cpu", "mps"]
 
     def __init__(self) -> None:
         """Initialize the StatefulMetric class."""
@@ -124,7 +126,8 @@ class StatefulMetric(ABC):
 
     @abstractmethod
     def move_to_device(self, device: str | torch.device) -> None:
-        """Move the metric to a specific device.
+        """
+        Move the metric to a specific device.
 
         Parameters
         ----------
@@ -132,3 +135,20 @@ class StatefulMetric(ABC):
             The device to move the metric to.
         """
         pass
+
+    def is_device_supported(self, device: str | torch.device) -> bool:
+        """
+        Check if the metric is compatible with the device.
+
+        Parameters
+        ----------
+        device : str | torch.device
+            The device to check.
+
+        Returns
+        -------
+        bool
+            True if the metric is compatible with the device, False otherwise.
+        """
+        dvc, idx = split_device(device_to_string(device))
+        return dvc in self.runs_on

--- a/src/pruna/evaluation/metrics/metric_stateful.py
+++ b/src/pruna/evaluation/metrics/metric_stateful.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from copy import deepcopy
 from typing import Any, Dict, List
 
+import torch
 from torch import Tensor
 
 from pruna.logging.logger import pruna_logger
@@ -120,3 +121,14 @@ class StatefulMetric(ABC):
             True if the metric is pairwise, False otherwise.
         """
         return self.call_type.startswith("pairwise")
+
+    @abstractmethod
+    def move_to_device(self, device: str | torch.device) -> None:
+        """Move the metric to a specific device.
+
+        Parameters
+        ----------
+        device : str | torch.device
+            The device to move the metric to.
+        """
+        pass

--- a/src/pruna/evaluation/metrics/metric_stateful.py
+++ b/src/pruna/evaluation/metrics/metric_stateful.py
@@ -33,6 +33,13 @@ class StatefulMetric(ABC):
     across multiple batches or iterations. Unlike simple metrics that compute values
     independently for each input, stateful metrics track running statistics or
     aggregated values over time.
+
+    Parameters
+    ----------
+    device : str | torch.device | None
+        The device to move the metric to.
+    **kwargs : Any
+        Additional keyword arguments.
     """
 
     metric_name: str

--- a/src/pruna/evaluation/metrics/metric_stateful.py
+++ b/src/pruna/evaluation/metrics/metric_stateful.py
@@ -136,7 +136,6 @@ class StatefulMetric(ABC):
         """
         return self.call_type.startswith("pairwise")
 
-    @abstractmethod
     def move_to_device(self, device: str | torch.device) -> None:
         """
         Move the metric to a specific device.
@@ -146,7 +145,11 @@ class StatefulMetric(ABC):
         device : str | torch.device
             The device to move the metric to.
         """
-        pass
+        if not self.is_device_supported(device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
+        self.device = device_to_string(device)
 
     def is_device_supported(self, device: str | torch.device) -> bool:
         """

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -35,6 +35,7 @@ from torchmetrics.multimodal.clip_score import CLIPScore
 from torchmetrics.text import Perplexity
 from torchvision import transforms
 
+from pruna.engine.utils import device_to_string
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -359,7 +360,7 @@ class TorchMetricWrapper(StatefulMetric):
             raise ValueError(
                 f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
             )
-        self.device = device
+        self.device = device_to_string(device)
         self.metric = self.metric.to(device)
 
 

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -35,7 +35,7 @@ from torchmetrics.multimodal.clip_score import CLIPScore
 from torchmetrics.text import Perplexity
 from torchvision import transforms
 
-from pruna.engine.utils import set_to_best_available_device
+from pruna.engine.utils import device_to_string, set_to_best_available_device, split_device
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -249,6 +249,9 @@ class TorchMetricWrapper(StatefulMetric):
         try:
             device = kwargs.pop("device", None)
             device = set_to_best_available_device(device=device)
+            dvc, idx = split_device(device_to_string(device))
+            if not self.is_device_supported(device):
+                raise ValueError(f"Metric {metric_name} does not support device {dvc}. Must be one of {self.runs_on}.")
             self.metric = TorchMetrics[metric_name](**kwargs)
             with suppress(AttributeError, TypeError):
                 self.metric = self.metric.to(device)
@@ -358,6 +361,10 @@ class TorchMetricWrapper(StatefulMetric):
         device : str | torch.device
             The device to move the metric to.
         """
+        if not self.is_device_supported(device):
+            raise ValueError(
+                f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
+            )
         self.metric = self.metric.to(device)
 
 

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -233,7 +233,6 @@ class TorchMetricWrapper(StatefulMetric):
         if metric_name == "clip_score" and call_type.startswith(PAIRWISE):
             from pruna.evaluation.metrics.metric_pairwise_clip import PairwiseClipScore
 
-            kwargs.pop("device", None)
             return PairwiseClipScore(**kwargs)
         return super().__new__(cls)
 
@@ -349,6 +348,17 @@ class TorchMetricWrapper(StatefulMetric):
             self.__dict__.copy(),
             result_value,
         )
+
+    def move_to_device(self, device: str | torch.device) -> None:
+        """
+        Move the metric to a specific device.
+
+        Parameters
+        ----------
+        device : str | torch.device
+            The device to move the metric to.
+        """
+        self.metric = self.metric.to(device)
 
 
 def get_call_type(call_type: str, metric_name: str) -> str:

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -35,7 +35,6 @@ from torchmetrics.multimodal.clip_score import CLIPScore
 from torchmetrics.text import Perplexity
 from torchvision import transforms
 
-from pruna.engine.utils import device_to_string, set_to_best_available_device, split_device
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 from pruna.evaluation.metrics.result import MetricResult
@@ -245,16 +244,12 @@ class TorchMetricWrapper(StatefulMetric):
         ValueError
             If the metric name is not supported.
         """
-        super().__init__()
+        self.metric_name = metric_name
+        super().__init__(kwargs.pop("device", None))
         try:
-            device = kwargs.pop("device", None)
-            device = set_to_best_available_device(device=device)
-            dvc, idx = split_device(device_to_string(device))
-            if not self.is_device_supported(device):
-                raise ValueError(f"Metric {metric_name} does not support device {dvc}. Must be one of {self.runs_on}.")
             self.metric = TorchMetrics[metric_name](**kwargs)
             with suppress(AttributeError, TypeError):
-                self.metric = self.metric.to(device)
+                self.metric = self.metric.to(self.device)
 
             # Get the specific update function for the metric, or use the default if not found.
             self.update_fn = TorchMetrics[metric_name].update_fn
@@ -264,7 +259,6 @@ class TorchMetricWrapper(StatefulMetric):
         self.call_type = get_call_type(call_type, metric_name)
 
         pruna_logger.info(f"Using call_type: {self.call_type} for metric {metric_name}")
-        self.metric_name = metric_name
         self.higher_is_better = self.metric.higher_is_better if self.metric.higher_is_better is not None else True
 
     def update(self, x: List[Any] | Tensor, gt: List[Any] | Tensor, outputs: Any) -> None:
@@ -365,6 +359,7 @@ class TorchMetricWrapper(StatefulMetric):
             raise ValueError(
                 f"Metric {self.metric_name} does not support device {device}. Must be one of {self.runs_on}."
             )
+        self.device = device
         self.metric = self.metric.to(device)
 
 

--- a/src/pruna/evaluation/metrics/registry.py
+++ b/src/pruna/evaluation/metrics/registry.py
@@ -109,17 +109,20 @@ class MetricRegistry:
             raise ValueError(f"Metric '{name}' is not registered.")
 
         metric_cls = cls._registry[name]
+        device = kwargs.pop("device", None)
         inference_device = kwargs.pop("inference_device", None)
         stateful_metric_device = kwargs.pop("stateful_metric_device", None)
         if isinstance(metric_cls, partial) and "TorchMetricWrapper" in metric_cls.func.__name__:
-            kwargs["device"] = stateful_metric_device
+            kwargs["device"] = stateful_metric_device if stateful_metric_device else device
             return metric_cls(**kwargs)
         elif isclass(metric_cls):
             if issubclass(metric_cls, StatefulMetric):
-                kwargs["device"] = stateful_metric_device
+                kwargs["device"] = stateful_metric_device if stateful_metric_device else device
             elif issubclass(metric_cls, BaseMetric):
-                kwargs["device"] = inference_device
+                kwargs["device"] = inference_device if inference_device else device
             return metric_cls(**filter_load_kwargs(metric_cls, kwargs))
+        elif isinstance(metric_cls, partial):  # For the mock tests
+            return metric_cls(**kwargs)
         else:
             raise ValueError(f"Metric '{metric_cls}' dos not inherit from a valid metric class.")
 

--- a/src/pruna/evaluation/metrics/registry.py
+++ b/src/pruna/evaluation/metrics/registry.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from functools import partial
+from inspect import isclass
 from typing import Any, Callable, Dict, Iterable, List
 
 from pruna.engine.load import filter_load_kwargs
@@ -108,10 +109,19 @@ class MetricRegistry:
             raise ValueError(f"Metric '{name}' is not registered.")
 
         metric_cls = cls._registry[name]
+        inference_device = kwargs.pop("inference_device", None)
+        stateful_metric_device = kwargs.pop("stateful_metric_device", None)
         if isinstance(metric_cls, partial) and "TorchMetricWrapper" in metric_cls.func.__name__:
+            kwargs["device"] = stateful_metric_device
             return metric_cls(**kwargs)
-        else:
+        elif isclass(metric_cls):
+            if issubclass(metric_cls, StatefulMetric):
+                kwargs["device"] = stateful_metric_device
+            elif issubclass(metric_cls, BaseMetric):
+                kwargs["device"] = inference_device
             return metric_cls(**filter_load_kwargs(metric_cls, kwargs))
+        else:
+            raise ValueError(f"Metric '{metric_cls}' dos not inherit from a valid metric class.")
 
     @classmethod
     def get_metrics(cls, names: List[str], **kwargs) -> List[BaseMetric | StatefulMetric]:

--- a/src/pruna/evaluation/metrics/registry.py
+++ b/src/pruna/evaluation/metrics/registry.py
@@ -109,6 +109,7 @@ class MetricRegistry:
             raise ValueError(f"Metric '{name}' is not registered.")
 
         metric_cls = cls._registry[name]
+        # We collect all device related arguments that could be passed to the metric.
         device = kwargs.pop("device", None)
         inference_device = kwargs.pop("inference_device", None)
         stateful_metric_device = kwargs.pop("stateful_metric_device", None)

--- a/src/pruna/evaluation/metrics/utils.py
+++ b/src/pruna/evaluation/metrics/utils.py
@@ -303,18 +303,8 @@ def get_call_type_for_single_metric(call_type_requested: str, default_call_type:
     elif call_type_requested == SINGLE:
         return default_call_type
     else:
-        if call_type_requested == default_call_type or call_type_requested == get_pairwise_pairing(default_call_type):
-            warn(
-                f"Calling metric with its call type is deprecated and will be removed in 'v0.2.8' release. \n"
-                f"Use {SINGLE} or {PAIRWISE} instead. \n"
-                f"Using default call type {default_call_type}.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return default_call_type
-        else:
-            pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
-            raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
 
 
 def ensure_device_consistency(model: PrunaModel, task: Task) -> None:

--- a/src/pruna/evaluation/task.py
+++ b/src/pruna/evaluation/task.py
@@ -67,7 +67,7 @@ class Task:
         self.device = set_to_best_available_device(
             device
         )  # The inference device is set as the task device for evaluation agent and optimization agent.
-        self.stateful_metric_device = self._set_stateful_metric_device_from_task_device()
+        self.stateful_metric_device = self._get_stateful_metric_device_from_task_device()
         self.metrics = _safe_build_metrics(request, self.device, self.stateful_metric_device)
 
         self.datamodule = datamodule
@@ -117,7 +117,7 @@ class Task:
         """
         return any(metric.is_pairwise() for metric in self.metrics if isinstance(metric, StatefulMetric))
 
-    def _set_stateful_metric_device_from_task_device(self) -> str:
+    def _get_stateful_metric_device_from_task_device(self) -> str:
         """
         Return the device for stateful metrics based on the task device.
 

--- a/src/pruna/evaluation/task.py
+++ b/src/pruna/evaluation/task.py
@@ -19,7 +19,7 @@ from typing import Any, List, cast
 import torch
 
 from pruna.data.pruna_datamodule import PrunaDataModule
-from pruna.engine.utils import set_to_best_available_device
+from pruna.engine.utils import device_to_string, find_bytes_free_per_gpu, set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.metric_cmmd import CMMD
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
@@ -57,13 +57,15 @@ class Task:
         datamodule: PrunaDataModule,
         device: str | torch.device | None = None,
     ) -> None:
-        device = set_to_best_available_device(device)
-        self.metrics = get_metrics(request, device)
+        self.auto_device = device is None  # We set this for the compatibility checks later on.
+        self.device = set_to_best_available_device(
+            device
+        )  # The inference device is set as the task device for evaluation agent and optimization agent.
+        self.stateful_metric_device = _set_stateful_metric_device_from_task_device(self.device)
+        self.metrics = _safe_build_metrics(request, self.device, self.stateful_metric_device)
+
         self.datamodule = datamodule
         self.dataloader = datamodule.test_dataloader()
-        if device not in ["cpu", "mps"] and not device.startswith("cuda"):
-            raise ValueError(f"Unsupported device: {device}. Must be one of: cuda, cpu, mps.")
-        self.device = device
 
     def get_single_stateful_metrics(self) -> List[StatefulMetric]:
         """
@@ -110,8 +112,19 @@ class Task:
         return any(metric.is_pairwise() for metric in self.metrics if isinstance(metric, StatefulMetric))
 
 
+def _safe_build_metrics(
+    request: str | List[str | BaseMetric | StatefulMetric], inference_device: str, stateful_metric_device: str
+):
+    try:
+        return get_metrics(request, inference_device, stateful_metric_device)
+    except torch.cuda.OutOfMemoryError as e:
+        if stateful_metric_device == "cuda":
+            pruna_logger.error("Not enough GPU memory for metrics on %s. try `device='cpu'`.", stateful_metric_device)
+        raise e
+
+
 def get_metrics(
-    request: str | List[str | BaseMetric | StatefulMetric], device: str | torch.device | None = None
+    request: str | List[str | BaseMetric | StatefulMetric], inference_device: str, stateful_metric_device: str
 ) -> List[BaseMetric | StatefulMetric]:
     """
     Convert user requests into a list of metrics.
@@ -120,35 +133,45 @@ def get_metrics(
     ----------
     request : str | List[str]
         The user request. Right now, it only supports image generation quality.
-    device : str | torch.device | None, optional
-        The device to be used, e.g., 'cuda' or 'cpu'. Default is None.
+    inference_device : str | torch.device | None, optional
+        The device to be used for inference, e.g., 'cuda' or 'cpu'. Default is None.
+        If None, the best available device will be used.
+    stateful_metric_device : str | torch.device | None, optional
+        The device to be used for stateful metrics, e.g., 'cuda' or 'cpu'. Default is None.
         If None, the best available device will be used.
 
     Returns
     -------
     List[BaseMetric | StatefulMetric]
         The list of metrics for the task.
-
-    Raises
-    ------
-    NotImplementedError
-        _description_
-    ValueError
-        _description_
     """
     if isinstance(request, List):
         if all(isinstance(item, BaseMetric | StatefulMetric) for item in request):
-            return _process_metric_instances(request=cast(List[BaseMetric | StatefulMetric], request))
+            return _process_metric_instances(
+                request=cast(List[BaseMetric | StatefulMetric], request),
+                inference_device=inference_device,
+                stateful_metric_device=stateful_metric_device,
+            )
         elif all(isinstance(item, str) for item in request):
-            return _process_metric_names(request=cast(List[str], request), device=device)
+            return _process_metric_names(
+                request=cast(List[str], request),
+                inference_device=inference_device,
+                stateful_metric_device=stateful_metric_device,
+            )
         else:
             pruna_logger.error("List must contain either all strings or all [BaseMetric | StatefulMetric] instances.")
             raise ValueError("List must contain either all strings or all [BaseMetric | StatefulMetric] instances.")
     else:
-        return _process_single_request(request, device)
+        return _process_single_request(
+            request=cast(str, request), inference_device=inference_device, stateful_metric_device=stateful_metric_device
+        )
 
 
-def _process_metric_instances(request: List[BaseMetric | StatefulMetric]) -> List[BaseMetric | StatefulMetric]:
+def _process_metric_instances(
+    request: List[BaseMetric | StatefulMetric],
+    inference_device: str,
+    stateful_metric_device: str,
+) -> List[BaseMetric | StatefulMetric]:
     pruna_logger.info("Using provided list of metric instances.")
     new_request_metrics: List[BaseMetric | StatefulMetric] = []
     for metric in request:
@@ -156,29 +179,58 @@ def _process_metric_instances(request: List[BaseMetric | StatefulMetric]) -> Lis
             for child in metric.__class__.__subclasses__():
                 child = cast(type[BaseMetric], child)
                 hyperparameters = get_hyperparameters(metric, metric.__class__.__init__)
+                if (
+                    "device" in hyperparameters and hyperparameters["device"] != inference_device
+                ):  # We check with inference device because everything in PARENT_METRICS is a BaseMetric.
+                    pruna_logger.warning(
+                        f"The task is requested to run on {inference_device}, but the metric {metric.metric_name} "
+                        f"is configured to run on {hyperparameters['device']}."
+                    )
+                    pruna_logger.info(f"Setting the metric to run on {inference_device}.")
+                    hyperparameters["device"] = inference_device
                 new_request_metrics.append(MetricRegistry.get_metric(child.metric_name, **hyperparameters))
         else:
+            if isinstance(metric, BaseMetric):
+                metric.device = device_to_string(inference_device)
+            else:
+                metric.move_to_device(stateful_metric_device)
             new_request_metrics.append(cast(BaseMetric | StatefulMetric, metric))
     return new_request_metrics
 
 
-def _process_metric_names(request: List[str], device: str | torch.device | None) -> List[BaseMetric | StatefulMetric]:
+def _process_metric_names(
+    request: List[str], inference_device: str, stateful_metric_device: str
+) -> List[BaseMetric | StatefulMetric]:
     pruna_logger.info(f"Creating metrics from names: {request}")
     new_requests: List[str] = []
     for metric_name in request:
         metric_name = cast(str, metric_name)
         new_requests.append(cast(str, metric_name))
-    return MetricRegistry.get_metrics(names=new_requests, device=device)
+    return MetricRegistry.get_metrics(
+        names=new_requests, inference_device=inference_device, stateful_metric_device=stateful_metric_device
+    )
 
 
-def _process_single_request(request: str, device: str | torch.device | None) -> List[BaseMetric | StatefulMetric]:
+def _process_single_request(
+    request: str, stateful_metric_device: str, inference_device: str
+) -> List[BaseMetric | StatefulMetric]:
     if request == "image_generation_quality":
         pruna_logger.info("An evaluation task for image generation quality is being created.")
         return [
-            TorchMetricWrapper("clip_score"),
-            TorchMetricWrapper("clip_score", call_type="pairwise"),
-            CMMD(device=device),
+            TorchMetricWrapper("clip_score", device=stateful_metric_device),
+            TorchMetricWrapper("clip_score", call_type="pairwise", device=stateful_metric_device),
+            CMMD(device=stateful_metric_device),
         ]
     else:
         pruna_logger.error(f"Metric {request} not found. Available requests: {AVAILABLE_REQUESTS}.")
         raise ValueError(f"Metric {request} not found. Available requests: {AVAILABLE_REQUESTS}.")
+
+
+def _set_stateful_metric_device_from_task_device(task_device: str) -> str:
+    if task_device == "accelerate":
+        return "cpu"  # We will move them to the device later after inference is done.
+    elif task_device == "cuda":
+        bytes_free_per_gpu = find_bytes_free_per_gpu()
+        return set_to_best_available_device("cuda", bytes_free_per_gpu)
+    else:
+        return task_device  # for when we pass a specific cuda device, or cpu or mps.

--- a/tests/evaluation/test_cmmd.py
+++ b/tests/evaluation/test_cmmd.py
@@ -79,6 +79,7 @@ def test_task_cmmd_pairwise(model_fixture: tuple[Any, SmashConfig], device: str,
 def test_cmmd_pairwise_direct_params(model_fixture: tuple[Any, SmashConfig], device: str, clip_model: str):
     """Test CMMD pairwise using direct parameters to EvaluationAgent."""
     model, _ = model_fixture
+    move_to_device(model, device)
     data_module = PrunaDataModule.from_string("LAION256")
     data_module.limit_datasets(10)
 

--- a/tests/evaluation/test_cmmd.py
+++ b/tests/evaluation/test_cmmd.py
@@ -8,7 +8,7 @@ from pruna.engine.pruna_model import PrunaModel
 from pruna.evaluation.evaluation_agent import EvaluationAgent
 from pruna.evaluation.metrics.metric_cmmd import CMMD
 from pruna.evaluation.task import Task
-
+from pruna.engine.utils import move_to_device
 @pytest.mark.parametrize(
     "model_fixture, device, clip_model",
     [
@@ -52,6 +52,7 @@ def test_cmmd(model_fixture: tuple[Any, SmashConfig], device: str, clip_model: s
 def test_task_cmmd_pairwise(model_fixture: tuple[Any, SmashConfig], device: str, clip_model: str):
     """Test CMMD pairwise."""
     model, _ = model_fixture
+    move_to_device(model, device)
     data_module = PrunaDataModule.from_string("LAION256")
     data_module.limit_datasets(10)
 

--- a/tests/evaluation/test_cmmd.py
+++ b/tests/evaluation/test_cmmd.py
@@ -21,7 +21,7 @@ def test_cmmd(model_fixture: tuple[Any, SmashConfig], device: str, clip_model: s
     model, smash_config = model_fixture
     smash_config.device = device
     pruna_model = PrunaModel(model, smash_config=smash_config)
-
+    move_to_device(pruna_model, device)
     metric = CMMD(clip_model_name=clip_model, device=device)
 
     batch = next(iter(smash_config.test_dataloader()))

--- a/tests/evaluation/test_cmmd.py
+++ b/tests/evaluation/test_cmmd.py
@@ -26,7 +26,7 @@ def test_cmmd(model_fixture: tuple[Any, SmashConfig], device: str, clip_model: s
 
     batch = next(iter(smash_config.test_dataloader()))
     x, gt = batch
-    outputs = pruna_model.run_inference(batch, device)
+    outputs = pruna_model.run_inference(batch)
 
     # Calculate CMMD between model outputs and ground truth
     metric.update(x, gt, outputs)

--- a/tests/evaluation/test_device_compatibility.py
+++ b/tests/evaluation/test_device_compatibility.py
@@ -1,0 +1,162 @@
+import pytest
+import torch
+
+from ..common import construct_device_map_manually
+from pruna.evaluation.task import Task
+from pruna.evaluation.evaluation_agent import EvaluationAgent
+from pruna.data.pruna_datamodule import PrunaDataModule
+from pruna.engine.utils import move_to_device, split_device, device_to_string
+from pruna.evaluation.metrics.metric_base import BaseMetric
+from pruna.evaluation.metrics.metric_stateful import StatefulMetric
+from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric
+from pruna.evaluation.metrics.metric_pairwise_clip import PairwiseClipScore
+from pruna.evaluation.metrics.metric_cmmd import CMMD
+from typing import Any, List
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
+@pytest.mark.parametrize(
+    "datamodule_fixture, model_fixture, evaluation_request",
+    [
+        ("LAION256",  "sd_tiny_random", list(('latency', 'cmmd', 'psnr', 'pairwise_clip_score'))),
+        ("LAION256", "sd_tiny_random", list(('latency', 'cmmd', 'psnr', 'pairwise_clip_score'))),
+    ],
+    indirect=["datamodule_fixture", "model_fixture"],
+)
+def test_auto_device_task_adapts_to_accelerate_model(datamodule_fixture: PrunaDataModule, model_fixture: Any, evaluation_request: List[str]):
+
+    task = Task(request=evaluation_request, datamodule=datamodule_fixture, device=None)
+    agent = EvaluationAgent(task)
+
+    model, _ = model_fixture
+    device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+
+    model = agent.prepare_model(model)
+
+    assert split_device(device_to_string(model.get_device())) == split_device(device_to_string(agent.device))
+    assert split_device(device_to_string(agent.device)) == split_device(device_to_string(task.device))
+    assert split_device(device_to_string(task.stateful_metric_device)) == split_device(device_to_string("cpu"))
+    for metric in task.metrics:
+        if isinstance(metric, BaseMetric):
+            assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.device))
+        elif isinstance(metric, StatefulMetric): # Stateful metrics should not be moved
+            if hasattr(metric, "device"):
+                assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.stateful_metric_device))
+            elif hasattr(metric, "metric") and hasattr(metric.metric, "device"): # Wrapper metric
+                assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.stateful_metric_device))
+            else:
+                raise ValueError("Could not find device for metric.")
+
+@pytest.mark.cuda
+@pytest.mark.parametrize(
+    "datamodule_fixture,model_device, model_fixture, evaluation_request",
+    [
+        ("LAION256", "cpu", "sd_tiny_random", list(('latency', 'cmmd', 'psnr', 'pairwise_clip_score'))),
+        ("LAION256", "cuda", "sd_tiny_random", list(('latency', 'cmmd', 'psnr', 'pairwise_clip_score'))),
+    ],
+    indirect=["datamodule_fixture", "model_fixture"],
+)
+def test_auto_device_task_adapts_to_model(datamodule_fixture: PrunaDataModule, model_device: str, model_fixture: Any, evaluation_request: List[str]):
+    task = Task(request=evaluation_request, datamodule=datamodule_fixture)
+    agent = EvaluationAgent(task)
+
+    model, _ = model_fixture
+    move_to_device(model, model_device)
+    model = agent.prepare_model(model)
+
+    assert split_device(device_to_string(model.get_device())) == split_device(device_to_string(task.device))
+    assert split_device(device_to_string(task.device)) == split_device(device_to_string(agent.device))
+    assert split_device(device_to_string(task.stateful_metric_device)) == split_device(device_to_string(task.device))
+    for metric in task.metrics:
+        if isinstance(metric, BaseMetric):
+            assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.device))
+        elif isinstance(metric, StatefulMetric):
+            if hasattr(metric, "device"):
+                assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.device))
+            elif hasattr(metric, "metric") and hasattr(metric.metric, "device"):
+                assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.device))
+            else:
+                raise ValueError("Could not find device for metric.")
+
+
+@pytest.mark.cuda
+@pytest.mark.parametrize(
+    "datamodule_fixture,model_fixture,task_device,model_device",
+    [
+        ("LAION256", "sd_tiny_random", "cuda", "cpu"),
+        ("LAION256", "sd_tiny_random", "cpu", "cuda"),
+    ],
+    indirect=["datamodule_fixture", "model_fixture"],
+)
+def test_ensure_task_model_device_mismatch_raises(datamodule_fixture: PrunaDataModule, model_fixture: Any, task_device: str, model_device: str):
+    task = Task(request=["latency", "cmmd", "pairwise_clip_score"], datamodule=datamodule_fixture, device=task_device)
+    agent = EvaluationAgent(task)
+
+    model, _ = model_fixture
+    move_to_device(model, model_device)
+    with pytest.raises(ValueError):
+        model = agent.prepare_model(model)
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
+@pytest.mark.parametrize(
+    "datamodule_fixture,model_fixture,task_device",
+    [
+        ("LAION256", "sd_tiny_random", "cuda"),
+        ("LAION256", "sd_tiny_random", "cpu"),
+    ],
+    indirect=["datamodule_fixture", "model_fixture"],
+)
+def test_ensure_task_model_accelerate_device_mismatch_raises(datamodule_fixture: PrunaDataModule, model_fixture: Any, task_device:str):
+    task = Task(request=["latency", "cmmd", "pairwise_clip_score"], datamodule=datamodule_fixture, device=task_device)
+    agent = EvaluationAgent(task)
+
+    model, _ = model_fixture
+    device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+
+    with pytest.raises(ValueError):
+        agent.prepare_model(model)
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
+@pytest.mark.parametrize(
+    "datamodule_fixture,model_fixture",
+    [
+        ("LAION256", "sd_tiny_random"),
+    ],
+    indirect=["datamodule_fixture", "model_fixture"],
+)
+def test_mismatched_metric_instances_adapts_to_model(datamodule_fixture: PrunaDataModule, model_fixture: Any):
+    latency = LatencyMetric(device="cpu")
+    cmmd = CMMD(device="cpu")
+    pairwise_clip_score = PairwiseClipScore(device="cpu")
+
+    task = Task(request=[latency, cmmd, pairwise_clip_score], datamodule=datamodule_fixture)
+    task_device , task_idx = split_device(device_to_string(task.device))
+
+    # Right now auto device casting will set the task device to cuda.
+    # We need to make sure to write additional tests for when it can return a different device.
+    assert task_device == "cuda"
+    agent = EvaluationAgent(task)
+
+    model, _ = model_fixture
+    device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+
+    model = agent.prepare_model(model)
+    assert split_device(device_to_string(model.get_device())) == split_device(device_to_string(task.device))
+    assert split_device(device_to_string(task.device)) == split_device(device_to_string(agent.device))
+    assert split_device(device_to_string(task.stateful_metric_device)) == split_device(device_to_string("cpu"))
+    for metric in task.metrics:
+        if isinstance(metric, BaseMetric):
+            assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.device))
+        elif isinstance(metric, StatefulMetric):
+            if hasattr(metric, "device"):
+                assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.stateful_metric_device))
+            elif hasattr(metric, "metric") and hasattr(metric.metric, "device"):
+                assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.stateful_metric_device))
+            else:
+                raise ValueError("Could not find device for metric.")

--- a/tests/evaluation/test_energy_metrics.py
+++ b/tests/evaluation/test_energy_metrics.py
@@ -5,6 +5,7 @@ import pytest
 from pruna import PrunaModel, SmashConfig
 from pruna.evaluation.metrics.metric_energy import EnergyConsumedMetric, CO2EmissionsMetric, ENERGY_CONSUMED, CO2_EMISSIONS
 from pruna.evaluation.metrics.registry import MetricRegistry
+from pruna.engine.utils import move_to_device
 
 
 @pytest.mark.parametrize(
@@ -20,6 +21,7 @@ def test_energy_consumed_metric(model_fixture: tuple[Any, SmashConfig], device: 
     model, smash_config = model_fixture
     metric = EnergyConsumedMetric(n_iterations=5, n_warmup_iterations=5, device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result >= 0  # Assuming energy consumption should be non-negative
 
@@ -36,6 +38,7 @@ def test_co2_emissions_metric(model_fixture: tuple[Any, SmashConfig], device: st
     model, smash_config = model_fixture
     metric = CO2EmissionsMetric(n_iterations=5, n_warmup_iterations=5, device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result >= 0  # Assuming CO2 emissions should be non-negative
 

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -7,7 +7,7 @@ from ..common import construct_device_map_manually
 from pruna import SmashConfig
 from pruna.engine.pruna_model import PrunaModel
 from pruna.engine.utils import move_to_device, get_device, get_device_map
-from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric
+from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric, LATENCY
 from pruna.evaluation.evaluation_agent import EvaluationAgent
 
 @pytest.mark.parametrize(

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -1,10 +1,14 @@
 from typing import Any
 
 import pytest
+import torch
 
+from ..common import construct_device_map_manually
 from pruna import SmashConfig
 from pruna.engine.pruna_model import PrunaModel
+from pruna.engine.utils import move_to_device, get_device, get_device_map
 from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric
+from pruna.evaluation.evaluation_agent import EvaluationAgent
 
 @pytest.mark.parametrize(
     "model_fixture, device",
@@ -21,6 +25,56 @@ def test_latency_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> 
     pruna_model = PrunaModel(model, smash_config=smash_config)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result > 0  # Assuming latency should be positive
+
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
+@pytest.mark.parametrize(
+    "model_fixture",
+    [
+        "sd_tiny_random",
+    ],
+    indirect=["model_fixture"],
+)
+def test_latency_metric_distributed(model_fixture: tuple[Any, SmashConfig]):
+    """Test the latency metric."""
+    model, smash_config = model_fixture
+    device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+
+    metric = LatencyMetric(n_iterations=5, n_warmup_iterations=5, device="accelerate")
+    pruna_model = PrunaModel(model, smash_config=smash_config)
+    results = metric.compute(pruna_model, smash_config.test_dataloader())
+
+    assert pruna_model.get_device() == "accelerate"
+    assert pruna_model.get_device_map() == device_map
+    assert results.result > 0  # Assuming latency should be positive
+
+@pytest.mark.distributed
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
+@pytest.mark.parametrize(
+    "model_fixture",
+    [
+        "sd_tiny_random",
+    ],
+    indirect=["model_fixture"],
+)
+def test_latency_metric_distributed_agent(model_fixture: tuple[Any, SmashConfig]):
+    """Test the latency metric."""
+    model, smash_config = model_fixture
+    device_map = construct_device_map_manually(model)
+    move_to_device(model, "accelerate", device_map=device_map)
+
+    request = [LATENCY]
+
+    eval_agent = EvaluationAgent(request=request, datamodule=smash_config.data, device="accelerate")
+    eval_agent.task.metrics[0].n_iterations = 5
+    eval_agent.task.metrics[0].n_warmup_iterations = 5
+    results =eval_agent.evaluate(model)
+
+    assert get_device(model) == "accelerate"
+    assert get_device_map(model) == device_map
+    assert results[0].result > 0
 
 @pytest.mark.parametrize(
     "model_fixture, device",

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -46,8 +46,8 @@ def test_latency_metric_distributed(model_fixture: tuple[Any, SmashConfig]):
     pruna_model = PrunaModel(model, smash_config=smash_config)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
 
-    assert pruna_model.get_device() == "accelerate"
-    assert pruna_model.get_device_map() == device_map
+    assert get_device(model) == "accelerate"
+    assert get_device_map(model) == device_map
     assert results.result > 0  # Assuming latency should be positive
 
 @pytest.mark.distributed

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -23,6 +23,7 @@ def test_latency_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> 
     model, smash_config = model_fixture
     metric = LatencyMetric(n_iterations=5, n_warmup_iterations=5, device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result > 0  # Assuming latency should be positive
 
@@ -89,6 +90,7 @@ def test_throughput_metric(model_fixture: tuple[Any, SmashConfig], device: str) 
     model, smash_config = model_fixture
     metric = ThroughputMetric(n_iterations=5, n_warmup_iterations=5, device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result > 0  # Assuming throughput should be positive
 
@@ -105,5 +107,6 @@ def test_total_time_metric(model_fixture: tuple[Any, SmashConfig], device: str) 
     model, smash_config = model_fixture
     metric = TotalTimeMetric(n_iterations=5, n_warmup_iterations=5, device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result > 0  # Assuming total time should be positive

--- a/tests/evaluation/test_memory_metrics.py
+++ b/tests/evaluation/test_memory_metrics.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 from pruna import PrunaModel, SmashConfig
+from pruna.engine.utils import move_to_device
 from pruna.evaluation.metrics.metric_memory import DiskMemoryMetric, InferenceMemoryMetric, TrainingMemoryMetric
 
 @pytest.mark.cuda
@@ -18,7 +19,7 @@ def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     model, smash_config = model_fixture
     disk_memory_metric = DiskMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
-    pruna_model.move_to_device("cuda")
+    move_to_device(pruna_model, "cuda")
     disk_memory_results = disk_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert disk_memory_results.result > 0
 
@@ -35,7 +36,7 @@ def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None
     model, smash_config = model_fixture
     inference_memory_metric = InferenceMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
-    pruna_model.move_to_device("cuda")
+    move_to_device(pruna_model, "cuda")
     inference_memory_results = inference_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert inference_memory_results.result > 0
 
@@ -52,7 +53,7 @@ def test_training_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     model, smash_config = model_fixture
     training_memory_metric = TrainingMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
-    pruna_model.move_to_device("cuda")
+    move_to_device(pruna_model, "cuda")
     training_memory_results = training_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert training_memory_results.result > 0
 
@@ -68,7 +69,7 @@ def test_memory_metric_raises_when_device_is_not_cuda(model_fixture: tuple[Any, 
     model, smash_config = model_fixture
     dmm = DiskMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
-    pruna_model.move_to_device("cpu")
+    move_to_device(pruna_model, "cpu")
     with pytest.raises(ValueError):
         dmm.compute(pruna_model, smash_config.test_dataloader())
     imm = InferenceMemoryMetric()

--- a/tests/evaluation/test_memory_metrics.py
+++ b/tests/evaluation/test_memory_metrics.py
@@ -5,15 +5,15 @@ import pytest
 from pruna import PrunaModel, SmashConfig
 from pruna.evaluation.metrics.metric_memory import DiskMemoryMetric, InferenceMemoryMetric, TrainingMemoryMetric
 
-
+@pytest.mark.cuda
 @pytest.mark.parametrize(
-    "model_fixture, device",
+    "model_fixture",
     [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
+       "sd_tiny_random",
     ],
     indirect=["model_fixture"],
 )
-def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
+def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     """Test the disk memory metric."""
     model, smash_config = model_fixture
     disk_memory_metric = DiskMemoryMetric()
@@ -22,15 +22,15 @@ def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig], device: str)
     disk_memory_results = disk_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert disk_memory_results.result > 0
 
-
+@pytest.mark.cuda
 @pytest.mark.parametrize(
-    "model_fixture, device",
+    "model_fixture",
     [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
+        "sd_tiny_random",
     ],
     indirect=["model_fixture"],
 )
-def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
+def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     """Test the inference memory metric."""
     model, smash_config = model_fixture
     inference_memory_metric = InferenceMemoryMetric()
@@ -39,15 +39,15 @@ def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig], device:
     inference_memory_results = inference_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert inference_memory_results.result > 0
 
-
+@pytest.mark.cuda
 @pytest.mark.parametrize(
-    "model_fixture, device",
+    "model_fixture",
     [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
+        "sd_tiny_random",
     ],
     indirect=["model_fixture"],
 )
-def test_training_memory_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
+def test_training_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     """Test the training memory metric."""
     model, smash_config = model_fixture
     training_memory_metric = TrainingMemoryMetric()
@@ -55,3 +55,25 @@ def test_training_memory_metric(model_fixture: tuple[Any, SmashConfig], device: 
     pruna_model.move_to_device("cuda")
     training_memory_results = training_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert training_memory_results.result > 0
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "model_fixture",
+    [
+        "sd_tiny_random",
+    ],
+    indirect=["model_fixture"],
+)
+def test_memory_metric_raises_when_device_is_not_cuda(model_fixture: tuple[Any, SmashConfig]):
+    model, smash_config = model_fixture
+    dmm = DiskMemoryMetric()
+    pruna_model = PrunaModel(model, smash_config=smash_config)
+    pruna_model.move_to_device("cpu")
+    with pytest.raises(ValueError):
+        dmm.compute(pruna_model, smash_config.test_dataloader())
+    imm = InferenceMemoryMetric()
+    with pytest.raises(ValueError):
+        imm.compute(pruna_model, smash_config.test_dataloader())
+    tmm = TrainingMemoryMetric()
+    with pytest.raises(ValueError):
+        tmm.compute(pruna_model, smash_config.test_dataloader())

--- a/tests/evaluation/test_model_architecture_metrics.py
+++ b/tests/evaluation/test_model_architecture_metrics.py
@@ -5,7 +5,7 @@ import pytest
 from pruna import SmashConfig
 from pruna.engine.pruna_model import PrunaModel
 from pruna.evaluation.metrics.metric_model_architecture import TotalMACsMetric, TotalParamsMetric
-
+from pruna.engine.utils import move_to_device
 
 @pytest.mark.parametrize(
     "model_fixture, device",
@@ -20,6 +20,7 @@ def test_total_macs_metric(model_fixture: tuple[Any, SmashConfig], device: str) 
     model, smash_config = model_fixture
     macs_metric = TotalMACsMetric(device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     macs_results = macs_metric.compute(pruna_model, smash_config.test_dataloader())
     assert macs_results.result > 0
 
@@ -37,5 +38,6 @@ def test_total_params_metric(model_fixture: tuple[Any, SmashConfig], device: str
     model, smash_config = model_fixture
     params_metric = TotalParamsMetric(device=device)
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
     params_results = params_metric.compute(pruna_model, smash_config.test_dataloader())
     assert params_results.result > 0

--- a/tests/evaluation/test_sharpness.py
+++ b/tests/evaluation/test_sharpness.py
@@ -10,6 +10,7 @@ from pruna.engine.pruna_model import PrunaModel
 from pruna.evaluation.evaluation_agent import EvaluationAgent
 from pruna.evaluation.metrics.metric_sharpness import SharpnessMetric
 from pruna.evaluation.task import Task
+from pruna.engine.utils import move_to_device
 
 
 @pytest.mark.parametrize(
@@ -25,13 +26,14 @@ def test_sharpness(model_fixture: tuple[Any, SmashConfig], device: str, kernel_s
     model, smash_config = model_fixture
     smash_config.device = device
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    move_to_device(pruna_model, device)
 
 
     metric = SharpnessMetric(kernel_size=kernel_size, device=device)
 
     batch = next(iter(smash_config.test_dataloader()))
     x, gt = batch
-    outputs = pruna_model.run_inference(batch, device)
+    outputs = pruna_model.run_inference(batch)
 
     # Calculate sharpness for model outputs
     metric.update(x, gt, outputs)
@@ -96,6 +98,7 @@ def test_sharpness_blurry_vs_sharp():
 def test_task_sharpness_from_instance(model_fixture: tuple[Any, SmashConfig], device: str, kernel_size: int):
     """Test EvaluationAgent with SharpnessMetric instance."""
     model, _ = model_fixture
+    move_to_device(model, device)
     data_module = PrunaDataModule.from_string("LAION256")
     data_module.limit_datasets(10)
 
@@ -126,6 +129,7 @@ def test_task_sharpness_from_instance(model_fixture: tuple[Any, SmashConfig], de
 def test_task_sharpness_from_string(model_fixture: tuple[Any, SmashConfig], device: str):
     """Test EvaluationAgent with sharpness metric specified as string."""
     model, _ = model_fixture
+    move_to_device(model, device)
     data_module = PrunaDataModule.from_string("LAION256")
     data_module.limit_datasets(10)
 

--- a/tests/evaluation/test_task.py
+++ b/tests/evaluation/test_task.py
@@ -79,6 +79,7 @@ def test_device_is_set_correctly_for_metrics(device:str):
     ],
 )
 def test_metric_device_adapts_to_task_device(inference_device: str, stateful_metric_device: str, task_device: str):
+    """ Test that the metrics in the task are moved to the task device if they are on a different device."""
     latency = LatencyMetric(device=inference_device)
     cmmd = CMMD(device=stateful_metric_device)
     pairwise_clip_score = PairwiseClipScore(device=stateful_metric_device)

--- a/tests/evaluation/test_task.py
+++ b/tests/evaluation/test_task.py
@@ -97,3 +97,11 @@ def test_metric_device_adapts_to_task_device(inference_device: str, stateful_met
                 assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.stateful_metric_device))
             else:
                 raise ValueError("Could not find device for metric.")
+
+@pytest.mark.cpu
+def test_task_from_string_request():
+    request = ["cmmd", "pairwise_clip_score", "psnr"]
+    task = Task(request=request, datamodule=PrunaDataModule.from_string("LAION256"), device = "cpu")
+    assert isinstance(task.metrics[0], CMMD)
+    assert isinstance(task.metrics[1], PairwiseClipScore)
+    assert isinstance(task.metrics[2], TorchMetricWrapper)

--- a/tests/evaluation/test_task.py
+++ b/tests/evaluation/test_task.py
@@ -51,8 +51,7 @@ def test_device_is_set_correctly_for_metrics(device:str):
         elif isinstance(metric, StatefulMetric):
             if hasattr(metric, 'metric'):
                 assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.stateful_metric_device))
-            else:
-                assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.stateful_metric_device))
+            assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.stateful_metric_device))
 
 
 @pytest.mark.cuda
@@ -93,9 +92,9 @@ def test_metric_device_adapts_to_task_device(inference_device: str, stateful_met
         elif isinstance(metric, StatefulMetric):
             if hasattr(metric, "device"):
                 assert split_device(device_to_string(metric.device)) == split_device(device_to_string(task.stateful_metric_device))
-            elif hasattr(metric, "metric") and hasattr(metric.metric, "device"): # Wrapper metric
+            if hasattr(metric, "metric") and hasattr(metric.metric, "device"): # Wrapper metric
                 assert split_device(device_to_string(metric.metric.device)) == split_device(device_to_string(task.stateful_metric_device))
-            else:
+            if not hasattr(metric, "device") and not hasattr(metric.metric, "device"):
                 raise ValueError("Could not find device for metric.")
 
 @pytest.mark.cpu

--- a/tests/evaluation/test_torch_metrics.py
+++ b/tests/evaluation/test_torch_metrics.py
@@ -6,11 +6,17 @@ import torch
 from pruna.evaluation.metrics.metric_torch import TorchMetricWrapper, TorchMetrics
 from pruna.data.pruna_datamodule import PrunaDataModule
 
-@pytest.mark.cuda
-@pytest.mark.parametrize("datamodule_fixture", ["WikiText"], indirect=True)
-def test_perplexity(datamodule_fixture: PrunaDataModule) -> None:
+@pytest.mark.parametrize(
+    "datamodule_fixture, device",
+    [
+        pytest.param("WikiText", "cpu", marks=pytest.mark.cpu),
+        pytest.param("WikiText", "cuda", marks=pytest.mark.cuda),
+    ],
+    indirect=["datamodule_fixture"],
+)
+def test_perplexity(datamodule_fixture: PrunaDataModule, device: str) -> None:
     """Test the perplexity."""
-    metric = TorchMetricWrapper("perplexity")
+    metric = TorchMetricWrapper("perplexity", device=device)
     dataloader = datamodule_fixture.val_dataloader()
 
     _, gt = next(iter(dataloader))
@@ -27,11 +33,17 @@ def test_perplexity(datamodule_fixture: PrunaDataModule) -> None:
     assert result.result == 1.0
 
 
-@pytest.mark.cpu
-@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
-def test_fid(datamodule_fixture: PrunaDataModule) -> None:
+@pytest.mark.parametrize(
+    "datamodule_fixture, device",
+    [
+        pytest.param("LAION256", "cpu", marks=pytest.mark.cpu),
+        pytest.param("LAION256", "cuda", marks=pytest.mark.cuda),
+    ],
+    indirect=["datamodule_fixture"],
+)
+def test_fid(datamodule_fixture: PrunaDataModule, device: str) -> None:
     """Test the fid."""
-    metric = TorchMetricWrapper("fid")
+    metric = TorchMetricWrapper("fid", device=device)
     dataloader = datamodule_fixture.val_dataloader()
     dataloader_iter = iter(dataloader)
 
@@ -42,11 +54,17 @@ def test_fid(datamodule_fixture: PrunaDataModule) -> None:
     assert metric.compute().result == pytest.approx(0.0, abs=1e-2)
 
 
-@pytest.mark.cpu
-@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
-def test_clip_score(datamodule_fixture: PrunaDataModule) -> None:
+@pytest.mark.parametrize(
+    "datamodule_fixture, device",
+    [
+        pytest.param("LAION256", "cpu", marks=pytest.mark.cpu),
+        pytest.param("LAION256", "cuda", marks=pytest.mark.cuda),
+    ],
+    indirect=["datamodule_fixture"],
+)
+def test_clip_score(datamodule_fixture: PrunaDataModule, device: str) -> None:
     """Test the clip score."""
-    metric = TorchMetricWrapper("clip_score")
+    metric = TorchMetricWrapper("clip_score", device=device)
     dataloader = datamodule_fixture.val_dataloader()
     dataloader_iter = iter(dataloader)
 
@@ -66,12 +84,21 @@ def test_clipiqa(dataloader_fixture: Any) -> None:
     assert score.result > 0.0 and score.result < 1.0
 
 
-@pytest.mark.cpu
-@pytest.mark.parametrize("datamodule_fixture", ["ImageNet"], indirect=True)
-@pytest.mark.parametrize("metric", ["accuracy", "recall", "precision"])
-def test_torch_metrics(datamodule_fixture: PrunaDataModule, metric: str) -> None:
+@pytest.mark.parametrize(
+    "datamodule_fixture, device, metric",
+    [
+        pytest.param("ImageNet", "cpu", "accuracy", marks=pytest.mark.cpu),
+        pytest.param("ImageNet", "cuda", "accuracy", marks=pytest.mark.cuda),
+        pytest.param("ImageNet", "cpu", "recall", marks=pytest.mark.cpu),
+        pytest.param("ImageNet", "cuda", "recall", marks=pytest.mark.cuda),
+        pytest.param("ImageNet", "cpu", "precision", marks=pytest.mark.cpu),
+        pytest.param("ImageNet", "cuda", "precision", marks=pytest.mark.cuda),
+    ],
+    indirect=["datamodule_fixture"],
+)
+def test_torch_metrics(datamodule_fixture: PrunaDataModule, device: str, metric: str) -> None:
     """Test the torch metrics accuracy, recall, precision."""
-    metric = TorchMetricWrapper(metric, task="multiclass", num_classes=1000)
+    metric = TorchMetricWrapper(metric, task="multiclass", num_classes=1000, device=device)
     dataloader = datamodule_fixture.val_dataloader()
     dataloader_iter = iter(dataloader)
 

--- a/tests/evaluation/test_torch_metrics.py
+++ b/tests/evaluation/test_torch_metrics.py
@@ -4,15 +4,16 @@ import pytest
 import torch
 
 from pruna.evaluation.metrics.metric_torch import TorchMetricWrapper, TorchMetrics
-
+from pruna.data.pruna_datamodule import PrunaDataModule
 
 @pytest.mark.cuda
-@pytest.mark.parametrize("dataloader_fixture", ["WikiText"], indirect=True)
-def test_perplexity(dataloader_fixture: Any) -> None:
+@pytest.mark.parametrize("datamodule_fixture", ["WikiText"], indirect=True)
+def test_perplexity(datamodule_fixture: PrunaDataModule) -> None:
     """Test the perplexity."""
     metric = TorchMetricWrapper("perplexity")
+    dataloader = datamodule_fixture.val_dataloader()
 
-    _, gt = next(iter(dataloader_fixture))
+    _, gt = next(iter(dataloader))
 
     vocab_size = 50257
     logits = torch.zeros(gt.shape[0], gt.shape[1], vocab_size)
@@ -27,13 +28,12 @@ def test_perplexity(dataloader_fixture: Any) -> None:
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("dataloader_fixture", ["LAION256"], indirect=True)
-def test_fid(dataloader_fixture: Any) -> None:
+@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
+def test_fid(datamodule_fixture: PrunaDataModule) -> None:
     """Test the fid."""
     metric = TorchMetricWrapper("fid")
-    metric.metric.to("cpu")
-
-    dataloader_iter = iter(dataloader_fixture)
+    dataloader = datamodule_fixture.val_dataloader()
+    dataloader_iter = iter(dataloader)
 
     _, gt1 = next(dataloader_iter)
     _, gt2 = next(dataloader_iter)
@@ -43,11 +43,14 @@ def test_fid(dataloader_fixture: Any) -> None:
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("dataloader_fixture", ["LAION256"], indirect=True)
-def test_clip_score(dataloader_fixture: Any) -> None:
+@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
+def test_clip_score(datamodule_fixture: PrunaDataModule) -> None:
     """Test the clip score."""
     metric = TorchMetricWrapper("clip_score")
-    x, gt = next(iter(dataloader_fixture))
+    dataloader = datamodule_fixture.val_dataloader()
+    dataloader_iter = iter(dataloader)
+
+    x, gt = next(dataloader_iter)
     metric.update(x, gt, gt)
     score = metric.compute()
     assert score.result > 0.0 and score.result < 100.0
@@ -64,12 +67,15 @@ def test_clipiqa(dataloader_fixture: Any) -> None:
 
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("dataloader_fixture", ["ImageNet"], indirect=True)
+@pytest.mark.parametrize("datamodule_fixture", ["ImageNet"], indirect=True)
 @pytest.mark.parametrize("metric", ["accuracy", "recall", "precision"])
-def test_torch_metrics(dataloader_fixture: Any, metric: str) -> None:
+def test_torch_metrics(datamodule_fixture: PrunaDataModule, metric: str) -> None:
     """Test the torch metrics accuracy, recall, precision."""
     metric = TorchMetricWrapper(metric, task="multiclass", num_classes=1000)
-    _, gt = next(iter(dataloader_fixture))
+    dataloader = datamodule_fixture.val_dataloader()
+    dataloader_iter = iter(dataloader)
+
+    x, gt = next(dataloader_iter)
     metric.update(gt, gt, gt)
     assert metric.compute().result == 1.0
 

--- a/tests/evaluation/test_torch_metrics.py
+++ b/tests/evaluation/test_torch_metrics.py
@@ -74,11 +74,14 @@ def test_clip_score(datamodule_fixture: PrunaDataModule, device: str) -> None:
     assert score.result > 0.0 and score.result < 100.0
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("dataloader_fixture", ["LAION256"], indirect=True)
-def test_clipiqa(dataloader_fixture: Any) -> None:
+@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
+def test_clipiqa(datamodule_fixture: PrunaDataModule) -> None:
     """Test the clipiqa."""
-    metric = TorchMetricWrapper("clipiqa")
-    x, gt = next(iter(dataloader_fixture))
+    metric = TorchMetricWrapper("clipiqa", device="cpu")
+
+    dataloader = datamodule_fixture.val_dataloader()
+    dataloader_iter = iter(dataloader)
+    x, gt = next(dataloader_iter)
     metric.update(x, gt, gt)
     score = metric.compute()
     assert score.result > 0.0 and score.result < 1.0
@@ -107,11 +110,13 @@ def test_torch_metrics(datamodule_fixture: PrunaDataModule, device: str, metric:
     assert metric.compute().result == 1.0
 
 @pytest.mark.cpu
-@pytest.mark.parametrize("dataloader_fixture", ["LAION256"], indirect=True)
-def test_arniqa(dataloader_fixture: Any) -> None:
+@pytest.mark.parametrize("datamodule_fixture", ["LAION256"], indirect=True)
+def test_arniqa(datamodule_fixture: PrunaDataModule) -> None:
     """Test arniqa."""
-    metric = TorchMetricWrapper("arniqa")
-    x, gt = next(iter(dataloader_fixture))
+    metric = TorchMetricWrapper("arniqa", device="cpu")
+    dataloader = datamodule_fixture.val_dataloader()
+    dataloader_iter = iter(dataloader)
+    x, gt = next(dataloader_iter)
     metric.update(x, gt, gt)
 
 @pytest.mark.cpu

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -38,8 +38,8 @@ def model_fixture(request: pytest.FixtureRequest) -> Any:
 
 
 @pytest.fixture(scope="function")
-def dataloader_fixture(request: pytest.FixtureRequest) -> Any:
-    """Model fixture for testing."""
+def datamodule_fixture(request: pytest.FixtureRequest) -> Any:
+    """PrunaDataModule fixture for testing."""
     if request.param in ["LAION256", "ImageNet"]:
         dm = PrunaDataModule.from_string(request.param)
     elif request.param in ["WikiText"]:
@@ -48,7 +48,9 @@ def dataloader_fixture(request: pytest.FixtureRequest) -> Any:
     else:
         raise ValueError(f"Invalid dataset: {request.param}")
 
-    return dm.val_dataloader()
+    yield weakref.proxy(dm)
+
+    del dm
 
 
 def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

This PR adds support for evaluating time metrics on multi-GPU setups using HuggingFace Accelerate and introduces a consistent, centralized system for device resolution across the model, Task, EvaluationAgent, and metrics.

Evaluation Pipeline

- EvaluationAgent now records the model's device and device map, and restores the model to its original setup after evaluation.

- Introduced `ensure_device_consistency()` to verify that Task and model devices match, or to sync them if not explicitly set.

Task Improvements

- Task now has a `low_memory=True` mode to offload stateful metrics to CPU by default.

- Separates inference-time device (task.device) from stateful-metric device (task.stateful_metric_device) to support mixed configurations.

Improved fallback logic:

- If the user doesn’t explicitly set a device on the Task, the system defaults to using the **model’s device**. Metrics inherit this unless overridden. 

- If `low_memory=True`, only stateful metrics are automatically offloaded to CPU to reduce GPU memory pressure.

- If the user does specify a device and it doesn’t match the model, we raise a clear error; no silent casting. Metrics themselves also raise if their .device is incompatible with their .runs_on spec.

Inference Flow Update

- `PrunaModel.run_inference()` now automatically detects model device and applies input placement logic accordingly.

- `move_inputs_to_device()` now supports Accelerate device maps and works consistently across CPU, CUDA, and Accelerate setups.


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

