### PR TITLE
Feature: Cache the Hugging Face directory so it doesn't download the test model each time

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Cache models
         uses: actions/cache@v4
+        key: huggingface
         with:
           path: ~/.cache/huggingface
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,6 +69,11 @@ jobs:
 
       - uses: ./.github/actions/setup-uv-project
 
+      - name: Cache models
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+
       - name: Run tests
         run: |
           pytest -m "cpu and not slow and not high_cpu"


### PR DESCRIPTION
## Description
This idea stems from [this PR](https://github.com/PrunaAI/pruna/pull/246), the thing is when we run the test cases in parallel these hosts (huggingface & torch) are not happy about it.

So I searched around, it seems people cache the data to prevent that and make the pipeline more efficient.

First, I test it with hugging-face if succeeds; then we can extend it to torch too (while never got any complain from torch :shrug:).
```
      - name: Cache Torch models
        uses: actions/cache@v4
        key: torch
        with:
          path: ~/.cache/torch
```

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
