### PR TITLE
feat: implement version tracking in SmashConfig

### DIFF
--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -27,6 +27,7 @@ from warnings import warn
 import numpy as np
 import torch
 from ConfigSpace import Configuration, ConfigurationSpace
+from importlib_metadata import version
 from transformers import AutoProcessor, AutoTokenizer
 from transformers.processing_utils import ProcessorMixin
 from transformers.tokenization_utils_base import PreTrainedTokenizerBase
@@ -44,6 +45,7 @@ ADDITIONAL_ARGS = [
     "save_fns",
     "load_fns",
     "reapply_after_load",
+    "_pruna_version",
 ]
 
 TOKENIZER_SAVE_PATH = "tokenizer/"
@@ -55,6 +57,10 @@ SUPPORTED_DEVICES = ["cpu", "cuda", "mps", "accelerate"]
 class SmashConfig:
     """
     Wrapper class to hold a ConfigSpace Configuration object as a Smash configuration.
+
+    The SmashConfig automatically tracks which version of the pruna library was used for smashing
+    the model. This information is stored in the `_pruna_version` field and is used to warn
+    about potential compatibility issues when loading models smashed with different versions.
 
     Parameters
     ----------
@@ -108,6 +114,9 @@ class SmashConfig:
         self.processor: ProcessorMixin | None = None
         self.data: PrunaDataModule | None = None
 
+        # Track the pruna version used for smashing
+        self._pruna_version: str = version("pruna")
+
         # internal variable *to save time* by avoiding compilers saving models for inference-only smashing
         self._prepare_saving = True
 
@@ -134,6 +143,7 @@ class SmashConfig:
             and self.save_fns == other.save_fns
             and self.load_fns == other.load_fns
             and self.reapply_after_load == other.reapply_after_load
+            and self._pruna_version == other._pruna_version
         )
 
     def cleanup_cache_dir(self) -> None:
@@ -146,16 +156,35 @@ class SmashConfig:
         self.cleanup_cache_dir()
         self.cache_dir = tempfile.mkdtemp(dir=self.cache_dir_prefix)
 
-    def load_from_json(self, path: str | Path) -> None:
+    @classmethod
+    def load_from_json(cls, path: str | Path) -> "SmashConfig":
         """
-        Load a SmashConfig from a JSON file.
+        Backwards compatible classmethod to load a SmashConfig from a JSON file.
 
         Parameters
         ----------
         path : str| Path
             The file path to the JSON file containing the configuration.
+
+        Returns
+        -------
+        SmashConfig
+            The loaded SmashConfig instance.
         """
-        with open(os.path.join(path, SMASH_CONFIG_FILE_NAME), "r") as f:
+        instance = cls()
+        instance._load_from_json_impl(path)
+        return instance
+
+    def _load_from_json_impl(self, path: str | Path) -> None:
+        """
+        Internal implementation for loading a SmashConfig from a JSON file.
+
+        Used by the classmethod and for backwards compatibility with the old instance method.
+        """
+        if not str(path).endswith(".json"):
+            path = os.path.join(path, SMASH_CONFIG_FILE_NAME)
+
+        with open(path, "r") as f:
             json_string = f.read()
             config_dict = json.loads(json_string)
 
@@ -171,6 +200,24 @@ class SmashConfig:
         # support deprecated max batch size argument
         if "max_batch_size" in config_dict:
             config_dict["batch_size"] = config_dict.pop("max_batch_size")
+
+        # Check for version mismatch and warn if necessary
+        if "_pruna_version" in config_dict:
+            saved_version = config_dict["_pruna_version"]
+            current_version = version("pruna")
+            if saved_version != current_version:
+                pruna_logger.warning(
+                    f"Version mismatch detected. The model was smashed with pruna version {saved_version}, "
+                    f"but you are currently using pruna version {current_version}. "
+                    f"This may cause compatibility issues. Consider using the same version of pruna "
+                    f"that was used to smash the model, or test the model thoroughly."
+                )
+        else:
+            # If no version was saved, this is likely an older model
+            pruna_logger.info(
+                "No pruna version information found in the saved configuration. "
+                "We introduced version tracking in pruna 0.2.7, so this is likely an older model."
+            )
 
         for name in ADDITIONAL_ARGS:
             if name not in config_dict:
@@ -220,6 +267,20 @@ class SmashConfig:
         if os.path.exists(os.path.join(path, PROCESSOR_SAVE_PATH)):
             self.processor = AutoProcessor.from_pretrained(os.path.join(path, PROCESSOR_SAVE_PATH))
 
+    # For backwards compatibility: allow instance method usage
+    def load_from_json(self, path: str | Path) -> None:  # type: ignore  # noqa:  F811
+        """
+        Instance method for loading a SmashConfig from a JSON file.
+
+        Deprecated: Prefer using SmashConfig.load_from_json(path) as a classmethod.
+
+        Parameters
+        ----------
+        path : str| Path
+            The file path to the JSON file containing the configuration.
+        """
+        self._load_from_json_impl(path)
+
     def save_to_json(self, path: str | Path) -> None:
         """
         Save the SmashConfig to a JSON file, including additional keys.
