### PR TITLE
fix: make qkv compatible with torch.compile in next diffusers release

### DIFF
--- a/src/pruna/algorithms/factorizing/qkv_diffusers.py
+++ b/src/pruna/algorithms/factorizing/qkv_diffusers.py
@@ -94,6 +94,11 @@ class QKVDiffusers(PrunaFactorizer):
         with ModelContext(model) as (pipeline, working_model, denoiser_type):
             # only this line thanks to https://github.com/huggingface/diffusers/pull/9185
             working_model.fuse_qkv_projections()
+            # adding a single attention processor instance for all layers for torch compile compatibility
+            # Get a random processor instance to initialize the new single processor
+            random_key = next(iter(working_model.attn_processors.keys()))
+            processor = working_model.attn_processors[random_key]
+            working_model.set_attn_processor(processor)
             # redefining the working_model breaks links with context manager
             # so we need to re-define the working_model as an attribute of the model.
             pipeline.working_model = working_model

--- a/src/pruna/engine/model_checks.py
+++ b/src/pruna/engine/model_checks.py
@@ -28,6 +28,8 @@ from transformers.pipelines.automatic_speech_recognition import AutomaticSpeechR
 from transformers.pipelines.text2text_generation import Text2TextGenerationPipeline
 from transformers.pipelines.text_generation import TextGenerationPipeline
 
+from pruna.engine.utils import ModelContext
+
 
 def is_causal_lm(model: Any) -> bool:
     """
@@ -593,34 +595,6 @@ def get_diffusers_unet_models() -> list:
     return unet_models
 
 
-def check_fused_attention_processor(model: Any) -> bool:
-    """
-    Helper function to check attention processors in a model.
-
-    Parameters
-    ----------
-    model : Any
-        The model to check.
-
-    Returns
-    -------
-    bool
-        True if the model can use a Fused attention processor, False otherwise.
-    """
-    if not hasattr(model, "attn_processors"):
-        return False
-    try:
-        attention_processor_module = diffusers.models.attention_processor  # type: ignore
-        fusing_possible_list = [
-            processor_name.replace("Fused", "")
-            for processor_name in dir(attention_processor_module)
-            if "Fused" in processor_name
-        ]
-        return any(processor.__class__.__name__ in fusing_possible_list for processor in model.attn_processors.values())
-    except AttributeError:
-        return False
-
-
 def has_fused_attention_processor(pipeline: Any) -> bool:
     """
     Check if the pipeline's unet or transformer can use a Fused attention processor.
@@ -635,9 +609,14 @@ def has_fused_attention_processor(pipeline: Any) -> bool:
     bool
         True if the pipeline can use a Fused attention processor, False otherwise.
     """
-    return (hasattr(pipeline, "unet") and check_fused_attention_processor(pipeline.unet)) or (
-        hasattr(pipeline, "transformer") and check_fused_attention_processor(pipeline.transformer)
-    )
+    with ModelContext(pipeline) as (_, working_model, _):
+        if hasattr(working_model, "fuse_qkv_projections"):
+            for _, attn_processor in working_model.attn_processors.items():
+                if "Added" in str(attn_processor.__class__.__name__):
+                    return False
+            return True
+        else:
+            return False
 
 
 def is_opt_model(model: Any) -> bool:

--- a/src/pruna/engine/model_checks.py
+++ b/src/pruna/engine/model_checks.py
@@ -610,6 +610,8 @@ def has_fused_attention_processor(pipeline: Any) -> bool:
         True if the pipeline can use a Fused attention processor, False otherwise.
     """
     with ModelContext(pipeline) as (_, working_model, _):
+        # add this line just to make the __exit__ method of ModelContext work
+        pipeline.working_model = working_model
         if hasattr(working_model, "fuse_qkv_projections"):
             for _, attn_processor in working_model.attn_processors.items():
                 if "Added" in str(attn_processor.__class__.__name__):


### PR DESCRIPTION
## Description
The current main branch in `diffusers` is undergoing a large refactorization for attention computation.
The attention processors still exist but Flux and Wan have now a local version of their own processor. Also qkv fusing was changed: it is now taking place in the AttentionMixin class (not anymore in the transformer class itself).
Sister PR in pruna_pro is [here](https://github.com/PrunaAI/prunatree/pull/197).

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
The combination qkv_diffusers+torch_compile is taking forever to compute on the latest diffusers codebase

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Tested on Flux-dev with diffusers==0.34.0 and diffusers==0.35.0dev0
On Flux-dev, the generation time goes from 10.44s (original) to 5.12s (with `qkv_diffusers`+`fp8`+`torch_compile`).
The warm-up time (first inference) takes 56.16s.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
