### PR TITLE
ci: add nightly workflow to mark PRs as stale

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,15 @@
+name: 'Mark stale PRs'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-pr-stale: 10
+          stale-pr-message: 'This PR has been inactive for 10 days and is now marked as stale.'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,5 +1,9 @@
 name: 'Mark stale PRs'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
## Description
This PR introduces a nightly workflow that checks all open PRs and marks those with no progress for more than 10 days as stale. This will help keep track of older PRs.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
