### PR TITLE
chore: remove deprecated metrics, metric modes and calltypes

### DIFF
--- a/src/pruna/evaluation/metrics/metric_elapsed_time.py
+++ b/src/pruna/evaluation/metrics/metric_elapsed_time.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import time
 from typing import Any, Dict, cast
-from warnings import warn
 
 import torch
 from torch.utils.data import DataLoader
@@ -323,28 +322,3 @@ class TotalTimeMetric(InferenceTimeStats):
         raw_results = super().compute(model, dataloader)
         result = cast(Dict[str, Any], raw_results)[self.metric_name]
         return MetricResult(self.metric_name, self.__dict__.copy(), result)
-
-
-class ElapsedTimeMetric:
-    """
-    Deprecated class.
-
-    Parameters
-    ----------
-    *args : Any
-        Arguments for InferenceTimeStats.
-    **kwargs : Any
-        Keyword arguments for InferenceTimeStats.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        """Forwards to InferenceTimeStats."""
-        warn(
-            "Class ElapsedTimeMetric is deprecated and will be removed in 'v0.2.8' release. \n"
-            "It has been replaced by InferenceTimeStats, \n"
-            "which is a shared parent class for 'LatencyMetric', 'ThroughputMetric' and 'TotalTimeMetric'. \n"
-            "In the future please use 'LatencyMetric', 'ThroughputMetric' or 'TotalTimeMetric' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return InferenceTimeStats(*args, **kwargs)

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import Any, Dict, Generator, List, Optional, Type, cast
-from warnings import warn
 
 import pynvml
 import torch
@@ -33,8 +32,6 @@ DISK_MEMORY = "disk_memory"
 INFERENCE_MEMORY = "inference_memory"
 TRAINING_MEMORY = "training_memory"
 VALID_MODES = (DISK_MEMORY, INFERENCE_MEMORY, TRAINING_MEMORY)
-DEPRECATED_MODES = ("disk", "inference", "training")
-DEPRECATED_MODES_MAP = {"disk": DISK_MEMORY, "inference": INFERENCE_MEMORY, "training": TRAINING_MEMORY}
 MEMORY_UNITS = "MB"
 
 
@@ -117,22 +114,7 @@ class GPUMemoryStats(BaseMetric):
             If the provided mode is invalid.
         """
         if mode not in VALID_MODES:
