### PR TITLE
fix: device state of input model for memory metrics

### DIFF
--- a/tests/evaluation/test_memory_metrics.py
+++ b/tests/evaluation/test_memory_metrics.py
@@ -18,6 +18,7 @@ def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig], device: str)
     model, smash_config = model_fixture
     disk_memory_metric = DiskMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    pruna_model.move_to_device("cuda")
     disk_memory_results = disk_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert disk_memory_results.result > 0
 
@@ -34,6 +35,7 @@ def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig], device:
     model, smash_config = model_fixture
     inference_memory_metric = InferenceMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    pruna_model.move_to_device("cuda")
     inference_memory_results = inference_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert inference_memory_results.result > 0
 
@@ -50,5 +52,6 @@ def test_training_memory_metric(model_fixture: tuple[Any, SmashConfig], device: 
     model, smash_config = model_fixture
     training_memory_metric = TrainingMemoryMetric()
     pruna_model = PrunaModel(model, smash_config=smash_config)
+    pruna_model.move_to_device("cuda")
     training_memory_results = training_memory_metric.compute(pruna_model, smash_config.test_dataloader())
     assert training_memory_results.result > 0


### PR DESCRIPTION
## Description
This PR fixes failures in the `memory_metric` tests as the input model is on CPU, which is not allowed for this metric.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Reran failing tests locally.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
