### PR TITLE
feat: add sharpness metric

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dependencies = [
     "llmcompressor",
     "gliner; python_version >= '3.10'",
     "piq",
+    "opencv-python",
 
 ]
 

--- a/src/pruna/evaluation/metrics/metric_sharpness.py
+++ b/src/pruna/evaluation/metrics/metric_sharpness.py
@@ -1,0 +1,128 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, List, cast
+
+import cv2
+import numpy as np
+import torch
+import torchvision.transforms.functional as transforms_functional
+from torch import Tensor
+
+from pruna.engine.utils import set_to_best_available_device
+from pruna.evaluation.metrics.metric_stateful import StatefulMetric
+from pruna.evaluation.metrics.registry import MetricRegistry
+from pruna.evaluation.metrics.result import MetricResult
+from pruna.evaluation.metrics.utils import SINGLE, get_call_type_for_single_metric, metric_data_processor
+from pruna.logging.logger import pruna_logger
+
+METRIC_SHARPNESS = "sharpness"
+
+
+@MetricRegistry.register(METRIC_SHARPNESS)
+class SharpnessMetric(StatefulMetric):
+    """
+    Laplacian‑variance image‑sharpness metric.
+
+    Parameters
+    ----------
+    *args : Any
+        Additional arguments.
+    kernel_size : int
+        The size of the kernel for the Laplacian operator. Default is 3.
+    call_type : str
+        The type of call to use for the metric. IQA metrics are only supported for single mode.
+    **kwargs : Any
+        Additional keyword arguments.
+    """
+
+    scores: List[float]
+    default_call_type: str = "y"  # Blind IQA metric
+    higher_is_better: bool = True
+    metric_name: str = METRIC_SHARPNESS
+    runs_on: List[str] = ["cpu", "cuda"]
+
+    def __init__(self, *args, kernel_size: int = 3, call_type: str = SINGLE, **kwargs) -> None:
+        device = kwargs.pop("device", None)
+        if device is not None and device not in self.runs_on:
+            pruna_logger.error(f"SharpnessMetric: device {device} not supported. Supported devices: {self.runs_on}")
+            raise
+        super().__init__(*args, **kwargs)
+        self.device = set_to_best_available_device(device)  # OpenCV only works on CPU
+        self.kernel_size = kernel_size
+        self.call_type = get_call_type_for_single_metric(call_type, self.default_call_type)
+        self.add_state("scores", [])
+
+    @torch.no_grad()
+    def update(self, x: List[Any] | Tensor, gt: List[Any] | Tensor, outputs: Any) -> None:
+        """
+        Accumulate the sharpness scores for each batch.
+
+        Parameters
+        ----------
+        x : List[Any] | torch.Tensor
+            The input data.
+        gt : torch.Tensor
+            The ground truth / cached images.
+        outputs : torch.Tensor
+            The output images.
+        """
+        images_list = metric_data_processor(x, gt, outputs, self.call_type)
+        images = cast(Tensor, images_list[0])  # Since the processor returns the batch wrapped in a list
+
+        # Batchify if single image
+        if images.ndim == 3:
+            images = images.unsqueeze(0)
+
+        if images.ndim != 4:
+            pruna_logger.error(f"Expected 4‑D tensor (B, C, H, W); got shape {tuple(images.shape)}")
+            raise
+
+        # Move to CPU OpenCV only works on numpy
+        imgs = images.detach().cpu()
+
+        # If range is 0‑1 → scale to 0‑255 for uint8
+        if imgs.max() <= 1.0:
+            imgs = imgs * 255.0
+        imgs = imgs.to(torch.uint8)
+
+        for img in imgs:
+            if img.shape[0] == 3:
+                img_gray = transforms_functional.rgb_to_grayscale(img.float()).squeeze(0).numpy().astype(np.uint8)
+            elif img.shape[0] == 1:
+                img_gray = img.squeeze(0).numpy().astype(np.uint8)
+            else:
+                pruna_logger.error("SharpnessMetric: unsupported channel count")
+                raise
+
+            lap = cv2.Laplacian(img_gray, cv2.CV_64F, ksize=self.kernel_size)
+            sharp = float(lap.var())
+            self.scores.append(sharp)
+
+    def compute(self) -> MetricResult:
+        """
+        Compute the mean sharpness score.
+
+        Returns
+        -------
+        MetricResult
+            The sharpness metric result.
+        """
+        if not self.scores:
+            return MetricResult(self.metric_name, self.__dict__, 0.0)
+
+        mean_val = float(np.mean(self.scores))
+        return MetricResult(self.metric_name, self.__dict__, mean_val)

