### PR TITLE
fix: change janus import into automodel import

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -89,7 +89,7 @@ def get_diffusers_model(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, S
     return model, smash_config
 
 
-def get_automodel_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
+def get_automodel_causallm_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
     model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
     smash_config = SmashConfig()
@@ -117,8 +117,12 @@ def get_torchvision_model(name: str) -> tuple[Any, SmashConfig]:
     return model, smash_config
 
 
-def get_janus_model(model_id: str) -> tuple[Any, SmashConfig]:
-    """Get a Janus model for image generation."""
+def get_automodel_image_text_to_text_transformers(model_id: str) -> tuple[Any, SmashConfig]:
+    """
+    Get an AutoModelForImageTextToText model.
+
+    This multi-modal model is not only for text generation, but also for AR image generation.
+    """
     model = AutoModelForImageTextToText.from_pretrained(model_id)
     smash_config = SmashConfig()
     return model, smash_config
@@ -148,13 +152,13 @@ MODEL_FACTORY: dict[str, Callable] = {
     "sana_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-sana"),
     "flux_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-flux"),
     # text generation models
-    "opt_125m": partial(get_automodel_transformers, "facebook/opt-125m"),
-    "opt_tiny_random": partial(get_automodel_transformers, "yujiepan/opt-tiny-random"),
-    "smollm_135m": partial(get_automodel_transformers, "HuggingFaceTB/SmolLM2-135M"),
-    "llama_3_2_1b": partial(get_automodel_transformers, "NousResearch/Llama-3.2-1B"),
-    "llama_3_1_8b": partial(get_automodel_transformers, "NousResearch/Hermes-3-Llama-3.1-8B"),
-    "llama_3_tiny_random": partial(get_automodel_transformers, "llamafactory/tiny-random-Llama-3"),
+    "opt_125m": partial(get_automodel_causallm_transformers, "facebook/opt-125m"),
+    "opt_tiny_random": partial(get_automodel_causallm_transformers, "yujiepan/opt-tiny-random"),
+    "smollm_135m": partial(get_automodel_causallm_transformers, "HuggingFaceTB/SmolLM2-135M"),
+    "llama_3_2_1b": partial(get_automodel_causallm_transformers, "NousResearch/Llama-3.2-1B"),
+    "llama_3_1_8b": partial(get_automodel_causallm_transformers, "NousResearch/Hermes-3-Llama-3.1-8B"),
+    "llama_3_tiny_random": partial(get_automodel_causallm_transformers, "llamafactory/tiny-random-Llama-3"),
     "dummy_lambda": dummy_model,
     # image generation AR models
-    "tiny_janus_pro": partial(get_janus_model, "loulou2/tiny_janus"),
+    "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "loulou2/tiny_janus"),
 }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 from huggingface_hub import snapshot_download
 from torchvision.models import get_model as torchvision_get_model
-from transformers import AutoModelForCausalLM, AutoTokenizer, JanusForConditionalGeneration, pipeline
+from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoTokenizer, pipeline
 
 from pruna import SmashConfig
 from pruna.data.pruna_datamodule import PrunaDataModule
@@ -119,7 +119,7 @@ def get_torchvision_model(name: str) -> tuple[Any, SmashConfig]:
 
 def get_janus_model(model_id: str) -> tuple[Any, SmashConfig]:
     """Get a Janus model for image generation."""
-    model = JanusForConditionalGeneration.from_pretrained(model_id)
+    model = AutoModelForImageTextToText.from_pretrained(model_id)
     smash_config = SmashConfig()
     return model, smash_config
 
@@ -155,7 +155,6 @@ MODEL_FACTORY: dict[str, Callable] = {
     "llama_3_1_8b": partial(get_automodel_transformers, "NousResearch/Hermes-3-Llama-3.1-8B"),
     "llama_3_tiny_random": partial(get_automodel_transformers, "llamafactory/tiny-random-Llama-3"),
     "dummy_lambda": dummy_model,
-
     # image generation AR models
     "tiny_janus_pro": partial(get_janus_model, "loulou2/tiny_janus"),
 }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -89,7 +89,7 @@ def get_diffusers_model(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, S
     return model, smash_config
 
 
-def get_automodel_causallm_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
+def get_automodel_transformers(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, SmashConfig]:
     """Get an AutoModelForCausalLM model for text generation."""
     model = AutoModelForCausalLM.from_pretrained(model_id, **kwargs)
     smash_config = SmashConfig()
@@ -152,12 +152,12 @@ MODEL_FACTORY: dict[str, Callable] = {
     "sana_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-sana"),
     "flux_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-flux"),
     # text generation models
-    "opt_125m": partial(get_automodel_causallm_transformers, "facebook/opt-125m"),
-    "opt_tiny_random": partial(get_automodel_causallm_transformers, "yujiepan/opt-tiny-random"),
-    "smollm_135m": partial(get_automodel_causallm_transformers, "HuggingFaceTB/SmolLM2-135M"),
-    "llama_3_2_1b": partial(get_automodel_causallm_transformers, "NousResearch/Llama-3.2-1B"),
-    "llama_3_1_8b": partial(get_automodel_causallm_transformers, "NousResearch/Hermes-3-Llama-3.1-8B"),
-    "llama_3_tiny_random": partial(get_automodel_causallm_transformers, "llamafactory/tiny-random-Llama-3"),
+    "opt_125m": partial(get_automodel_transformers, "facebook/opt-125m"),
+    "opt_tiny_random": partial(get_automodel_transformers, "yujiepan/opt-tiny-random"),
+    "smollm_135m": partial(get_automodel_transformers, "HuggingFaceTB/SmolLM2-135M"),
+    "llama_3_2_1b": partial(get_automodel_transformers, "NousResearch/Llama-3.2-1B"),
+    "llama_3_1_8b": partial(get_automodel_transformers, "NousResearch/Hermes-3-Llama-3.1-8B"),
+    "llama_3_tiny_random": partial(get_automodel_transformers, "llamafactory/tiny-random-Llama-3"),
     "dummy_lambda": dummy_model,
     # image generation AR models
     "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "loulou2/tiny_janus"),


### PR DESCRIPTION
## Description
This PR makes use and replace the `JanusForConditionalGeneration` by a `AutoModelForImageTextToText` : in case there is a package version mismatch, only the Janus test would fail with some model-not-available-error.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
The previous PR #145 on janus introduced some test that yields import error if the `transformers` is outdated.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
Local test on Janus pass

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
