### PR TITLE
tests: add `durations` argument to pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ addopts = [
     "--cov=src/pruna",
     "--cov-report=term-missing",
     "--cov-config=pyproject.toml",
+    "--durations=0"
 ]
 
 python_files = "test_*.py"


### PR DESCRIPTION
## Description
This PR extends the newly introduced pytest configuration in the `pyproject.toml` with the `duration` argument, which helps us keep track of the computation time on some experiments. Specifically for the CPU tests run on GitHub action, we will use this to determine which tests will be marked as `pytest.mark.slow`, meaning they will only run during the nightly tests.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Verified updated logging locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
