### PR TITLE
fix: warnings related to `chunk_length_s` in ifw

### DIFF
--- a/src/pruna/algorithms/batching/ifw.py
+++ b/src/pruna/algorithms/batching/ifw.py
@@ -128,6 +128,7 @@ class IFWBatcher(PrunaBatcher):
                 else {"attn_implementation": "sdpa"}
             ),
             device=smash_config["device"],
+            ignore_warning=True,
         )
         return pipe
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -62,7 +62,6 @@ def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
     model = pipeline(
         "automatic-speech-recognition",
         model=model_id,
-        chunk_length_s=30,
         torch_dtype=torch.float16,
         device_map="cpu",
     )


### PR DESCRIPTION
## Description
This PR addresses warnings by transformers related to the `chunk_length_s` parameter when using a seq2seq pipeline. Since we are aware that the ifw algorithm is experimental and not exact, we dont have to display these warnings to the user.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Reran tests raising this warning.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
