### PR TITLE
feat: add prompt only image generation datasets

### DIFF
--- a/docs/user_manual/configure.rst
+++ b/docs/user_manual/configure.rst
@@ -266,9 +266,9 @@ Underneath you can find the list of all the available datasets.
      - ``text_generation_collate``
      - ``text: str``
    * - Image Generation
-     - `LAION256 <https://huggingface.co/datasets/nannullna/laion_subset>`_, `OpenImage <https://huggingface.co/datasets/data-is-better-together/open-image-preferences-v1>`_, `COCO <https://huggingface.co/datasets/phiyodr/coco2017>`_
+     - `LAION256 <https://huggingface.co/datasets/nannullna/laion_subset>`_, `OpenImage <https://huggingface.co/datasets/data-is-better-together/open-image-preferences-v1>`_, `COCO <https://huggingface.co/datasets/phiyodr/coco2017>`_, `DrawBench <https://huggingface.co/datasets/sayakpaul/drawbench>`_, `PartiPrompts <https://huggingface.co/datasets/nateraw/parti-prompts>`_, `GenAIBench <https://huggingface.co/datasets/BaiqiL/GenAI-Bench>`_
      - ``image_generation_collate``
-     - ``image: PIL.Image.Image``, ``text: str``
+     - ``image: Optional[PIL.Image.Image]``, ``text: str``
    * - Image Classification
      - `ImageNet <https://huggingface.co/datasets/zh-plus/tiny-imagenet>`_, `MNIST <https://huggingface.co/datasets/ylecun/mnist>`_, `CIFAR10 <https://huggingface.co/datasets/uoft-cs/cifar10>`_
      - ``image_classification_collate``

