### PR TITLE
fix: update datamodules for datasets v4.0.0

### DIFF
--- a/docs/user_manual/configure.rst
+++ b/docs/user_manual/configure.rst
@@ -277,7 +277,7 @@ Underneath you can find the list of all the available datasets.
      - ``image_classification_collate``
      - ``image: PIL.Image.Image``, ``label: int``
    * - Audio Processing
-     - `CommonVoice <https://huggingface.co/datasets/mozilla-foundation/common_voice_1_0>`_, `AIPodcast <https://huggingface.co/datasets/reach-vb/random-audios/blob/main/sam_altman_lex_podcast_367.flac>`_, `MiniPresentation <https://huggingface.co/datasets/reach-vb/random-audios/blob/main/4469669-10.mp3>`_
+     - `LibriSpeech <https://huggingface.co/datasets/argmaxinc/librispeech-200>`_, `AIPodcast <https://huggingface.co/datasets/reach-vb/random-audios/blob/main/sam_altman_lex_podcast_367.flac>`_, `MiniPresentation <https://huggingface.co/datasets/reach-vb/random-audios/blob/main/4469669-10.mp3>`_
      - ``audio_processing_collate``
      - ``audio: Optional[torch.Tensor]``, ``path: Optional[str]``, ``sentence: str``
    * - Question Answering

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ dependencies = [
     "transformers",
     "pytorch-lightning",
     "huggingface-hub[hf-xet]>=0.30.0",
-    "datasets<=3.5.0",
+    "datasets>=0.34",
     "numpy>=1.24.4",
     "diffusers>=0.21.4",
     "torch_pruning",

--- a/src/pruna/data/__init__.py
+++ b/src/pruna/data/__init__.py
@@ -15,7 +15,7 @@
 from typing import Any, Callable, Tuple
 
 from pruna.data.datasets.audio import (
-    setup_commonvoice_dataset,
+    setup_librispeech_dataset,
     setup_mini_presentation_audio_dataset,
     setup_podcast_dataset,
 )
@@ -42,7 +42,7 @@ from pruna.data.datasets.text_to_image import (
 base_datasets: dict[str, Tuple[Callable, str, dict[str, Any]]] = {
     "COCO": (setup_coco_dataset, "image_generation_collate", {"img_size": 512}),
     "LAION256": (setup_laion256_dataset, "image_generation_collate", {"img_size": 512}),
-    "CommonVoice": (setup_commonvoice_dataset, "audio_collate", {}),
+    "LibriSpeech": (setup_librispeech_dataset, "audio_collate", {}),
     "AIPodcast": (setup_podcast_dataset, "audio_collate", {}),
     "MiniPresentation": (setup_mini_presentation_audio_dataset, "audio_collate", {}),
     "ImageNet": (setup_imagenet_dataset, "image_classification_collate", {"img_size": 224}),

--- a/src/pruna/data/datasets/audio.py
+++ b/src/pruna/data/datasets/audio.py
@@ -14,31 +14,35 @@
 
 import os
 from pathlib import Path
-from typing import List, Tuple
+from typing import Tuple
 
 from datasets import Dataset, load_dataset
 
+from pruna.data.utils import split_train_into_train_val_test
 from pruna.logging.logger import pruna_logger
 
 
-def setup_commonvoice_dataset() -> List[Dataset]:
+def setup_librispeech_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     """
-    Setup the Common Voice dataset.
+    Setup the LibriSpeech dataset.
 
-    License: CC0-1.0
+    License: MIT
+
+    Parameters
+    ----------
+    seed : int
+        The seed to use for the split.
 
     Returns
     -------
-    List[Dataset]
-        The Common Voice dataset.
+    Tuple[Dataset, Dataset, Dataset]
+        The LibriSpeech dataset with explicit audio paths.
     """
-    return load_dataset(
-        "mozilla-foundation/common_voice_1_0",
-        "fr",
-        revision="refs/pr/5",
-        split=["train", "validation", "test"],
-        trust_remote_code=True,
-    )
+    ds = load_dataset("argmaxinc/librispeech-200", split="train", streaming=False)
+    ds = ds.map(lambda batch: {"sentence": ""})
+
+    ds_train, ds_val, ds_test = split_train_into_train_val_test(ds, seed)
+    return ds_train, ds_val, ds_test
 
 
 def setup_podcast_dataset() -> Tuple[Dataset, Dataset, Dataset]:
@@ -70,7 +74,7 @@ def setup_mini_presentation_audio_dataset() -> Tuple[Dataset, Dataset, Dataset]:
 
 
 def _download_audio_and_select_sample(file_id: str) -> Tuple[Dataset, Dataset, Dataset]:
-    load_dataset("reach-vb/random-audios", trust_remote_code=True)
+    load_dataset("reach-vb/random-audios")
     cache_path = os.environ.get("HUGGINGFACE_HUB_CACHE")
     if cache_path is None:
         cache_path = str(Path.home() / ".cache" / "huggingface" / "hub")

--- a/src/pruna/data/datasets/image.py
+++ b/src/pruna/data/datasets/image.py
@@ -36,7 +36,7 @@ def setup_mnist_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The MNIST dataset.
     """
-    train_ds, test_ds = load_dataset("ylecun/mnist", split=["train", "test"], trust_remote_code=True)
+    train_ds, test_ds = load_dataset("ylecun/mnist", split=["train", "test"])
     train_ds, val_ds = split_train_into_train_val(train_ds, seed)
     return train_ds, val_ds, test_ds
 
@@ -57,7 +57,7 @@ def setup_imagenet_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The ImageNet dataset.
     """
-    train_ds, val = load_dataset("zh-plus/tiny-imagenet", split=["train", "valid"], trust_remote_code=True)
+    train_ds, val = load_dataset("zh-plus/tiny-imagenet", split=["train", "valid"])
     val_ds, test_ds = split_val_into_val_test(val, seed)
     return train_ds, val_ds, test_ds
 
@@ -78,6 +78,6 @@ def setup_cifar10_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The CIFAR-10 dataset.
     """
-    train_ds, test_ds = load_dataset("uoft-cs/cifar10", split=["train", "test"], trust_remote_code=True)
+    train_ds, test_ds = load_dataset("uoft-cs/cifar10", split=["train", "test"])
     train_ds, val_ds = split_train_into_train_val(train_ds, seed)
     return train_ds, val_ds, test_ds

--- a/src/pruna/data/datasets/question_answering.py
+++ b/src/pruna/data/datasets/question_answering.py
@@ -35,7 +35,7 @@ def setup_polyglot_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The Polyglot dataset.
     """
-    dataset = load_dataset("Polyglot-or-Not/Fact-Completion", split="english".capitalize(), trust_remote_code=True)
+    dataset = load_dataset("Polyglot-or-Not/Fact-Completion", split="english".capitalize())
     dataset = dataset.rename_column("true", "answer")
     dataset = dataset.rename_column("stem", "question")
     return split_train_into_train_val_test(dataset, seed)

--- a/src/pruna/data/datasets/text_generation.py
+++ b/src/pruna/data/datasets/text_generation.py
@@ -100,8 +100,8 @@ def setup_smolsmoltalk_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The SmolSmolTalk dataset.
     """
-    train_full = load_dataset("HuggingFaceTB/smol-smoltalk", split="train", trust_remote_code=True)
-    test_ds = load_dataset("HuggingFaceTB/smol-smoltalk", split="test", trust_remote_code=True)
+    train_full = load_dataset("HuggingFaceTB/smol-smoltalk", split="train")
+    test_ds = load_dataset("HuggingFaceTB/smol-smoltalk", split="test")
 
     train_ds, val_ds = split_train_into_train_val(train_full, seed)
 
@@ -148,7 +148,7 @@ def setup_pubchem_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The PubChem dataset.
     """
-    dataset = load_dataset("alxfgh/PubChem10M_SELFIES", trust_remote_code=True)["train"]
+    dataset = load_dataset("alxfgh/PubChem10M_SELFIES")["train"]
     dataset = dataset.rename_column("SELFIES", "text")
     return split_train_into_train_val_test(dataset, seed)
 
@@ -169,9 +169,7 @@ def setup_openassistant_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The OpenAssistant dataset.
     """
-    train_dataset, test_dataset = load_dataset(
-        "timdettmers/openassistant-guanaco", split=["train", "test"], trust_remote_code=True
-    )
+    train_dataset, test_dataset = load_dataset("timdettmers/openassistant-guanaco", split=["train", "test"])
     train_ds, val_ds = split_train_into_train_val(train_dataset, seed)
     return train_ds, val_ds, test_dataset
 
@@ -187,8 +185,8 @@ def setup_c4_dataset() -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The C4 dataset.
     """
-    train_dataset = load_dataset("allenai/c4", "en", split="train", streaming=True, trust_remote_code=True)
-    val_dataset = load_dataset("allenai/c4", "en", split="validation", streaming=True, trust_remote_code=True)
+    train_dataset = load_dataset("allenai/c4", "en", split="train", streaming=True)
+    val_dataset = load_dataset("allenai/c4", "en", split="validation", streaming=True)
     pruna_logger.info("Received only train and val datasets as iterable datasets, copying validation dataset to test.")
     test_dataset = copy.deepcopy(val_dataset)
     return train_dataset, val_dataset, test_dataset

--- a/src/pruna/data/datasets/text_to_image.py
+++ b/src/pruna/data/datasets/text_to_image.py
@@ -41,7 +41,7 @@ def setup_open_image_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The OpenImage dataset.
     """
-    dataset = load_dataset("data-is-better-together/open-image-preferences-v1", trust_remote_code=True)["cleaned"]
+    dataset = load_dataset("data-is-better-together/open-image-preferences-v1")["cleaned"]
     dataset = dataset.rename_column("image_quality_dev", "image")
     dataset = dataset.rename_column("quality_prompt", "text")
     return split_train_into_train_val_test(dataset, seed)
@@ -61,7 +61,7 @@ def setup_laion256_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The LAION256 dataset.
     """
-    dataset = load_dataset("nannullna/laion_subset", trust_remote_code=True)["artwork"]
+    dataset = load_dataset("nannullna/laion_subset")["artwork"]
     return split_train_into_train_val_test(dataset, seed)
 
 
@@ -97,7 +97,7 @@ def setup_coco_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
 
             zip_path.unlink()
 
-    dataset = load_dataset("phiyodr/coco2017", trust_remote_code=True)
+    dataset = load_dataset("phiyodr/coco2017")
 
     def _process_example(example: Dict[str, Any], directory_dataset: str) -> Dict[str, Any]:
         """

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -25,7 +25,7 @@ def iterate_dataloaders(datamodule: PrunaDataModule) -> None:
         pytest.param("COCO", dict(img_size=512), marks=pytest.mark.slow),
         pytest.param("LAION256", dict(img_size=512), marks=pytest.mark.slow),
         pytest.param("OpenImage", dict(img_size=512), marks=pytest.mark.slow),
-        pytest.param("CommonVoice", dict(), marks=pytest.mark.slow),
+        pytest.param("LibriSpeech", dict(), marks=pytest.mark.slow),
         pytest.param("AIPodcast", dict(), marks=pytest.mark.slow),
         ("ImageNet", dict(img_size=512)),
         pytest.param("MNIST", dict(img_size=512), marks=pytest.mark.slow),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
This PR updates our dataset loading code to be compatible with 🤗 datasets ≥4.0.0, which removed support for loading datasets via scripts (trust_remote_code).

Removed all trust_remote_code=True usage across dataset setup functions.

Replaced CommonVoice with LibriSpeech (librispeech-200) because:

- CommonVoice relied on a remote loading script that no longer works.
- librispeech-200 is a small enough subset to keep downloads manageable.
-  Audio pipelines require file paths, which Parquet-style datasets do not provide. librispeech-200 includes raw audio files with explicit paths.

Updated tests to reflect the dataset change.


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
All datamodule tests pass with the updated version of datasets.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