-            if mode in DEPRECATED_MODES:
-                warn(
-                    "GPUMemoryStats is no longer the preferred interface for GPU memory evaluation. "
-                    "Please use 'DiskMemoryMetric', 'InferenceMemoryMetric' or 'TrainingMemoryMetric' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                warn(
-                    f"Mode '{mode}' is deprecated and will be removed in 'v0.2.8' release. "
-                    f"Please use '{DEPRECATED_MODES_MAP[mode]}' instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                mode = DEPRECATED_MODES_MAP[mode]
-            else:
-                raise ValueError(f"Mode must be one of {VALID_MODES}, got '{mode}'.")
+            raise ValueError(f"Mode must be one of {VALID_MODES}, got '{mode}'.")
 
         self.mode = mode
         self.gpu_indices = gpu_indices
@@ -480,28 +462,3 @@ class TrainingMemoryMetric(BaseMetric):
             The training memory usage of the model.
         """
         return self.metric.compute(model, dataloader)
-
-
-class GPUMemoryMetric:
-    """
-    Deprecated class.
-
-    Parameters
-    ----------
-    *args : Any
-        Arguments for GPUMemoryStats.
-    **kwargs : Any
-        Keyword arguments for GPUMemoryStats.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        """Forwards to GPUMemoryStats."""
-        warn(
-            "GPUMemoryMetric is deprecated and will be removed in 'v0.2.8' release. \n "
-            "It has been replaced by GPUMemoryStats, "
-            "which is a shared parent class for 'DiskMemoryMetric', 'InferenceMemoryMetric' and 'TrainingMemoryMetric'. \n"  # noqa: E501
-            "In the future, please use 'DiskMemoryMetric', 'InferenceMemoryMetric' or 'TrainingMemoryMetric' instead.\n",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return GPUMemoryStats(*args, **kwargs)

--- a/src/pruna/evaluation/metrics/metric_model_architecture.py
+++ b/src/pruna/evaluation/metrics/metric_model_architecture.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import inspect
 from typing import Any, Dict, List, Tuple, cast
-from warnings import warn
 
 import thop
 import torch
@@ -263,28 +262,3 @@ class TotalParamsMetric(ModelArchitectureStats):
         # Use EvaluationAgent to share computation across model architecture metrics.
         results = super().compute(model, dataloader)
         return MetricResult.from_results_dict(self.metric_name, self.__dict__.copy(), cast(Dict[str, Any], results))
-
-
-class ModelArchitectureMetric:
-    """
-    Deprecated class.
-
-    Parameters
-    ----------
-    *args : Any
-        Arguments for ModelArchitectureStats.
-    **kwargs : Any
-        Keyword arguments for ModelArchitectureStats.
-    """
-
-    def __new__(cls, *args, **kwargs):
-        """Forwards to ModelArchitectureStats."""
-        warn(
-            "ModelArchitectureMetric is deprecated and will be removed in 'v0.2.8' release. \n"
-            "It has been replaced by ModelArchitectureStats, \n"
-            "which is a shared parent class for 'TotalMACsMetric' and 'TotalParamsMetric'. \n"
-            "In the future, please use 'TotalMACsMetric' or 'TotalParamsMetric' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return ModelArchitectureStats(*args, **kwargs)

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -18,7 +18,6 @@ from contextlib import suppress
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, List, Optional, Union
-from warnings import warn
 
 import torch
 from torch import Tensor
@@ -43,7 +42,6 @@ from pruna.evaluation.metrics.utils import (
     CALL_TYPES,
     PAIRWISE,
     SINGLE,
-    get_any_call_type_pairing,
     get_pairwise_pairing,
     get_single_pairing,
     metric_data_processor,
@@ -379,18 +377,5 @@ def get_call_type(call_type: str, metric_name: str) -> str:
         else:
             return get_single_pairing(TorchMetrics[metric_name].call_type)
     else:
-        # If the correct call type is called we give a deprecation warning.
-        if call_type == TorchMetrics[metric_name].call_type or call_type == get_any_call_type_pairing(
-            TorchMetrics[metric_name].call_type
-        ):
-            warn(
-                f"Calling with call type {call_type} is deprecated and will be removed in 'v0.2.8' release. \n"
-                f"Use {SINGLE} or {PAIRWISE} instead. \n"
-                f"Using default call type {TorchMetrics[metric_name].call_type}.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return TorchMetrics[metric_name].call_type
-        else:
-            pruna_logger.error(f"Invalid call type: {call_type}. Must be one of {CALL_TYPES}.")
-            raise ValueError(f"Invalid call type: {call_type}. Must be one of {CALL_TYPES}.")
+        pruna_logger.error(f"Invalid call type: {call_type}. Must be one of {CALL_TYPES}.")
+        raise ValueError(f"Invalid call type: {call_type}. Must be one of {CALL_TYPES}.")

--- a/src/pruna/evaluation/metrics/utils.py
+++ b/src/pruna/evaluation/metrics/utils.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from collections import defaultdict
 from inspect import Signature, getmro, signature
 from typing import Any, Callable, Dict, List, Tuple, Type, cast
-from warnings import warn
 
 import torch
 
@@ -265,18 +264,8 @@ def get_call_type_for_pairwise_metric(call_type_requested: str, default_call_typ
     elif call_type_requested == SINGLE:
         return get_single_pairing(default_call_type)
     else:
-        if call_type_requested == default_call_type or call_type_requested == get_single_pairing(default_call_type):
-            warn(
-                f"Calling metric with its call type is deprecated and will be removed in 'v0.2.8' release. \n"
-                f"Use {SINGLE} or {PAIRWISE} instead. \n"
-                f"Using default call type {default_call_type}.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return default_call_type
-        else:
-            pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
-            raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
 
 
 def get_call_type_for_single_metric(call_type_requested: str, default_call_type: str) -> str:
@@ -300,15 +289,5 @@ def get_call_type_for_single_metric(call_type_requested: str, default_call_type:
     elif call_type_requested == SINGLE:
         return default_call_type
     else:
-        if call_type_requested == default_call_type or call_type_requested == get_pairwise_pairing(default_call_type):
-            warn(
-                f"Calling metric with its call type is deprecated and will be removed in 'v0.2.8' release. \n"
-                f"Use {SINGLE} or {PAIRWISE} instead. \n"
-                f"Using default call type {default_call_type}.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            return default_call_type
-        else:
-            pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
-            raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        pruna_logger.error(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")
+        raise ValueError(f"Invalid call type: {call_type_requested}. Must be one of {CALL_TYPES}.")

--- a/src/pruna/evaluation/task.py
+++ b/src/pruna/evaluation/task.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from typing import Any, List, cast
-from warnings import warn
 
 import torch
 
@@ -23,10 +22,6 @@ from pruna.data.pruna_datamodule import PrunaDataModule
 from pruna.engine.utils import set_to_best_available_device
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.metric_cmmd import CMMD
-from pruna.evaluation.metrics.metric_elapsed_time import LATENCY, THROUGHPUT, TOTAL_TIME
-from pruna.evaluation.metrics.metric_energy import CO2_EMISSIONS, ENERGY_CONSUMED
-from pruna.evaluation.metrics.metric_memory import DISK_MEMORY
-from pruna.evaluation.metrics.metric_model_architecture import TOTAL_MACS, TOTAL_PARAMS
 from pruna.evaluation.metrics.metric_stateful import StatefulMetric
 from pruna.evaluation.metrics.metric_torch import TorchMetricWrapper
 from pruna.evaluation.metrics.registry import MetricRegistry
@@ -39,12 +34,6 @@ PARENT_METRICS = (
     "InferenceTimeStats",
     "EnvironmentalImpactStats",
 )
-DEPRECATION_TO_NEW_MAP = {
-    "elapsed_time": [LATENCY, THROUGHPUT, TOTAL_TIME],
-    "gpu_memory": [DISK_MEMORY],
-    "energy": [ENERGY_CONSUMED, CO2_EMISSIONS],
-    "model_architecture": [TOTAL_MACS, TOTAL_PARAMS],
-}
 
 
 class Task:
@@ -178,17 +167,7 @@ def _process_metric_names(request: List[str], device: str | torch.device | None)
     new_requests: List[str] = []
     for metric_name in request:
         metric_name = cast(str, metric_name)
-        if metric_name in DEPRECATION_TO_NEW_MAP:
-            warn(
-                f"Metric {metric_name} is deprecated and will be removed in 'v0.2.8' release. "
-                f"Use {DEPRECATION_TO_NEW_MAP[metric_name]} instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            for new_metric in DEPRECATION_TO_NEW_MAP[metric_name]:
-                new_requests.append(cast(str, new_metric))
-        else:
-            new_requests.append(cast(str, metric_name))
+        new_requests.append(cast(str, metric_name))
     return MetricRegistry.get_metrics(names=new_requests, device=device)
 
 

--- a/tests/evaluation/test_energy_metrics.py
+++ b/tests/evaluation/test_energy_metrics.py
@@ -3,7 +3,7 @@ from typing import Any
 import pytest
 
 from pruna import PrunaModel, SmashConfig
-from pruna.evaluation.metrics.metric_energy import EnergyConsumedMetric, CO2EmissionsMetric, EnergyMetric, ENERGY_CONSUMED, CO2_EMISSIONS
+from pruna.evaluation.metrics.metric_energy import EnergyConsumedMetric, CO2EmissionsMetric
 
 @pytest.mark.parametrize(
     "model_fixture, device",
@@ -36,19 +36,3 @@ def test_co2_emissions_metric(model_fixture: tuple[Any, SmashConfig], device: st
     pruna_model = PrunaModel(model, smash_config=smash_config)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result >= 0  # Assuming CO2 emissions should be non-negative
-
-@pytest.mark.parametrize(
-    "model_fixture, device",
-    [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
-    ],
-    indirect=["model_fixture"],
-)
-def test_deprecated_energy_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
-    """Test the deprecated energy metric."""
-    model, smash_config = model_fixture
-    metric = EnergyMetric(n_iterations=5, n_warmup_iterations=5, device=device)
-    pruna_model = PrunaModel(model, smash_config=smash_config)
-    results = metric.compute(pruna_model, smash_config.test_dataloader())
-    assert results[ENERGY_CONSUMED] >= 0
-    assert results[CO2_EMISSIONS] >= 0

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -4,7 +4,7 @@ import pytest
 
 from pruna import SmashConfig
 from pruna.engine.pruna_model import PrunaModel
-from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric, ElapsedTimeMetric, LATENCY, THROUGHPUT, TOTAL_TIME
+from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric
 
 @pytest.mark.parametrize(
     "model_fixture, device",
@@ -53,20 +53,3 @@ def test_total_time_metric(model_fixture: tuple[Any, SmashConfig], device: str) 
     pruna_model = PrunaModel(model, smash_config=smash_config)
     results = metric.compute(pruna_model, smash_config.test_dataloader())
     assert results.result > 0  # Assuming total time should be positive
-
-@pytest.mark.parametrize(
-    "model_fixture, device",
-    [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
-    ],
-    indirect=["model_fixture"],
-)
-def test_deprecated_time_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
-    """Test the deprecated time metric."""
-    model, smash_config = model_fixture
-    metric = ElapsedTimeMetric(n_iterations=5, n_warmup_iterations=5, device=device)
-    pruna_model = PrunaModel(model, smash_config=smash_config)
-    results = metric.compute(pruna_model, smash_config.test_dataloader())
-    assert results[LATENCY] > 0
-    assert results[THROUGHPUT] > 0
-    assert results[TOTAL_TIME] > 0

--- a/tests/evaluation/test_model_architecture_metrics.py
+++ b/tests/evaluation/test_model_architecture_metrics.py
@@ -4,7 +4,7 @@ import pytest
 
 from pruna import SmashConfig
 from pruna.engine.pruna_model import PrunaModel
-from pruna.evaluation.metrics.metric_model_architecture import TotalMACsMetric, TotalParamsMetric, ModelArchitectureMetric, TOTAL_MACS, TOTAL_PARAMS
+from pruna.evaluation.metrics.metric_model_architecture import TotalMACsMetric, TotalParamsMetric
 
 
 @pytest.mark.parametrize(
@@ -39,19 +39,3 @@ def test_total_params_metric(model_fixture: tuple[Any, SmashConfig], device: str
     pruna_model = PrunaModel(model, smash_config=smash_config)
     params_results = params_metric.compute(pruna_model, smash_config.test_dataloader())
     assert params_results.result > 0
-
-@pytest.mark.parametrize(
-    "model_fixture, device",
-    [
-        pytest.param("sd_tiny_random", "cuda", marks=pytest.mark.cuda),
-    ],
-    indirect=["model_fixture"],
-)
-def test_deprecated_model_architecture(model_fixture: tuple[Any, SmashConfig], device: str) -> None:
-    """Test the deprecated model architecture metrics."""
-    model, smash_config = model_fixture
-    params_metric = ModelArchitectureMetric(device=device)
-    pruna_model = PrunaModel(model, smash_config=smash_config)
-    params_results = params_metric.compute(pruna_model, smash_config.test_dataloader())
-    assert params_results[TOTAL_MACS] > 0
-    assert params_results[TOTAL_PARAMS] > 0


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
 Removed deprecated:

-  stateless metrics
- metric modes for GPU memory metric
-  initialisation option with explicit call types


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