--- a/src/pruna/data/__init__.py
+++ b/src/pruna/data/__init__.py
@@ -35,8 +35,11 @@ from pruna.data.datasets.text_generation import (
 )
 from pruna.data.datasets.text_to_image import (
     setup_coco_dataset,
+    setup_drawbench_dataset,
+    setup_genai_bench_dataset,
     setup_laion256_dataset,
     setup_open_image_dataset,
+    setup_parti_prompts_dataset,
 )
 
 base_datasets: dict[str, Tuple[Callable, str, dict[str, Any]]] = {
@@ -56,4 +59,7 @@ base_datasets: dict[str, Tuple[Callable, str, dict[str, Any]]] = {
     "Polyglot": (setup_polyglot_dataset, "question_answering_collate", {}),
     "OpenImage": (setup_open_image_dataset, "image_generation_collate", {"img_size": 1024}),
     "CIFAR10": (setup_cifar10_dataset, "image_classification_collate", {"img_size": 32}),
+    "DrawBench": (setup_drawbench_dataset, "image_generation_collate", {"img_size": None}),
+    "PartiPrompts": (setup_parti_prompts_dataset, "image_generation_collate", {"img_size": None}),
+    "GenAIBench": (setup_genai_bench_dataset, "image_generation_collate", {"img_size": None}),
 }

--- a/src/pruna/data/collate.py
+++ b/src/pruna/data/collate.py
@@ -54,7 +54,9 @@ def image_format_to_transforms(output_format: str, img_size: int) -> transforms.
         raise ValueError(f"Invalid output format: {output_format}")
 
 
-def image_generation_collate(data: Any, img_size: int, output_format: str = "int") -> Tuple[List[str], torch.Tensor]:
+def image_generation_collate(
+    data: Any, img_size: int | None, output_format: str = "int"
+) -> Tuple[List[str], torch.Tensor]:
     """
     Custom collation function for text-to-image generation datasets.
 
@@ -65,8 +67,8 @@ def image_generation_collate(data: Any, img_size: int, output_format: str = "int
     ----------
     data : Any
         The data to collate.
-    img_size : int
-        The size of the image to resize to.
+    img_size : int | None
+        The size of the image to resize to. None if dataset does not contain images.
     output_format : str
         The output format, in ["int", "float", "normalized"].
         With "int", output tensors have integer values between 0 and 255. With "float", they have float values
@@ -77,17 +79,21 @@ def image_generation_collate(data: Any, img_size: int, output_format: str = "int
     Tuple[torch.Tensor, Any]
         The collated data with size img_size and normalized to [0, 1].
     """
-    transformations = image_format_to_transforms(output_format, img_size)
+    if img_size is not None:
+        transformations = image_format_to_transforms(output_format, img_size)
     images, texts = [], []
 
     for item in data:
+        texts.append(item["text"])
+        if img_size is None:
+            continue
         image = item["image"]
         if image.mode != "RGB":
             image = image.convert("RGB")
         image_tensor = transformations(image)
         images.append(image_tensor)
-        texts.append(item["text"])
-
+    if img_size is None:
+        return texts, None
     images_tensor = torch.stack(images)
     return texts, images_tensor
 

--- a/src/pruna/data/datasets/text_to_image.py
+++ b/src/pruna/data/datasets/text_to_image.py
@@ -124,3 +124,66 @@ def setup_coco_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     val_dataset = dataset["validation"].map(partial(_process_example, directory_dataset=str(directory_dataset)))
     val_dataset, test_dataset = split_val_into_val_test(val_dataset, seed)
     return train_dataset, val_dataset, test_dataset
+
+
+def setup_drawbench_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
+    """
+    Setup the DrawBench dataset.
+
+    License: Apache 2.0
+
+    Parameters
+    ----------
+    seed : int
+        The seed to use.
+
+    Returns
+    -------
+    Tuple[Dataset, Dataset, Dataset]
+        The DrawBench dataset.
+    """
+    ds = load_dataset("sayakpaul/drawbench", trust_remote_code=True)["train"]
+    ds = ds.rename_column("Prompts", "text")
+    return ds.select([0]), ds.select([0]), ds
+
+
+def setup_parti_prompts_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
+    """
+    Setup the Parti Prompts dataset.
+
+    License: Apache 2.0
+
+    Parameters
+    ----------
+    seed : int
+        The seed to use.
+
+    Returns
+    -------
+    Tuple[Dataset, Dataset, Dataset]
+        The Parti Prompts dataset.
+    """
+    ds = load_dataset("nateraw/parti-prompts")["train"]
+    ds = ds.rename_column("Prompt", "text")
+    return ds.select([0]), ds.select([0]), ds
+
+
+def setup_genai_bench_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
+    """
+    Setup the GenAI Bench dataset.
+
+    License: Apache 2.0
+
+    Parameters
+    ----------
+    seed : int
+        The seed to use.
+
+    Returns
+    -------
+    Tuple[Dataset, Dataset, Dataset]
+        The GenAI Bench dataset.
+    """
+    ds = load_dataset("BaiqiL/GenAI-Bench")["train"]
+    ds = ds.rename_column("Prompt", "text")
+    return ds.select([0]), ds.select([0]), ds

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -36,6 +36,9 @@ def iterate_dataloaders(datamodule: PrunaDataModule) -> None:
         pytest.param("OpenAssistant", dict(tokenizer=bert_tokenizer), marks=pytest.mark.slow),
         pytest.param("C4", dict(tokenizer=bert_tokenizer), marks=pytest.mark.slow),
         pytest.param("Polyglot", dict(tokenizer=bert_tokenizer), marks=pytest.mark.slow),
+        pytest.param("DrawBench", dict(), marks=pytest.mark.slow),
+        pytest.param("PartiPrompts", dict(), marks=pytest.mark.slow),
+        pytest.param("GenAIBench", dict(), marks=pytest.mark.slow),
     ],
 )
 def test_dm_from_string(dataset_name: str, collate_fn_args: dict[str, Any]) -> None:


### PR DESCRIPTION
## Description
Currently, we only support image-generation datasets consisting of prompt–image pairs. For many applications (e.g., evaluation agents, distillation), only the prompt is needed, and some benchmarking datasets for image-generation models consist of prompts only. This PR relaxes the requirement to always include images by adjusting the collate function. It also adds three common benchmarking datasets for image-generation models: DrawBench, PartiPrompts, and GenAiBench.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
- I added tests for the newly added datasets that pass locally.
- I tried the old and new image generation datasets together with the optimization agent. 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
