### PR TITLE
feat: add `flash_attention 3` kernel for diffusers pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Since Pruna offers a broad range of optimization algorithms, the following table
 | `factorizer` | Factorization batches several small matrix multiplications into one large fused operation. | ✅ | ➖ | ➖ |
 | `enhancer`   | Enhances the model output by applying post-processing algorithms such as denoising or upscaling. | ❌ | ➖ | ✅ |
 | `distributer`   | Distributes the inference, the model or certain calculations across multiple devices. | ✅ | ❌ | ➖ |
+| `kernel`   | Kernels are specialized GPU routines that speed up parts of the computation.  | ✅ | ➖ | ➖ |
 
 ✅ (improves), ➖ (approx. the same), ❌ (worsens)
 

--- a/docs/user_manual/configure.rst
+++ b/docs/user_manual/configure.rst
@@ -124,6 +124,11 @@ The table underneath provides a general overview of the impact of each algorithm
      - ✅
      - ❌
      - ➖
+   * - ``kernel``
+     - Specialized GPU routines that speed up parts of the computation.
+     - ✅
+     - ➖
+     - ➖
 
 ✅(improves), ➖(approx. the same), ❌(worsens)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ dependencies = [
     "gliner; python_version >= '3.10'",
     "piq",
     "opencv-python",
-    "kernels"
+    "kernels",
     "aenum"
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,8 @@ dependencies = [
     "gliner; python_version >= '3.10'",
     "piq",
     "opencv-python",
+    "kernels"
+    "aenum"
 
 ]
 

--- a/src/pruna/algorithms/caching/fora.py
+++ b/src/pruna/algorithms/caching/fora.py
@@ -43,6 +43,7 @@ class FORACacher(PrunaCacher):
         compiler=["stable_fast", "torch_compile"],
         quantizer=["diffusers_int8", "hqq_diffusers", "torchao"],
         factorizer=["qkv_diffusers"],
+        kernel=["flash_attn3"],
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/compilation/torch_compile.py
+++ b/src/pruna/algorithms/compilation/torch_compile.py
@@ -55,6 +55,7 @@ class TorchCompileCompiler(PrunaCompiler):
         quantizer=["half", "hqq_diffusers", "diffusers_int8", "gptq", "llm_int8", "hqq", "torchao"],
         cacher=["deepcache", "fora"],
         pruner=["torch_structured"],
+        kernel=["flash_attn3"],
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/algorithms/kernels/__init__.py
+++ b/src/pruna/algorithms/kernels/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pruna.algorithms.pruna_base import PrunaAlgorithmBase
+from pruna.config.smash_space import KERNEL
+from pruna.engine.save import SAVE_FUNCTIONS
+
+
+class PrunaKernel(PrunaAlgorithmBase):
+    """Base class for kernel algorithms."""
+
+    algorithm_group = KERNEL
+    save_fn = SAVE_FUNCTIONS.reapply

--- a/src/pruna/algorithms/kernels/flash_attn3.py
+++ b/src/pruna/algorithms/kernels/flash_attn3.py
@@ -46,7 +46,9 @@ class FlashAttn3Kernel(PrunaKernel):
     processor_required: bool = False
     runs_on: list[str] = ["cuda", "accelerate"]
     dataset_required: bool = False
-    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"], cacher=["fora"])
+    compatible_algorithms: dict[str, list[str]] = dict(
+        compiler=["torch_compile"], cacher=["fora"], quantizer=["torchao"]
+    )
 
     def model_check_fn(self, model: Any) -> bool:
         """
@@ -91,6 +93,9 @@ class FlashAttn3Kernel(PrunaKernel):
         """
         imported_packages = self.import_algorithm_packages()
 
+        # register the flash attention 3 operation with torch ops to make it compatible with full-graph compilation
+        register_pruna_flash_attn_op(imported_packages["flash_attention_3"])
+
         # in the new version of diffusers, we can use the modular attention backend to inject flash_attn3
         if Version(diffusers_version) >= Version("0.35.0.dev0"):
             # register our "custom" attention function as a backend
@@ -105,9 +110,6 @@ class FlashAttn3Kernel(PrunaKernel):
                     component.set_attention_backend("flash_attn3_pruna")
 
         else:
-            # register the flash attention 3 operation with torch ops to make it compatible with fullgraph compilation
-            register_pruna_flash_attn_op(imported_packages["flash_attention_3"])
-
             # wrap the model generate function to replace attention computations with flash_attn3 where possible
             wrap_pipeline_call(model, imported_packages)
         return model
@@ -152,6 +154,8 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
     """
     Register the attention backend for flash_attn3 by mimicing the native backend.
 
+    Applies to diffusers >= 0.35.0.dev0.
+
     Parameters
     ----------
     imported_packages : Dict[str, Any]
@@ -162,7 +166,6 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
     _check_shape = imported_packages["_check_shape"]
     _check_qkv_dtype_bf16_or_fp16 = imported_packages["_check_qkv_dtype_bf16_or_fp16"]
     _native_attention = imported_packages["_native_attention"]
-    flash_attention_3 = imported_packages["flash_attention_3"]
     attention_backend_name = imported_packages["AttentionBackendName"]
 
     if attention_backend_registry.get_active_backend()[0].name != "NATIVE":
@@ -203,7 +206,7 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
             # if any constraints are not met or unsupported input arguments are being used, reroute to native attention
             if attn_mask is not None or dropout_p != 0.0 or not dtype_pass or not num_heads_pass or not head_dim_pass:
                 pruna_logger.debug(
-                    "Rerouting to native attention... Check the following criteria: "
+                    "Rerouting to native attention. Check the following criteria in algorithms/kernels/flash_attn3.py: "
                     f"attn_mask_pass: {attn_mask is not None}, dropout_p_pass: {dropout_p != 0.0}, "
                     f"dtype_pass: {dtype_pass}, num_heads_pass: {num_heads_pass}, head_dim_pass: {head_dim_pass}"
                 )
@@ -220,13 +223,8 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
                 )
             else:
                 pruna_logger.debug("Using FA3...")
-                out, _, *_ = flash_attention_3.flash_attn_func(
-                    q=query,
-                    k=key,
-                    v=value,
-                    softmax_scale=scale,
-                    causal=is_causal,
-                    deterministic=False,
+                out, _, *_ = torch.ops.flash_attn_pruna._flash_attn_forward(
+                    q=query, k=key, v=value, softmax_scale=scale, causal=is_causal
                 )
                 return out
 
@@ -236,6 +234,8 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
 class FlashAttention3Context(TorchFunctionMode):
     """
     Context manager to intercept calls to scaled_dot_product_attention and replace them with flash_attn3.
+
+    Applies to diffusers < 0.35.0.dev0.
 
     Parameters
     ----------
@@ -282,7 +282,7 @@ class FlashAttention3Context(TorchFunctionMode):
                 return _flash_attention3(*args, **kwargs, kernel=self.kernel)
             else:
                 pruna_logger.debug(
-                    "Rerouting to native attention... Check the following criteria: "
+                    "Rerouting to native attention. Check the following criteria in algorithms/kernels/flash_attn3.py: "
                     f"attn_mask_pass: {attn_mask_pass}, dropout_p_pass: {dropout_p_pass}, shapes_pass: {shapes_pass},"
                     f"dtype_pass: {dtype_pass}, head_dim_pass: {head_dim_pass}"
                 )
@@ -302,6 +302,8 @@ def _flash_attention3(query, key, value, *, is_causal=False, softmax_scale=None,
 def wrap_pipeline_call(model: Any, imported_packages: Dict[str, Any]) -> None:
     """
     Wrap the model generate function to replace attention computations with flash_attn3 where possible.
+
+    Applies to diffusers < 0.35.0.dev0.
 
     Parameters
     ----------
@@ -339,7 +341,7 @@ def register_pruna_flash_attn_op(kernel_mod: Any) -> None:
         softmax_scale: float | None = None,
         causal: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        out, lse = flash_attn_cuda(q, k, v, softmax_scale=softmax_scale or None, causal=causal)
+        out, lse = flash_attn_cuda(q, k, v, softmax_scale=softmax_scale or None, causal=causal, deterministic=False)
         return out, lse.permute(0, 2, 1)  # (B,H,S) → (B,S,H)
 
     @torch.library.register_fake("flash_attn_pruna::_flash_attn_forward")

--- a/src/pruna/algorithms/kernels/flash_attn3.py
+++ b/src/pruna/algorithms/kernels/flash_attn3.py
@@ -1,0 +1,333 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+from aenum import extend_enum
+from diffusers import DiffusionPipeline
+from diffusers import __version__ as diffusers_version
+from kernels import get_kernel
+from packaging.version import Version
+from torch.overrides import TorchFunctionMode
+
+from pruna.algorithms.kernels import PrunaKernel
+from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.logging.logger import pruna_logger
+
+
+class FlashAttn3Kernel(PrunaKernel):
+    """
+    Replace torch.nn.functional.scaled_dot_product_attention with flash_attn3.
+
+    Flash Attention 3 is a fast and memory-efficient attention mechanism. It uses a combination of tiling, streaming
+    and fusing to speed up attention computations.
+    """
+
+    algorithm_name: str = "flash_attn3"
+    references: dict[str, str] = {
+        "GitHub": "https://github.com/Dao-AILab/flash-attention",
+        "Kernel Hub": "https://huggingface.co/kernels-community/models",
+    }
+    tokenizer_required: bool = False
+    processor_required: bool = False
+    runs_on: list[str] = ["cuda", "accelerate"]
+    dataset_required: bool = False
+    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"], cacher=["fora"])
+
+    def model_check_fn(self, model: Any) -> bool:
+        """
+        Check if the model has an attention mechanism that can be replaced with flash_attn3.
+
+        Parameters
+        ----------
+        model : Any
+            The model to check.
+
+        Returns
+        -------
+        bool
+            True if the model is a valid model for the algorithm, False otherwise.
+        """
+        if Version(diffusers_version) >= Version("0.35.0.dev0 "):
+            if not isinstance(model, DiffusionPipeline) or not hasattr(model, "components"):
+                return False
+
+            return any(
+                hasattr(component, "set_attention_backend") and component.dtype in [torch.bfloat16, torch.float16]
+                for component in model.components.values()
+            )
+        else:
+            return isinstance(model, DiffusionPipeline) and hasattr(model, "transformer")
+
+    def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
+        """
+        Wrap the model to use flash_attn3 where possible.
+
+        Parameters
+        ----------
+        model : Any
+            The model to wrap.
+        smash_config : SmashConfigPrefixWrapper
+            The configuration for the application of the algorithm.
+
+        Returns
+        -------
+        Any
+            The wrapped model.
+        """
+        imported_packages = self.import_algorithm_packages()
+
+        # in the new version of diffusers, we can use the modular attention backend to inject flash_attn3
+        if Version(diffusers_version) >= Version("0.35.0.dev0 "):
+            # register our "custom" attention function as a backend
+            register_custom_backend(imported_packages)
+
+            # replace in all compatible components
+            for component in model.components.values():
+                if hasattr(component, "set_attention_backend") and component.dtype in [torch.bfloat16, torch.float16]:
+                    component.set_attention_backend("flash_attn3_pruna")
+
+        else:
+            # register the flash attention 3 operation with torch ops to make it compatible with fullgraph compilation
+            register_pruna_flash_attn_op(imported_packages["flash_attention_3"])
+
+            # wrap the model generate function to replace attention computations with flash_attn3 where possible
+            wrap_pipeline_call(model, imported_packages)
+        return model
+
+    def import_algorithm_packages(self) -> Dict[str, Any]:
+        """
+        Import the algorithm packages.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The algorithm packages.
+        """
+        flash_attention_3 = get_kernel("kernels-community/flash-attn3")
+        packages = {"flash_attention_3": flash_attention_3}
+
+        if Version(diffusers_version) >= Version("0.35.0.dev0"):
+            from diffusers.models.attention_dispatch import (
+                AttentionBackendName,
+                _AttentionBackendRegistry,
+                _check_device,
+                _check_qkv_dtype_bf16_or_fp16,
+                _check_shape,
+                _native_attention,
+            )
+
+            packages.update(
+                {
+                    "_AttentionBackendRegistry": _AttentionBackendRegistry,
+                    "_check_device": _check_device,
+                    "_check_qkv_dtype_bf16_or_fp16": _check_qkv_dtype_bf16_or_fp16,
+                    "_check_shape": _check_shape,
+                    "_native_attention": _native_attention,
+                    "AttentionBackendName": AttentionBackendName,
+                    "flash_attention_3": flash_attention_3,
+                }
+            )
+        return packages
+
+
+def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
+    """
+    Register the attention backend for flash_attn3 by mimicing the native backend.
+
+    Parameters
+    ----------
+    imported_packages : Dict[str, Any]
+        The imported packages.
+    """
+    attention_backend_registry = imported_packages["_AttentionBackendRegistry"]
+    _check_device = imported_packages["_check_device"]
+    _check_shape = imported_packages["_check_shape"]
+    _check_qkv_dtype_bf16_or_fp16 = imported_packages["_check_qkv_dtype_bf16_or_fp16"]
+    _native_attention = imported_packages["_native_attention"]
+    flash_attention_3 = imported_packages["flash_attention_3"]
+    attention_backend_name = imported_packages["AttentionBackendName"]
+
+    if attention_backend_registry.get_active_backend()[0] != "NATIVE":
+        pruna_logger.warning(
+            "The current active attention backend is not native. This might lead to unexpected behavior."
+        )
+
+    if "FLASH_ATTN3_PRUNA" not in attention_backend_name.__members__:
+
+        @attention_backend_registry.register(
+            "flash_attn3_pruna",
+            constraints=[_check_device, _check_shape],
+        )
+        def _flash_attention_3(
+            query: torch.Tensor,
+            key: torch.Tensor,
+            value: torch.Tensor,
+            scale: Optional[float] = None,
+            is_causal: bool = False,
+            # unsupported by flash_attn3 but we catch them to reroute to native attention if necessary
+            attn_mask: Optional[torch.Tensor] = None,
+            dropout_p: float = 0.0,
+            enable_gqa: bool = False,
+        ) -> torch.Tensor:
+            # flash attention 3 only supports bfloat16 and fp16
+            dtype_pass = True
+            try:
+                _check_qkv_dtype_bf16_or_fp16(query=query, key=key, value=value)
+            except ValueError:
+                dtype_pass = False
+
+            # fa3 only supports attention with num_query_heads % num_kv_heads == 0
+            num_heads_pass = all(t.shape[1] % t.shape[2] == 0 for t in (query, key, value))
+
+            # test head dimension
+            head_dim_pass = all(t.shape[3] <= 256 for t in (query, key, value))
+
+            # if any constraints are not met or unsupported input arguments are being used, reroute to native attention
+            if attn_mask is not None or dropout_p != 0.0 or not dtype_pass or not num_heads_pass or not head_dim_pass:
+                return _native_attention(
+                    query=query,
+                    key=key,
+                    value=value,
+                    attn_mask=attn_mask,
+                    dropout_p=dropout_p,
+                    is_causal=is_causal,
+                    scale=scale,
+                    # GQA is anyway supported by flash attention 3
+                    enable_gqa=enable_gqa,
+                )
+            else:
+                out, _, *_ = flash_attention_3.flash_attn_func(
+                    q=query,
+                    k=key,
+                    v=value,
+                    softmax_scale=scale,
+                    causal=is_causal,
+                    deterministic=False,
+                )
+                return out
+
+        extend_enum(attention_backend_name, "FLASH_ATTN3_PRUNA", "flash_attn3_pruna")
+
+
+class FlashAttention3Context(TorchFunctionMode):
+    """
+    Context manager to intercept calls to scaled_dot_product_attention and replace them with flash_attn3.
+
+    Parameters
+    ----------
+    kernel : Any
+        The kernel to use for the flash attention 3.
+    """
+
+    def __init__(self, kernel: Any):
+        super().__init__()
+        self.kernel = kernel
+
+    def __torch_function__(self, func, types, args=(), kwargs=None):  # noqa: D105
+        kwargs = {} if kwargs is None else kwargs
+        if func == torch.nn.functional.scaled_dot_product_attention:
+            # rename keyword arguments in case of naming mismatch
+            if "q" in kwargs:
+                kwargs["query"] = kwargs.pop("q")
+            if "k" in kwargs:
+                kwargs["key"] = kwargs.pop("k")
+            if "v" in kwargs:
+                kwargs["value"] = kwargs.pop("v")
+
+            # parse arguments from kwargs or args
+            query = kwargs["query"] if "query" in kwargs else args[0]
+            key = kwargs["key"] if "key" in kwargs else args[1]
+            value = kwargs["value"] if "value" in kwargs else args[2]
+
+            # check that unsupported arguments are not being used
+            attn_mask_pass = kwargs.get("attn_mask", None) is None
+            dropout_p_pass = kwargs.get("dropout_p", 0.0) == 0.0
+
+            # check that the sequence dimension is divisible by the number of heads
+            shapes_pass = all(t.shape[1] % query.shape[1] == 0 for t in (key, value))
+            # check that the dtype is bfloat16 or fp16
+            dtype_pass = query.dtype in [torch.bfloat16, torch.float16]
+            head_dim_pass = all(t.shape[3] <= 256 for t in (key, value, query))
+
+            if attn_mask_pass and dropout_p_pass and shapes_pass and dtype_pass and head_dim_pass:
+                kwargs.pop("attn_mask", None)
+                kwargs.pop("dropout_p", None)
+                kwargs.pop("enable_gqa", None)
+                kwargs["softmax_scale"] = kwargs.pop("scale", None)
+                print("Using Flash 3 attention")
+                return _flash_attention3(*args, **kwargs, kernel=self.kernel)
+            else:
+                print("Rerouting to native attention")
+                return func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
+
+def _flash_attention3(query, key, value, *, is_causal=False, softmax_scale=None, kernel=None):
+    # convert (B, H, S, D) → (B, S, H, D)
+    q, k, v = [x.transpose(1, 2).contiguous() for x in (query, key, value)]
+    out, _ = torch.ops.flash_attn_pruna._flash_attn_forward(q, k, v, causal=is_causal, softmax_scale=softmax_scale)
+    # back to (B, H, S, D) for the rest of the pipeline
+    return out.transpose(1, 2)
+
+
+def wrap_pipeline_call(model: Any, imported_packages: Dict[str, Any]) -> None:
+    """
+    Wrap the model generate function to replace attention computations with flash_attn3 where possible.
+
+    Parameters
+    ----------
+    model : Any
+        The model to wrap.
+    imported_packages : Dict[str, Any]
+        The imported packages.
+    """
+    original_forward = model.__call__
+
+    @functools.wraps(original_forward)
+    def new_forward(*args, original_forward=original_forward, **kwargs):
+        with FlashAttention3Context(kernel=imported_packages["flash_attention_3"]):
+            return original_forward(*args, **kwargs)
+
+    model.__call__ = new_forward  # type: ignore
+
+
+def register_pruna_flash_attn_op(kernel_mod: Any) -> None:
+    """
+    Register the flash attention 3 operation with torch ops to make it compatible with fullgraph compilation.
+
+    Parameters
+    ----------
+    kernel_mod : Any
+        The flash attention 3 kernel module.
+    """
+    flash_attn_cuda = kernel_mod.flash_attn_func
+
+    @torch.library.custom_op("flash_attn_pruna::_flash_attn_forward", mutates_args=(), device_types="cuda")
+    def _flash_attn_forward(
+        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float | None = None, causal: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        out, lse = flash_attn_cuda(q, k, v, softmax_scale=softmax_scale or None, causal=causal)
+        return out, lse.permute(0, 2, 1)  # (B,H,S) → (B,S,H)
+
+    @torch.library.register_fake("flash_attn_pruna::_flash_attn_forward")
+    def _flash_attn_forward_fake(
+        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float | None = None, causal: bool = False
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        b, s, h, d = q.shape
+        return torch.empty_like(q), q.new_empty((b, s, h))

--- a/src/pruna/algorithms/kernels/flash_attn3.py
+++ b/src/pruna/algorithms/kernels/flash_attn3.py
@@ -46,7 +46,9 @@ class FlashAttn3Kernel(PrunaKernel):
     processor_required: bool = False
     runs_on: list[str] = ["cuda", "accelerate"]
     dataset_required: bool = False
-    compatible_algorithms: dict[str, list[str]] = dict(compiler=["torch_compile"], cacher=["fora"])
+    compatible_algorithms: dict[str, list[str]] = dict(
+        compiler=["torch_compile"], cacher=["fora"]
+    )
 
     def model_check_fn(self, model: Any) -> bool:
         """
@@ -62,16 +64,21 @@ class FlashAttn3Kernel(PrunaKernel):
         bool
             True if the model is a valid model for the algorithm, False otherwise.
         """
-        if Version(diffusers_version) >= Version("0.35.0.dev0 "):
-            if not isinstance(model, DiffusionPipeline) or not hasattr(model, "components"):
+        if Version(diffusers_version) >= Version("0.35.0.dev0"):
+            if not isinstance(model, DiffusionPipeline) or not hasattr(
+                model, "components"
+            ):
                 return False
 
             return any(
-                hasattr(component, "set_attention_backend") and component.dtype in [torch.bfloat16, torch.float16]
+                hasattr(component, "set_attention_backend")
+                and component.dtype in [torch.bfloat16, torch.float16]
                 for component in model.components.values()
             )
         else:
-            return isinstance(model, DiffusionPipeline) and hasattr(model, "transformer")
+            return isinstance(model, DiffusionPipeline) and hasattr(
+                model, "transformer"
+            )
 
     def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         """
@@ -92,13 +99,16 @@ class FlashAttn3Kernel(PrunaKernel):
         imported_packages = self.import_algorithm_packages()
 
         # in the new version of diffusers, we can use the modular attention backend to inject flash_attn3
-        if Version(diffusers_version) >= Version("0.35.0.dev0 "):
+        if Version(diffusers_version) >= Version("0.35.0.dev0"):
             # register our "custom" attention function as a backend
             register_custom_backend(imported_packages)
 
             # replace in all compatible components
             for component in model.components.values():
-                if hasattr(component, "set_attention_backend") and component.dtype in [torch.bfloat16, torch.float16]:
+                if hasattr(component, "set_attention_backend") and component.dtype in [
+                    torch.bfloat16,
+                    torch.float16,
+                ]:
                     component.set_attention_backend("flash_attn3_pruna")
 
         else:
@@ -162,7 +172,7 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
     flash_attention_3 = imported_packages["flash_attention_3"]
     attention_backend_name = imported_packages["AttentionBackendName"]
 
-    if attention_backend_registry.get_active_backend()[0] != "NATIVE":
+    if attention_backend_registry.get_active_backend()[0].name != "NATIVE":
         pruna_logger.warning(
             "The current active attention backend is not native. This might lead to unexpected behavior."
         )
@@ -192,13 +202,19 @@ def register_custom_backend(imported_packages: Dict[str, Any]) -> None:
                 dtype_pass = False
 
             # fa3 only supports attention with num_query_heads % num_kv_heads == 0
-            num_heads_pass = all(t.shape[1] % t.shape[2] == 0 for t in (query, key, value))
+            num_heads_pass = all(query.shape[1] % t.shape[1] == 0 for t in (key, value))
 
             # test head dimension
             head_dim_pass = all(t.shape[3] <= 256 for t in (query, key, value))
 
             # if any constraints are not met or unsupported input arguments are being used, reroute to native attention
-            if attn_mask is not None or dropout_p != 0.0 or not dtype_pass or not num_heads_pass or not head_dim_pass:
+            if (
+                attn_mask is not None
+                or dropout_p != 0.0
+                or not dtype_pass
+                or not num_heads_pass
+                or not head_dim_pass
+            ):
                 pruna_logger.debug(
                     "Rerouting to native attention... Check the following criteria: "
                     f"attn_mask_pass: {attn_mask is not None}, dropout_p_pass: {dropout_p != 0.0}, dtype_pass: {dtype_pass},"
@@ -264,13 +280,19 @@ class FlashAttention3Context(TorchFunctionMode):
             attn_mask_pass = kwargs.get("attn_mask", None) is None
             dropout_p_pass = kwargs.get("dropout_p", 0.0) == 0.0
 
-            # check that the sequence dimension is divisible by the number of heads
-            shapes_pass = all(t.shape[1] % query.shape[1] == 0 for t in (key, value))
+            # check that the number of query heads is divisible by the number of key/value heads (GQA constraint)
+            shapes_pass = all(query.shape[1] % t.shape[1] == 0 for t in (key, value))
             # check that the dtype is bfloat16 or fp16
             dtype_pass = query.dtype in [torch.bfloat16, torch.float16]
             head_dim_pass = all(t.shape[3] <= 256 for t in (key, value, query))
 
-            if attn_mask_pass and dropout_p_pass and shapes_pass and dtype_pass and head_dim_pass:
+            if (
+                attn_mask_pass
+                and dropout_p_pass
+                and shapes_pass
+                and dtype_pass
+                and head_dim_pass
+            ):
                 kwargs.pop("attn_mask", None)
                 kwargs.pop("dropout_p", None)
                 kwargs.pop("enable_gqa", None)
@@ -288,10 +310,14 @@ class FlashAttention3Context(TorchFunctionMode):
             return func(*args, **kwargs)
 
 
-def _flash_attention3(query, key, value, *, is_causal=False, softmax_scale=None, kernel=None):
+def _flash_attention3(
+    query, key, value, *, is_causal=False, softmax_scale=None, kernel=None
+):
     # convert (B, H, S, D) → (B, S, H, D)
     q, k, v = [x.transpose(1, 2).contiguous() for x in (query, key, value)]
-    out, _ = torch.ops.flash_attn_pruna._flash_attn_forward(q, k, v, causal=is_causal, softmax_scale=softmax_scale)
+    out, _ = torch.ops.flash_attn_pruna._flash_attn_forward(
+        q, k, v, causal=is_causal, softmax_scale=softmax_scale
+    )
     # back to (B, H, S, D) for the rest of the pipeline
     return out.transpose(1, 2)
 
@@ -328,16 +354,28 @@ def register_pruna_flash_attn_op(kernel_mod: Any) -> None:
     """
     flash_attn_cuda = kernel_mod.flash_attn_func
 
-    @torch.library.custom_op("flash_attn_pruna::_flash_attn_forward", mutates_args=(), device_types="cuda")
+    @torch.library.custom_op(
+        "flash_attn_pruna::_flash_attn_forward", mutates_args=(), device_types="cuda"
+    )
     def _flash_attn_forward(
-        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float | None = None, causal: bool = False
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale: float | None = None,
+        causal: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        out, lse = flash_attn_cuda(q, k, v, softmax_scale=softmax_scale or None, causal=causal)
+        out, lse = flash_attn_cuda(
+            q, k, v, softmax_scale=softmax_scale or None, causal=causal
+        )
         return out, lse.permute(0, 2, 1)  # (B,H,S) → (B,S,H)
 
     @torch.library.register_fake("flash_attn_pruna::_flash_attn_forward")
     def _flash_attn_forward_fake(
-        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, softmax_scale: float | None = None, causal: bool = False
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        softmax_scale: float | None = None,
+        causal: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         b, s, h, d = q.shape
         return torch.empty_like(q), q.new_empty((b, s, h))

--- a/src/pruna/algorithms/quantization/torchao.py
+++ b/src/pruna/algorithms/quantization/torchao.py
@@ -85,6 +85,7 @@ class TorchaoQuantizer(PrunaQuantizer):
         compiler=["torch_compile"],
         factorizer=["qkv_diffusers"],
         pruner=["torch_structured"],
+        kernel=["flash_attn3"],
     )
 
     def get_hyperparameters(self) -> list:

--- a/src/pruna/config/smash_space.py
+++ b/src/pruna/config/smash_space.py
@@ -34,9 +34,10 @@ COMPILER = "compiler"
 CACHER = "cacher"
 BATCHER = "batcher"
 FACTORIZER = "factorizer"
+KERNEL = "kernel"
 
-# this ordering determins the order of smashing, modify carefully
-ALGORITHM_GROUPS = [FACTORIZER, PRUNER, QUANTIZER, CACHER, COMPILER, BATCHER]
+# this ordering determines the order of smashing, modify carefully
+ALGORITHM_GROUPS = [FACTORIZER, PRUNER, QUANTIZER, KERNEL, CACHER, COMPILER, BATCHER]
 
 
 class Boolean(CategoricalHyperparameter):

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -59,6 +59,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("flux_tiny_random", dict(cacher="fora", compiler="torch_compile"), False, 'cmmd'),
         ("flux_tiny_random", dict(cacher="fora", compiler="stable_fast"), False, 'cmmd'),
         ("tiny_janus_pro", dict(quantizer="hqq", compiler="torch_compile"), False, 'cmmd'),
+        ("flux_tiny", dict(cacher="fora", kernel="flash_attn3", compiler="torch_compile"), False, 'cmmd'),
     ],
     indirect=["model_fixture"],
 )

--- a/tests/algorithms/testers/__init__.py
+++ b/tests/algorithms/testers/__init__.py
@@ -5,3 +5,4 @@ from .compilation import *
 from .factorizing import *
 from .pruning import *
 from .quantization import *
+from .kernels import *

--- a/tests/algorithms/testers/kernels.py
+++ b/tests/algorithms/testers/kernels.py
@@ -1,0 +1,13 @@
+from pruna.algorithms.kernels.flash_attn3 import FlashAttn3Kernel
+
+from .base_tester import AlgorithmTesterBase
+
+
+class TestFlashAttn3(AlgorithmTesterBase):
+    """Test the flash attention 3 kernel."""
+
+    models = ["flux_tiny", "wan_tiny_random"]
+    reject_models = ["opt_tiny_random"]
+    allow_pickle_files = False
+    algorithm_class = FlashAttn3Kernel
+    metrics = ["latency"]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -149,7 +149,7 @@ MODEL_FACTORY: dict[str, Callable] = {
         torch_dtype=torch.float16,
     ),
     "sana_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-sana"),
-    "flux_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-flux"),
+    "flux_tiny_random": partial(get_diffusers_model, "katuni4ka/tiny-random-flux", torch_dtype=torch.bfloat16),
     # text generation models
     "opt_125m": partial(get_automodel_transformers, "facebook/opt-125m"),
     "opt_tiny_random": partial(get_automodel_transformers, "yujiepan/opt-tiny-random"),
@@ -160,4 +160,6 @@ MODEL_FACTORY: dict[str, Callable] = {
     "dummy_lambda": dummy_model,
     # image generation AR models
     "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "loulou2/tiny_janus"),
+    "wan_tiny_random": partial(get_diffusers_model, "PrunaAI/wan-t2v-tiny-random", torch_dtype=torch.bfloat16),
+    "flux_tiny": partial(get_diffusers_model, "loulou2/tiny_flux", torch_dtype=torch.float16),
 }


### PR DESCRIPTION
## Description
In this PR, we make use of HuggingFace's kernel hub to utilize flash attention 3 in diffusers pipelines where possible. Importantly, diffusers is refactoring their attention handling right now, hence we have two different implementations. 

In the current diffusers version, we wrap the call of a pipeline to intercept each call to `torch.nn.funcional.scaled_dot_product_attention`. If shapes, dtype and keyword arguments can be supported by flash attention, we reroute the computation to the fa3 kernel.

In the newer diffusers version (0.35.0, unreleased so far), we can register a new attention backend that calls the native attention or fa3 on the same criteria.

Overall, the speedup is minor for T2I pipelines but is substantial for Video Gen pipelines, in particular Wan.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Added algorithm tests with Flux and Wan and added combination tests.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
Flash Attention 3 on WAN gives around a 1.4 speedup, no warmup or quality degradation of course.


Minimal Script:
``` python
from pruna import SmashConfig, smash
from diffusers import WanPipeline
import torch

pipeline = WanPipeline.from_pretrained(
    "Wan-AI/Wan2.2-T2V-A14B-Diffusers", torch_dtype=torch.bfloat16
)
pipeline.to("cuda");

config = SmashConfig()
config._prepare_saving = False
config["kernel"] = "flash_attn3"
pipeline = smash(pipeline, config)

prompt = "A cat is doing an acrobatic dive into a swimming pool at the olympics, from a 10m high diving board, flips and spins"
negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
output = pipeline.__call__(
    prompt=prompt,
    negative_prompt=negative_prompt,
    height=480,
    width=640,
    num_frames=69,
    guidance_scale=5.0,
    num_inference_steps=10,
    generator=torch.Generator(device="cpu").manual_seed(1),
).frames[0]
```
Output during Generation:
`100%|██████████| 10/10 [01:04<00:00,  6.45s/it]`

----
Generation times on the prompt / size above on 1 H100:
- base: 8.04 s/it
- `flash_attn3`: 6.46 s/it (no warmup!)
- `torch.compile`: 6.38 s/it
- `flash_attn3` + `torch.compile`: 5.15 s/it
