### PR TITLE
fix: pin `torchmetric` until PSNR adjustment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ classifiers = [
 dependencies = [
     "torch==2.7.0",
     "torchvision==0.22.0",
-    "torchmetrics[image]",
+    "torchmetrics[image]==1.7.4",
     "requests>=2.31.0",
     "transformers",
     "pytorch-lightning",


### PR DESCRIPTION
## Description
After the release of torchmetrics `1.8.0` PSNR needs an additional `data_range` argument that needs to be implemented before upgrading to the latest version.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