--- a/tests/evaluation/test_sharpness.py
+++ b/tests/evaluation/test_sharpness.py
@@ -1,0 +1,123 @@
+from typing import Any
+
+import pytest
+
+from pruna.config.smash_config import SmashConfig
+from pruna.data.pruna_datamodule import PrunaDataModule
+from pruna.engine.pruna_model import PrunaModel
+from pruna.evaluation.evaluation_agent import EvaluationAgent
+from pruna.evaluation.metrics.metric_sharpness import SharpnessMetric
+from pruna.evaluation.task import Task
+
+
+@pytest.mark.parametrize(
+    "model_fixture, device, kernel_size",
+    [
+        pytest.param("flux_tiny_random", "cpu", 3, marks=pytest.mark.cpu),
+        pytest.param("flux_tiny_random", "cuda", 5, marks=pytest.mark.cuda),
+    ],
+    indirect=["model_fixture"],
+)
+def test_sharpness(model_fixture: tuple[Any, SmashConfig], device: str, kernel_size: int) -> None:
+    """Test SharpnessMetric initialization and scoring."""
+    model, smash_config = model_fixture
+    smash_config.device = device
+    pruna_model = PrunaModel(model, smash_config=smash_config)
+
+
+    metric = SharpnessMetric(kernel_size=kernel_size, device=device)
+
+    batch = next(iter(smash_config.test_dataloader()))
+    x, gt = batch
+    outputs = pruna_model.run_inference(batch, device)
+
+    # Calculate sharpness for model outputs
+    metric.update(x, gt, outputs)
+    comparison_results = metric.compute().result
+
+    metric.reset()
+
+    # Calculate sharpness for ground truth
+    metric.update(x, gt, gt)
+    gt_results = metric.compute().result
+
+    # Both should be positive sharpness values (higher is better)
+    assert comparison_results > 0.0
+    assert gt_results > 0.0
+
+
+
+@pytest.mark.parametrize(
+    "model_fixture, device, kernel_size",
+    [
+        pytest.param("sd_tiny_random", "cuda", 3, marks=pytest.mark.cuda),
+        pytest.param("flux_tiny_random", "cpu", 5, marks=pytest.mark.cpu),
+    ],
+    indirect=["model_fixture"],
+)
+def test_task_sharpness_from_instance(model_fixture: tuple[Any, SmashConfig], device: str, kernel_size: int):
+    """Test EvaluationAgent with SharpnessMetric instance."""
+    model, _ = model_fixture
+    data_module = PrunaDataModule.from_string("LAION256")
+    data_module.limit_datasets(10)
+
+    # Create metric instance
+    sharpness_metric = SharpnessMetric(kernel_size=kernel_size, device=device)
+
+    task = Task(
+        request=[sharpness_metric],
+        datamodule=data_module,
+        device=device,
+    )
+    eval_agent = EvaluationAgent(task=task)
+
+    result = eval_agent.evaluate(model)
+
+
+    assert result[0].result > 0.0
+
+
+@pytest.mark.parametrize(
+    "model_fixture, device",
+    [
+        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
+        pytest.param("flux_tiny_random", "cpu", marks=pytest.mark.cpu),
+    ],
+    indirect=["model_fixture"],
+)
+def test_task_sharpness_from_string(model_fixture: tuple[Any, SmashConfig], device: str):
+    """Test EvaluationAgent with sharpness metric specified as string."""
+    model, _ = model_fixture
+    data_module = PrunaDataModule.from_string("LAION256")
+    data_module.limit_datasets(10)
+
+    eval_agent = EvaluationAgent(
+        request=["sharpness"],
+        datamodule=data_module,
+        device=device,
+    )
+
+    result = eval_agent.evaluate(model)
+
+    # Sharpness should be a positive value
+    assert result[0].result > 0.0
+
+
+@pytest.mark.parametrize(
+    "kernel_size, call_type",
+    [
+        (3, "single"),
+        (5, "y"),
+        (7, "single"),
+    ],
+)
+def test_sharpness_metric_parameters(kernel_size: int, call_type: str):
+    """Test SharpnessMetric with different parameters."""
+    metric = SharpnessMetric(kernel_size=kernel_size, call_type=call_type, device="cpu")
+
+    assert metric.kernel_size == kernel_size
+    assert metric.call_type == "y"
+    assert metric.metric_name == "sharpness"
+    assert metric.higher_is_better is True
+    assert "cpu" in metric.runs_on
+    assert "cuda" in metric.runs_on