@@ -241,7 +302,15 @@ class SmashConfig:
             del config_dict["cache_dir"]
 
         # Save the updated dictionary back to a JSON file
-        with open(os.path.join(path, SMASH_CONFIG_FILE_NAME), "w") as f:
+        if str(path).endswith(".json"):
+            json_path = path
+            dir_path = os.path.dirname(json_path)
+        else:
+            json_path = os.path.join(path, SMASH_CONFIG_FILE_NAME)
+            dir_path = str(path)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+        with open(json_path, "w") as f:
             json.dump(config_dict, f, indent=4)
 
         if self.tokenizer:
@@ -307,6 +376,9 @@ class SmashConfig:
 
         # reset potentially previously used cache directory
         self.reset_cache_dir()
+
+        # update version to current version when flushing
+        self._pruna_version = version("pruna")
 
     def __get_dataloader(self, dataloader_name: str, **kwargs) -> torch.utils.data.DataLoader | None:
         if self.data is None:

--- a/tests/config/test_version_tracking.py
+++ b/tests/config/test_version_tracking.py
@@ -1,0 +1,68 @@
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+from importlib_metadata import version
+
+from pruna.config.smash_config import SmashConfig
+from pruna.logging.logger import pruna_logger
+
+
+def test_version_mismatch_warning_and_missing_info():
+    config = SmashConfig()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config.save_to_json(temp_dir)
+        config_file = Path(temp_dir) / "smash_config.json"
+
+        # Simulate version mismatch
+        with open(config_file, "r") as f:
+            saved = json.load(f)
+        saved["_pruna_version"] = "0.1.0"
+        with open(config_file, "w") as f:
+            json.dump(saved, f)
+        with patch.object(pruna_logger, "warning") as mock_warn:
+            SmashConfig().load_from_json(temp_dir)
+            mock_warn.assert_called()
+            # Check all warning calls for the version mismatch message
+            found = False
+            for call in mock_warn.call_args_list:
+                msg = call[0][0]
+                if "Version mismatch detected." in msg and "0.1.0" in msg:
+                    found = True
+                    break
+            assert found, "Version mismatch warning not found in logger calls."
+
+        # Simulate missing version info
+        with open(config_file, "r") as f:
+            saved = json.load(f)
+        saved.pop("_pruna_version", None)
+        with open(config_file, "w") as f:
+            json.dump(saved, f)
+        with patch.object(pruna_logger, "info") as mock_info:
+            SmashConfig().load_from_json(temp_dir)
+            mock_info.assert_called()
+            assert "No pruna version information found" in mock_info.call_args[0][0]
+
+
+def test_version_tracking_and_equality():
+    config = SmashConfig()
+    current_version = version("pruna")
+    assert config._pruna_version == current_version
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config.save_to_json(temp_dir)
+        config_file = Path(temp_dir) / "smash_config.json"
+        with open(config_file) as f:
+            saved = json.load(f)
+        assert saved["_pruna_version"] == current_version
+
+        loaded = SmashConfig()
+        loaded.load_from_json(temp_dir)
+        assert loaded._pruna_version == current_version
+
+    # Equality and flush
+    c1, c2 = SmashConfig(), SmashConfig()
+    assert c1 == c2
+    c1["cacher"] = "deepcache"
+    c1.flush_configuration()
+    assert c1._pruna_version == current_version


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
* Added `_pruna_version` attribute to track the version of the pruna library used for smashing models.
* Enhanced `load_from_json` method to check for version mismatches and log warnings accordingly.
* Introduced a new class method for loading configurations while maintaining backwards compatibility.
* Added unit tests to verify version tracking functionality and warning behavior for version mismatches.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
