### PR TITLE
feat: new quantizer for vllm

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -11,7 +11,7 @@ This tutorial will guide you through the process of using |pruna| to optimize yo
       :text-align: center
       :link: ./image_generation.ipynb
 
-      Compress with a ``hq_diffusers`` ``quantizer`` and a ``deepcache`` ``cacher``, and evaluate with ``throughput``, ``total time``, ``clip_score``.
+      Compress with a ``hqq_diffusers`` ``quantizer`` and a ``deepcache`` ``cacher``, and evaluate with ``throughput``, ``total time``, ``clip_score``.
 
    .. grid-item-card:: Compress and Evaluate Large Language Models
       :text-align: center

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -84,6 +84,12 @@ class HQQQuantizer(PrunaQuantizer):
                 default_value=True,
                 meta=dict(desc="Whether to patch the model for inference (with torchaoint4 kernels)."),
             ),
+            CategoricalHyperparameter(
+                "default_to_hf",
+                choices=[True, False],
+                default_value=False,
+                meta=dict(desc="Whether or not to bypass the HQQ quantization and use the generic HF quantization."),
+            ),
         ]
 
     def model_check_fn(self, model: Any) -> bool:
@@ -129,14 +135,20 @@ class HQQQuantizer(PrunaQuantizer):
         safe_memory_cleanup()
         with ModelContext(model) as (pipeline, working_model, denoiser_type):
             try:  # Try to quantize the model using HQQ
+                if smash_config["default_to_hf"]:
+                    raise Exception(
+                        "AutoHQQHFModel is bypassed, defaulting to generic HF quantization. "
+                        "Set default_to_hf to False to (try to) use AutoHQQHFModel."
+                    )
                 working_model = imported_modules["AutoHQQHFModel"].quantize_model(
                     working_model,
                     quant_config=quant_config_hqq,
                     device=smash_config["device"],
                     compute_dtype=torch.float16 if smash_config["compute_dtype"] == "torch.float16" else torch.bfloat16,
                 )
-            except Exception:  # Default to generic HF quantization if it fails
-                pruna_logger.info("Could not quantize model using specialized HQQ pipeline, trying generic interface...")
+            except Exception:  # Default to generic HF quantization if it fails or if default_to_hf is True
+                if not smash_config["default_to_hf"]:
+                    pruna_logger.info("Could not quantize model using specialized HQQ pipeline, trying generic interface...")
                 # Create a temporary directory in a specific location
                 base_temp_dir = smash_config["cache_dir"]
                 temp_dir = tempfile.mkdtemp(dir=base_temp_dir)

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -78,6 +78,12 @@ class HQQQuantizer(PrunaQuantizer):
                 default_value="torch.float16",
                 meta=dict(desc="Compute dtype for quantization."),
             ),
+            CategoricalHyperparameter(
+                "patch_for_inference",
+                choices=[True, False],
+                default_value=True,
+                meta=dict(desc="Whether to patch the model for inference (with torchaoint4 kernels)."),
+            ),
         ]
 
     def model_check_fn(self, model: Any) -> bool:
@@ -149,7 +155,12 @@ class HQQQuantizer(PrunaQuantizer):
 
             # Prepare the model for fast inference
             try:
-                if weight_quantization_bits == 4:
+                if weight_quantization_bits == 4 and smash_config["patch_for_inference"]:
+                    pruna_logger.info(
+                        "Patching model for fast inference with torchaoint4 kernels. "
+                        "This operation makes the model incompatible with re-load. "
+                        "If you plan to save and re-load the model, set patch_for_inference to False."
+                    )
                     imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])
             except Exception as e:
                 pruna_logger.error(f"Error: {e}")

--- a/src/pruna/algorithms/quantization/hqq.py
+++ b/src/pruna/algorithms/quantization/hqq.py
@@ -148,7 +148,9 @@ class HQQQuantizer(PrunaQuantizer):
                 )
             except Exception:  # Default to generic HF quantization if it fails or if default_to_hf is True
                 if not smash_config["default_to_hf"]:
-                    pruna_logger.info("Could not quantize model using specialized HQQ pipeline, trying generic interface...")
+                    pruna_logger.info(
+                        "Could not quantize model using specialized HQQ pipeline, trying generic interface..."
+                    )
                 # Create a temporary directory in a specific location
                 base_temp_dir = smash_config["cache_dir"]
                 temp_dir = tempfile.mkdtemp(dir=base_temp_dir)
@@ -170,7 +172,7 @@ class HQQQuantizer(PrunaQuantizer):
                 if weight_quantization_bits == 4 and smash_config["patch_for_inference"]:
                     pruna_logger.info(
                         "Patching model for fast inference with torchaoint4 kernels. "
-                        "This operation makes the model incompatible with re-load. "
+                        "This operation can make the model incompatible with re-load. "
                         "If you plan to save and re-load the model, set patch_for_inference to False."
                     )
                     imported_modules["prepare_for_inference"](working_model, backend=smash_config["backend"])


### PR DESCRIPTION
## Description
This PR is the little sister of this [PR]() in pruna_pro.
This PR in pruna add some flexibility around hqq quantization and saving:
- a new parameter `patch_for_inference` is added to allow the user to quantize in 4bits without patching the layers (because can make them un-loadable);
- a new parameter `default_to_hf` allows the user to select a specific implementation of hqq quantization (previously only a try:...except was done, but no freedom was given to the user). this is important in particular because vllm expects a models that has been saved with the 'transformers' structure, not the AutoHQQModel one.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Unit test pass locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