--- a/tests/evaluation/test_sharpness.py
+++ b/tests/evaluation/test_sharpness.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 import pytest
+import torch
+import torch.nn.functional as F
 
 from pruna.config.smash_config import SmashConfig
 from pruna.data.pruna_datamodule import PrunaDataModule
@@ -45,6 +47,42 @@ def test_sharpness(model_fixture: tuple[Any, SmashConfig], device: str, kernel_s
     assert comparison_results > 0.0
     assert gt_results > 0.0
 
+
+def test_sharpness_blurry_vs_sharp():
+    """Test that sharpness metric decreases for blurrier images."""
+    # Create a sharp test image (checkerboard pattern)
+    size = 64
+    sharp_image = torch.zeros(1, 3, size, size)
+
+    # Create a checkerboard pattern for sharp edges
+    for i in range(size):
+        for j in range(size):
+            if (i // 8 + j // 8) % 2 == 0:
+                sharp_image[0, :, i, j] = 1.0
+
+    # Create a blurry version by applying average pooling to simulate blur
+    # Use padding to maintain the same size
+    blurry_image = F.avg_pool2d(sharp_image, kernel_size=3, stride=1, padding=1)
+    # Apply multiple times to increase blur effect
+    blurry_image = F.avg_pool2d(blurry_image, kernel_size=3, stride=1, padding=1)
+
+    # Create metric
+    metric = SharpnessMetric(kernel_size=3, device="cpu")
+
+    # Test sharp image
+    metric.update([sharp_image], sharp_image, sharp_image)
+    sharp_score = metric.compute().result
+
+    metric.reset()
+
+    # Test blurry image
+    metric.update([blurry_image], blurry_image, blurry_image)
+    blurry_score = metric.compute().result
+
+    # Sharp image should have higher sharpness score
+    assert sharp_score > blurry_score, f"Sharp score ({sharp_score}) should be higher than blurry score ({blurry_score})"
+    assert sharp_score > 0.0
+    assert blurry_score > 0.0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- Adds SharpnessMetric, which computes focus via the variance of the Laplacian (higher = sharper). 

- CPU‑side numpy/OpenCV implementation.


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
You can use the `SharpnessMetric` directly or via the EvaluationAgent:
```
from pruna.evaluation.metrics.metric_sharpness import SharpnessMetric
from pruna.evaluation.task import Task
from pruna.evaluation.evaluation_agent import EvaluationAgent
from pruna.data.pruna_datamodule import PrunaDataModule

# 1) Direct use 
metric = SharpnessMetric(kernel_size=5)

inputs, gts = next(iter(my_dataloader))          # your B×C×H×W tensors
outputs = my_model(inputs)

metric.update(inputs, gts, outputs)
print("Sharpness:", metric.compute().result)     # higher = sharper

# 2) Via Task / EvaluationAgent
dm = PrunaDataModule.from_string("LAION256")
dm.limit_datasets(10)

task = Task(
    request=["sharpness"],        # or [SharpnessMetric(kernel_size=5)]
    datamodule=dm,
)
agent = EvaluationAgent(task=task)

results = agent.evaluate(my_model)
print(results[0])                 # MetricResult(name='sharpness', value=…)
