### PR TITLE
torch.load always to cpu first

### DIFF
--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -329,10 +329,10 @@ def load_pickled(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
     model = torch.load(
         Path(path) / PICKLED_FILE_NAME,
         weights_only=False,
-        map_location=target_device,
+        map_location="cpu",
         **filter_load_kwargs(torch.load, kwargs),
     )
-    # for cpu/cuda this will just continue as its on the correct device, for accelerate it will now distribute / cast
+    # move to target device, for accelerate it will now distribute / cast
     move_to_device(model, target_device, device_map=smash_config.device_map)
     return model
 


### PR DESCRIPTION
## Description
This PR does a little fix
When using torch.load, always load to cpu first and then move to target device.
Problem when loading to the device directly was, that every tensor within a pipeline e.g. was moved to cuda, also some which are not supposed to be - not every pipeline can handle this unexpected device (e.g. SanaPipeline)
By loading to cpu first and then moving to target device, we make sure that only the right parts are moved to the target_device

## Related Issue


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Every test which is using torch.load has been re-run and is successful

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
