### PR TITLE
docs: add target modules documentation

### DIFF
--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -70,6 +70,12 @@ These tutorials will guide you through the process of using |pruna| to optimize 
 
       Optimize your ``diffusion`` model with ``deepcache`` ``caching``.
 
+   .. grid-item-card:: Target Modules
+      :text-align: center
+      :link: ./target_modules_quanto.ipynb
+      
+      Learn how to use the ``target_modules`` parameter to target specific modules in your model.
+
 .. toctree::
    :hidden:
    :maxdepth: 1

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -70,7 +70,7 @@ These tutorials will guide you through the process of using |pruna| to optimize 
 
       Optimize your ``diffusion`` model with ``deepcache`` ``caching``.
 
-   .. grid-item-card:: Target Modules
+   .. grid-item-card:: Smashing at Finer Granularity with Target Modules
       :text-align: center
       :link: ./target_modules_quanto.ipynb
       

--- a/docs/tutorials/target_modules_quanto.ipynb
+++ b/docs/tutorials/target_modules_quanto.ipynb
@@ -62,7 +62,7 @@
     }
    },
    "source": [
-    "### 1. Loading a model"
+    "### 1. Loading a Model"
    ]
   },
   {
@@ -175,7 +175,7 @@
    "id": "e110d97f",
    "metadata": {},
    "source": [
-    "### 3. Load the original model again"
+    "### 3. Load the Original Model again"
    ]
   },
   {
@@ -249,7 +249,7 @@
    "id": "081bc8ef",
    "metadata": {},
    "source": [
-    "As before, we use 4-bit quantization from Quanto"
+    "As before, we use 4-bit quantization from Quanto:"
    ]
   },
   {
@@ -315,7 +315,7 @@
    "id": "eb24a47a",
    "metadata": {},
    "source": [
-    "### Comparison"
+    "### 5. Compare the Results"
    ]
   },
   {
@@ -346,15 +346,45 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f2f7b93",
+   "id": "157a3b44",
    "metadata": {},
    "source": [
-    "Much better! Although the fully-quantized model produced an image close to the original, the one with the `target_modules` option is even closer.\n",
+    "Much better! Although the fully-quantized model produced an image close to the original, the one with the `target_modules` option is even closer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cf329c5",
+   "metadata": {},
+   "source": [
+    "### Wrap up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd744e68",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "Congratulation! You have successfully smashed a model with a fine-grained control over which modules are quantized.\n",
     "\n",
-    "You can play around excluding different parts of the layer and see their effect on the end result and on your VRAM.\n",
-    "We plan to add this option to other quantizer so make sure to check if your favorite algorithm already has a `target_modules` hyperparameter!\n",
-    "\n",
-    "Make sure to check out other pruna tutorials to juice all the speed out of your model!"
+    "You can play around excluding different parts of the layer and see their effect on the end result, on the VRAM usage and on the speed of the model.\n",
+    "We plan to add this option to other quantizers so make sure to check if your favorite algorithm already has a `target_modules` hyperparameter!\n"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "5f2f7b93",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "Make sure to check out other :doc:`pruna tutorials </docs_pruna/tutorials/index>` to juice all the speed out of your model!"
    ]
   }
  ],

--- a/docs/tutorials/target_modules_quanto.ipynb
+++ b/docs/tutorials/target_modules_quanto.ipynb
@@ -1,390 +1,382 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "2ca35392",
-            "metadata": {},
-            "source": [
-                "# Targeted Quantization with Quanto"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "1ee1e798",
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        },
-        {
-            "cell_type": "raw",
-            "id": "6be5627c",
-            "metadata": {
-                "raw_mimetype": "text/restructuredtext",
-                "vscode": {
-                    "languageId": "raw"
-                }
-            },
-            "source": [
-                "This tutorial demonstrates how to use :doc:`Target Modules </docs_pruna/user_manual/target_modules>` hyperparameters to specify which modules an algorithm should be applied to. We will use Quanto for this demonstration which has such a ``target_modules`` hyperparameter."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "5755afb2",
-            "metadata": {},
-            "source": [
-                "### Getting Started"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "b7834d46",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
-                "# the following command will install the latest version of pruna\n",
-                "%pip install pruna"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "9dad6c69",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import torch\n",
-                "\n",
-                "device = \"cuda\" if torch.cuda.is_available() else \"mps\" if torch.backends.mps.is_available() else \"cpu\""
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "4445e12e",
-            "metadata": {
-                "vscode": {
-                    "languageId": "plaintext"
-                }
-            },
-            "source": [
-                "### 1. Loading a model"
-            ]
-        },
-        {
-            "cell_type": "raw",
-            "id": "2fc8eed0",
-            "metadata": {
-                "raw_mimetype": "text/restructuredtext",
-                "vscode": {
-                    "languageId": "raw"
-                }
-            },
-            "source": [
-                "We will demonstrate this feature using Flux.\n",
-                "Alternatively, you could use an LLM instead of an image generation model and adapt the loading, configuration, and evaluation steps by following :doc:`this tutorial </docs_pruna/tutorials/llm_quantization_compilation_acceleration>`, for example."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "73d954b6",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import torch\n",
-                "from diffusers import DiffusionPipeline\n",
-                "\n",
-                "model_id = \"black-forest-labs/FLUX.1-dev\"\n",
-                "pipe = DiffusionPipeline.from_pretrained(\n",
-                "    pretrained_model_name_or_path=model_id,\n",
-                "    torch_dtype=torch.bfloat16,\n",
-                ")\n",
-                "pipe = pipe.to(device)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "9b2ff44e",
-            "metadata": {},
-            "source": [
-                "We'll generate an image to compare it to the quantized model later"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "6ca7e4b7",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "prompt = \"A crow flying over snowy mountains with a vibrant green valley below and warm colors from the sunset. High resolution, realistic style.\"\n",
-                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
-                "img.save(\"original.png\")\n",
-                "img"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "18b4c694",
-            "metadata": {},
-            "source": [
-                "### 2. Define a SmashConfig with Quanto and Smash the Model"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "9de62754",
-            "metadata": {},
-            "source": [
-                "A module is select if it matches at least one include pattern and none of the exclude patterns."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "504d0d92",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from pruna import SmashConfig, smash\n",
-                "\n",
-                "smash_config = SmashConfig()\n",
-                "smash_config[\"quantizer\"] = \"quanto\"\n",
-                "smash_config[\"quanto_weight_bits\"] = \"qint4\"\n",
-                "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "6854d4ed",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
-                "img.save(\"smashed.png\")\n",
-                "img"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "1af03b63",
-            "metadata": {},
-            "source": [
-                "We're using a 4-bit quantization, which is pretty aggressive with quanto. The quality is still there but the image is different from the original.\n",
-                "To make it closer, we'll exclude sensitive parts of the layer from the quantization."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "e110d97f",
-            "metadata": {},
-            "source": [
-                "### 3. Load the original model again"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "ae629097",
-            "metadata": {},
-            "source": [
-                "First let's clear the first model to free memory."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "ee82542d",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from pruna.engine.utils import safe_memory_cleanup\n",
-                "\n",
-                "pipe.destroy()\n",
-                "del pipe\n",
-                "safe_memory_cleanup()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "06962b1e",
-            "metadata": {},
-            "source": [
-                "Now we can load the original model again."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "23d806a6",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "pipe = DiffusionPipeline.from_pretrained(\n",
-                "    pretrained_model_name_or_path=model_id,\n",
-                "    torch_dtype=torch.bfloat16,\n",
-                ")\n",
-                "pipe = pipe.to(device)"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "f868185a",
-            "metadata": {},
-            "source": [
-                "### 4. Smash the Model again with Target Modules"
-            ]
-        },
-        {
-            "cell_type": "raw",
-            "id": "14ffad65",
-            "metadata": {
-                "raw_mimetype": "text/restructuredtext",
-                "vscode": {
-                    "languageId": "raw"
-                }
-            },
-            "source": [
-                "Some algorithm such as Quanto offer the option of specifying a :doc:`target_modules </docs_pruna/user_manual/target_modules>` hyperparameter.\n",
-                "This allows you to choose which modules the algorithm should be applied to by providing unix-shell style patterns of modules to include or exclude."
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "081bc8ef",
-            "metadata": {},
-            "source": [
-                "As before, we use 4-bit quantization from Quanto"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "31ced6bc",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "smash_config[\"quantizer\"] = \"quanto\"\n",
-                "smash_config[\"quanto_weight_bits\"] = \"qint4\""
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "2974373f",
-            "metadata": {},
-            "source": [
-                "Here, we'll avoid quantizing layers related to the embeddings which are sensitive to quantization.\n",
-                "\n",
-                "Of course, applying quantization to fewer parts of the model means that the final model will need more VRAM.\n",
-                "However, the selection below only excludes 0.4% of the parameters, so the overhead should be manageable."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "2d7ef30a",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "smash_config['quanto_target_modules'] = {\n",
-                "    \"include\": [\"transformer.*\"],  # here we consider any module in the model's unet\n",
-                "    \"exclude\": [\"*embed*\"],  # and exclude any module containing \"embed\" in its path\n",
-                "    # you can add other patterns in the include or exclude lists\n",
-                "}"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "be049e96",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "c792e19b",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
-                "img.save(\"smashed_target_modules.png\")\n",
-                "img"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "eb24a47a",
-            "metadata": {},
-            "source": [
-                "### Comparison"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "70245373",
-            "metadata": {},
-            "source": [
-                "Let's load the images we generated and show them side by side."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "b4fef931",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "import matplotlib.pyplot as plt\n",
-                "\n",
-                "plt.figure(figsize=(15, 5))\n",
-                "for i, img_name in enumerate([\"original.png\", \"smashed.png\", \"smashed_target_modules.png\"]):\n",
-                "    plt.subplot(1, 3, i + 1)\n",
-                "    plt.imshow(plt.imread(img_name))\n",
-                "    plt.title(img_name)\n",
-                "    plt.axis(\"off\")\n",
-                "plt.show()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "5f2f7b93",
-            "metadata": {},
-            "source": [
-                "Much better! Although the fully-quantized model produced an image close to the original, the one with the `target_modules` option is even closer.\n",
-                "\n",
-                "You can play around excluding different parts of the layer and see their effect on the end result and on your VRAM.\n",
-                "We plan to add this option to other quantizer so make sure to check if your favorite algorithm already has a `target_modules` hyperparameter!\n",
-                "\n",
-                "Make sure to check out other pruna tutorials to juice all the speed out of your model!"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "prunatree",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.10.18"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2ca35392",
+   "metadata": {},
+   "source": [
+    "# Targeted Quantization with Quanto"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "6be5627c",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "This tutorial demonstrates how to use :doc:`Target Modules </docs_pruna/user_manual/target_modules>` hyperparameters to specify which modules an algorithm should be applied to. We will use Quanto for this demonstration which has such a ``target_modules`` hyperparameter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5755afb2",
+   "metadata": {},
+   "source": [
+    "### Getting Started"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7834d46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
+    "# the following command will install the latest version of pruna\n",
+    "%pip install pruna"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dad6c69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"mps\" if torch.backends.mps.is_available() else \"cpu\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4445e12e",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "### 1. Loading a model"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "2fc8eed0",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "We will demonstrate this feature using Flux.\n",
+    "Alternatively, you could use an LLM instead of an image generation model and adapt the loading, configuration, and evaluation steps by following :doc:`this tutorial </docs_pruna/tutorials/llm_quantization_compilation_acceleration>`, for example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73d954b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "from diffusers import DiffusionPipeline\n",
+    "\n",
+    "model_id = \"black-forest-labs/FLUX.1-dev\"\n",
+    "pipe = DiffusionPipeline.from_pretrained(\n",
+    "    pretrained_model_name_or_path=model_id,\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    ")\n",
+    "pipe = pipe.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b2ff44e",
+   "metadata": {},
+   "source": [
+    "We'll generate an image to compare it to the quantized model later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ca7e4b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = \"A crow flying over snowy mountains with a vibrant green valley below and warm colors from the sunset. High resolution, realistic style.\"\n",
+    "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+    "img.save(\"original.png\")\n",
+    "img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18b4c694",
+   "metadata": {},
+   "source": [
+    "### 2. Define a SmashConfig with Quanto and Smash the Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9de62754",
+   "metadata": {},
+   "source": [
+    "A module is select if it matches at least one include pattern and none of the exclude patterns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504d0d92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pruna import SmashConfig, smash\n",
+    "\n",
+    "smash_config = SmashConfig()\n",
+    "smash_config[\"quantizer\"] = \"quanto\"\n",
+    "smash_config[\"quanto_weight_bits\"] = \"qint4\"\n",
+    "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6854d4ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+    "img.save(\"smashed.png\")\n",
+    "img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1af03b63",
+   "metadata": {},
+   "source": [
+    "We're using a 4-bit quantization, which is pretty aggressive with quanto. The quality is still there but the image is different from the original.\n",
+    "To make it closer, we'll exclude sensitive parts of the layer from the quantization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e110d97f",
+   "metadata": {},
+   "source": [
+    "### 3. Load the original model again"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae629097",
+   "metadata": {},
+   "source": [
+    "First let's clear the first model to free memory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ee82542d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pruna.engine.utils import safe_memory_cleanup\n",
+    "\n",
+    "pipe.destroy()\n",
+    "del pipe\n",
+    "safe_memory_cleanup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06962b1e",
+   "metadata": {},
+   "source": [
+    "Now we can load the original model again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23d806a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = DiffusionPipeline.from_pretrained(\n",
+    "    pretrained_model_name_or_path=model_id,\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    ")\n",
+    "pipe = pipe.to(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f868185a",
+   "metadata": {},
+   "source": [
+    "### 4. Smash the Model again with Target Modules"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "14ffad65",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext",
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "Some algorithm such as Quanto offer the option of specifying a :doc:`target_modules </docs_pruna/user_manual/target_modules>` hyperparameter.\n",
+    "This allows you to choose which modules the algorithm should be applied to by providing unix-shell style patterns of modules to include or exclude."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "081bc8ef",
+   "metadata": {},
+   "source": [
+    "As before, we use 4-bit quantization from Quanto"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31ced6bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smash_config[\"quantizer\"] = \"quanto\"\n",
+    "smash_config[\"quanto_weight_bits\"] = \"qint4\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2974373f",
+   "metadata": {},
+   "source": [
+    "Here, we'll avoid quantizing layers related to the embeddings which are sensitive to quantization.\n",
+    "\n",
+    "Note that we are applying quantization to fewer parts of the model, which means that the smashed model will need more VRAM than the fully quantized version.\n",
+    "However, the selection below only excludes 0.4% of the parameters, so the overhead should be manageable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d7ef30a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "smash_config[\"quanto_target_modules\"] = {\n",
+    "    \"include\": [\"transformer.*\"],  # here we consider any module in the model's unet\n",
+    "    \"exclude\": [\"*embed*\"],  # and exclude any module containing \"embed\" in its path\n",
+    "    # you can add other patterns in the include or exclude lists\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be049e96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c792e19b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+    "img.save(\"smashed_target_modules.png\")\n",
+    "img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb24a47a",
+   "metadata": {},
+   "source": [
+    "### Comparison"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70245373",
+   "metadata": {},
+   "source": [
+    "Let's load the images we generated and show them side by side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4fef931",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(15, 5))\n",
+    "for i, img_name in enumerate([\"original.png\", \"smashed.png\", \"smashed_target_modules.png\"]):\n",
+    "    plt.subplot(1, 3, i + 1)\n",
+    "    plt.imshow(plt.imread(img_name))\n",
+    "    plt.title(img_name)\n",
+    "    plt.axis(\"off\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f2f7b93",
+   "metadata": {},
+   "source": [
+    "Much better! Although the fully-quantized model produced an image close to the original, the one with the `target_modules` option is even closer.\n",
+    "\n",
+    "You can play around excluding different parts of the layer and see their effect on the end result and on your VRAM.\n",
+    "We plan to add this option to other quantizer so make sure to check if your favorite algorithm already has a `target_modules` hyperparameter!\n",
+    "\n",
+    "Make sure to check out other pruna tutorials to juice all the speed out of your model!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "prunatree",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/docs/tutorials/target_modules_quanto.ipynb
+++ b/docs/tutorials/target_modules_quanto.ipynb
@@ -1,0 +1,390 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "2ca35392",
+            "metadata": {},
+            "source": [
+                "# Targeted Quantization with Quanto"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "1ee1e798",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        },
+        {
+            "cell_type": "raw",
+            "id": "6be5627c",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "This tutorial demonstrates how to use :doc:`Target Modules </docs_pruna/user_manual/target_modules>` hyperparameters to specify which modules an algorithm should be applied to. We will use Quanto for this demonstration which has such a ``target_modules`` hyperparameter."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "5755afb2",
+            "metadata": {},
+            "source": [
+                "### Getting Started"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "b7834d46",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
+                "# the following command will install the latest version of pruna\n",
+                "%pip install pruna"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "9dad6c69",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import torch\n",
+                "\n",
+                "device = \"cuda\" if torch.cuda.is_available() else \"mps\" if torch.backends.mps.is_available() else \"cpu\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "4445e12e",
+            "metadata": {
+                "vscode": {
+                    "languageId": "plaintext"
+                }
+            },
+            "source": [
+                "### 1. Loading a model"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "id": "2fc8eed0",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "We will demonstrate this feature using Flux.\n",
+                "Alternatively, you could use an LLM instead of an image generation model and adapt the loading, configuration, and evaluation steps by following :doc:`this tutorial </docs_pruna/tutorials/llm_quantization_compilation_acceleration>`, for example."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "73d954b6",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import torch\n",
+                "from diffusers import DiffusionPipeline\n",
+                "\n",
+                "model_id = \"black-forest-labs/FLUX.1-dev\"\n",
+                "pipe = DiffusionPipeline.from_pretrained(\n",
+                "    pretrained_model_name_or_path=model_id,\n",
+                "    torch_dtype=torch.bfloat16,\n",
+                ")\n",
+                "pipe = pipe.to(device)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9b2ff44e",
+            "metadata": {},
+            "source": [
+                "We'll generate an image to compare it to the quantized model later"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "6ca7e4b7",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "prompt = \"A crow flying over snowy mountains with a vibrant green valley below and warm colors from the sunset. High resolution, realistic style.\"\n",
+                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+                "img.save(\"original.png\")\n",
+                "img"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "18b4c694",
+            "metadata": {},
+            "source": [
+                "### 2. Define a SmashConfig with Quanto and Smash the Model"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "9de62754",
+            "metadata": {},
+            "source": [
+                "A module is select if it matches at least one include pattern and none of the exclude patterns."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "504d0d92",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from pruna import SmashConfig, smash\n",
+                "\n",
+                "smash_config = SmashConfig()\n",
+                "smash_config[\"quantizer\"] = \"quanto\"\n",
+                "smash_config[\"quanto_weight_bits\"] = \"qint4\"\n",
+                "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "6854d4ed",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+                "img.save(\"smashed.png\")\n",
+                "img"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "1af03b63",
+            "metadata": {},
+            "source": [
+                "We're using a 4-bit quantization, which is pretty aggressive with quanto. The quality is still there but the image is different from the original.\n",
+                "To make it closer, we'll exclude sensitive parts of the layer from the quantization."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "e110d97f",
+            "metadata": {},
+            "source": [
+                "### 3. Load the original model again"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ae629097",
+            "metadata": {},
+            "source": [
+                "First let's clear the first model to free memory."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "ee82542d",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from pruna.engine.utils import safe_memory_cleanup\n",
+                "\n",
+                "pipe.destroy()\n",
+                "del pipe\n",
+                "safe_memory_cleanup()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "06962b1e",
+            "metadata": {},
+            "source": [
+                "Now we can load the original model again."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "23d806a6",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "pipe = DiffusionPipeline.from_pretrained(\n",
+                "    pretrained_model_name_or_path=model_id,\n",
+                "    torch_dtype=torch.bfloat16,\n",
+                ")\n",
+                "pipe = pipe.to(device)"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "f868185a",
+            "metadata": {},
+            "source": [
+                "### 4. Smash the Model again with Target Modules"
+            ]
+        },
+        {
+            "cell_type": "raw",
+            "id": "14ffad65",
+            "metadata": {
+                "raw_mimetype": "text/restructuredtext",
+                "vscode": {
+                    "languageId": "raw"
+                }
+            },
+            "source": [
+                "Some algorithm such as Quanto offer the option of specifying a :doc:`target_modules </docs_pruna/user_manual/target_modules>` hyperparameter.\n",
+                "This allows you to choose which modules the algorithm should be applied to by providing unix-shell style patterns of modules to include or exclude."
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "081bc8ef",
+            "metadata": {},
+            "source": [
+                "As before, we use 4-bit quantization from Quanto"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "31ced6bc",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "smash_config[\"quantizer\"] = \"quanto\"\n",
+                "smash_config[\"quanto_weight_bits\"] = \"qint4\""
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "2974373f",
+            "metadata": {},
+            "source": [
+                "Here, we'll avoid quantizing layers related to the embeddings which are sensitive to quantization.\n",
+                "\n",
+                "Of course, applying quantization to fewer parts of the model means that the final model will need more VRAM.\n",
+                "However, the selection below only excludes 0.4% of the parameters, so the overhead should be manageable."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "2d7ef30a",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "smash_config['quanto_target_modules'] = {\n",
+                "    \"include\": [\"transformer.*\"],  # here we consider any module in the model's unet\n",
+                "    \"exclude\": [\"*embed*\"],  # and exclude any module containing \"embed\" in its path\n",
+                "    # you can add other patterns in the include or exclude lists\n",
+                "}"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "be049e96",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "pipe = smash(pipe, smash_config)  # this may take a couple of minutes"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "c792e19b",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "img = pipe(prompt, generator=torch.Generator(device=device).manual_seed(42)).images[0]\n",
+                "img.save(\"smashed_target_modules.png\")\n",
+                "img"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "eb24a47a",
+            "metadata": {},
+            "source": [
+                "### Comparison"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "70245373",
+            "metadata": {},
+            "source": [
+                "Let's load the images we generated and show them side by side."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "b4fef931",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import matplotlib.pyplot as plt\n",
+                "\n",
+                "plt.figure(figsize=(15, 5))\n",
+                "for i, img_name in enumerate([\"original.png\", \"smashed.png\", \"smashed_target_modules.png\"]):\n",
+                "    plt.subplot(1, 3, i + 1)\n",
+                "    plt.imshow(plt.imread(img_name))\n",
+                "    plt.title(img_name)\n",
+                "    plt.axis(\"off\")\n",
+                "plt.show()"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "5f2f7b93",
+            "metadata": {},
+            "source": [
+                "Much better! Although the fully-quantized model produced an image close to the original, the one with the `target_modules` option is even closer.\n",
+                "\n",
+                "You can play around excluding different parts of the layer and see their effect on the end result and on your VRAM.\n",
+                "We plan to add this option to other quantizer so make sure to check if your favorite algorithm already has a `target_modules` hyperparameter!\n",
+                "\n",
+                "Make sure to check out other pruna tutorials to juice all the speed out of your model!"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "prunatree",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.10.18"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}

--- a/docs/user_manual/target_modules.rst
+++ b/docs/user_manual/target_modules.rst
@@ -2,8 +2,8 @@
 .. this page presents more advanced features and is not directly presented in the user manual
 .. but is referenced by algorithms that support the target_modules parameter.
 
-Target Modules
-==============
+Selective Smashing with Target Modules
+======================================
 
 Some algorithms let you target specific modules in your model via the ``target_modules`` parameter.
 It specifies exactly which parts of the model the algorithm should operate on.

--- a/docs/user_manual/target_modules.rst
+++ b/docs/user_manual/target_modules.rst
@@ -45,6 +45,7 @@ The following example shows how to use ``target_modules`` with the ``quanto`` qu
 .. code-block:: python
 
     from pruna import SmashConfig
+
     smash_config = SmashConfig()
     smash_config["quantizer"] = "quanto"
     smash_config["quanto_target_modules"] = {
@@ -55,19 +56,19 @@ The following example shows how to use ``target_modules`` with the ``quanto`` qu
 Previewing the Targeted Modules
 -------------------------------
 
-You can preview the targeted modules by using the ``expand_list_of_modules_paths`` function as shown in the example below:
+You can preview the targeted modules by using the ``expand_list_of_targeted_paths`` function as shown in the example below:
 
 .. code-block:: python
 
     from transformers import AutoModelForCausalLM
-    from pruna.config.target_modules import expand_list_of_modules_paths
+    from pruna.config.target_modules import expand_list_of_targeted_paths
 
     model = AutoModelForCausalLM.from_pretrained("HuggingFaceTB/SmolLM2-135M")
     target_modules = {
         "include": ["model.layers.[01].*attn.*"],
         "exclude": ["*v_proj"]
     }
-    print(expand_list_of_modules_paths(target_modules, model))
+    print(expand_list_of_targeted_paths(target_modules, model))
 
 This will return the list of module paths that match the ``include`` and ``exclude`` patterns.
 In this example, the output contains the first two attention modules (``model.layers.0.self_attn`` and ``model.layers.1.self_attn``) and the

--- a/docs/user_manual/target_modules.rst
+++ b/docs/user_manual/target_modules.rst
@@ -1,0 +1,76 @@
+.. _target_modules:
+.. this page presents more advanced features and is not directly presented in the user manual
+.. but is referenced by algorithms that support the target_modules parameter.
+
+Target Modules
+==============
+
+Some algorithms let you target specific modules in your model via the ``target_modules`` parameter.
+It specifies exactly which parts of the model the algorithm should operate on.
+
+.. code-block:: python
+
+    TARGET_MODULES_TYPE = Dict[Literal["include", "exclude"], List[str]]
+
+The parameter is a dictionary with two keys, ``include`` and ``exclude``, each mapping to a list of pattern strings to match module paths.
+
+A module is targeted if its path in the model matches at least one ``include`` pattern and does not match any ``exclude`` pattern.
+
+Check out `this tutorial notebook <../tutorials/target_modules_quanto.ipynb>`_ to learn more about how to use ``target_modules``.
+
+Pattern Format
+--------------
+
+The ``include`` and ``exclude`` lists each contain glob patterns, allowing you to match module paths like you would in a file search:
+
+* ``*`` to match any number of characters (e.g., ``attention.*`` matches ``attention.to_q``, ``attention.to_k``, etc.)
+* ``?`` to match exactly one character
+* ``[abc]`` to match any single character from the set (e.g., ``to_[qk]`` matches ``to_q`` and ``to_k``)
+
+Default Values
+--------------
+
+If ``target_modules`` is not provided (i.e., ``None``), default values are inferred automatically from the model, configuration and algorithm used.
+
+If a ``target_modules`` dictionary is provided but missing either the ``include`` or ``exclude`` key:
+
+* Missing ``include``: defaults to ``["*"]`` (considering all modules)
+* Missing ``exclude``: defaults to ``[]`` (excluding no modules)
+
+Usage Examples ``target_modules``
+---------------------------------
+
+The following example shows how to use ``target_modules`` with the ``quanto`` quantizer to target your model's transformer, excluding the embedding layers.
+
+.. code-block:: python
+
+    from pruna import SmashConfig
+    smash_config = SmashConfig()
+    smash_config["quantizer"] = "quanto"
+    smash_config["quanto_target_modules"] = {
+        "include": ["transformer.*"],
+        "exclude": ["*embed*"]
+    }
+
+Previewing the Targeted Modules
+-------------------------------
+
+You can preview the targeted modules by using the ``expand_list_of_modules_paths`` function as shown in the example below:
+
+.. code-block:: python
+
+    from transformers import AutoModelForCausalLM
+    from pruna.config.target_modules import expand_list_of_modules_paths
+
+    model = AutoModelForCausalLM.from_pretrained("HuggingFaceTB/SmolLM2-135M")
+    target_modules = {
+        "include": ["model.layers.[01].*attn.*"],
+        "exclude": ["*v_proj"]
+    }
+    print(expand_list_of_modules_paths(target_modules, model))
+
+This will return the list of module paths that match the ``include`` and ``exclude`` patterns.
+In this example, the output contains the first two attention modules (``model.layers.0.self_attn`` and ``model.layers.1.self_attn``) and the
+``q_proj``, ``k_proj`` and ``o_proj`` layers inside them.
+
+Note that this will list *all* modules that match the patterns, some algorithms may only apply to the linear layers among those.

--- a/docs/user_manual/target_modules.rst
+++ b/docs/user_manual/target_modules.rst
@@ -21,7 +21,7 @@ Check out `this tutorial notebook <../tutorials/target_modules_quanto.ipynb>`_ t
 Pattern Format
 --------------
 
-The ``include`` and ``exclude`` lists each contain glob patterns, allowing you to match module paths like you would in a file search:
+Each of the ``include`` and ``exclude`` lists contains glob patterns, allowing you to match module paths like you would in a file search:
 
 * ``*`` to match any number of characters (e.g., ``attention.*`` matches ``attention.to_q``, ``attention.to_k``, etc.)
 * ``?`` to match exactly one character
@@ -37,7 +37,7 @@ If a ``target_modules`` dictionary is provided but missing either the ``include`
 * Missing ``include``: defaults to ``["*"]`` (considering all modules)
 * Missing ``exclude``: defaults to ``[]`` (excluding no modules)
 
-Usage Examples ``target_modules``
+Usage Example ``target_modules``
 ---------------------------------
 
 The following example shows how to use ``target_modules`` with the ``quanto`` quantizer to target your model's transformer, excluding the embedding layers.
@@ -73,4 +73,4 @@ This will return the list of module paths that match the ``include`` and ``exclu
 In this example, the output contains the first two attention modules (``model.layers.0.self_attn`` and ``model.layers.1.self_attn``) and the
 ``q_proj``, ``k_proj`` and ``o_proj`` layers inside them.
 
-Note that this will list *all* modules that match the patterns, some algorithms may only apply to the linear layers among those.
+Note that this will list *all* modules that match the patterns, although some algorithms may only apply to the linear layers among those.

--- a/docs/utils/gen_docs.py
+++ b/docs/utils/gen_docs.py
@@ -13,6 +13,7 @@ from ConfigSpace import (
 
 from pruna.algorithms import PRUNA_ALGORITHMS
 from pruna.algorithms.pruna_base import PrunaAlgorithmBase
+from pruna.config.hyperparameters import UnconstrainedHyperparameter
 
 
 def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> str:
@@ -44,7 +45,9 @@ def generate_algorithm_desc(obj: PrunaAlgorithmBase, name_suffix: str = "") -> s
             f"| **Can be applied on**: {compatible_devices_str}.",
             f"| **Required**: {required_inputs_str}.",
             f"| **Compatible with**: {compatible_algorithms_str}.",
-            f"| **Required install**: {required_install_str}." if required_install_str else "",
+            f"| **Required install**: {required_install_str}."
+            if required_install_str
+            else "",
         ]
     )
 
@@ -80,12 +83,20 @@ def format_grid_table(rows: list[list[str]]) -> str:
     total_widths = [w + 2 for w in col_widths]
 
     horizontal_border = "+" + "+".join("-" * width for width in total_widths) + "+"
-    header_line = "|" + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+    header_line = (
+        "|"
+        + "|".join(" " + rows[0][i].ljust(col_widths[i]) + " " for i in range(num_cols))
+        + "|"
+    )
     header_separator = "+" + "+".join("=" * width for width in total_widths) + "+"
 
     data_lines = []
     for row in rows[1:]:
-        row_line = "|" + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols)) + "|"
+        row_line = (
+            "|"
+            + "|".join(" " + row[i].ljust(col_widths[i]) + " " for i in range(num_cols))
+            + "|"
+        )
         data_lines.append(row_line)
         data_lines.append(horizontal_border)
 
@@ -177,7 +188,7 @@ def get_table_rows(obj: PrunaAlgorithmBase) -> tuple[list[list[str]], int]:
     hyperparameter_counter = 0
 
     for hp in obj.get_hyperparameters():
-        if isinstance(hp, Constant):
+        if isinstance(hp, Constant) and not isinstance(hp, UnconstrainedHyperparameter):
             continue  # Skip constant hyperparameters
 
         param_name = f"``{obj.algorithm_name}_{hp.name}``"
@@ -194,6 +205,9 @@ def get_table_rows(obj: PrunaAlgorithmBase) -> tuple[list[list[str]], int]:
         elif isinstance(hp, CategoricalHyperparameter):
             values = ", ".join(str(v) for v in hp.choices)
             default = str(hp.default_value)
+        elif isinstance(hp, UnconstrainedHyperparameter):
+            default = str(hp.value)
+            values = "Unconstrained"
         else:
             raise ValueError(f"Unsupported hyperparameter type: {type(hp)}")
 

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -72,7 +72,8 @@ class QuantoQuantizer(PrunaQuantizer):
                 name="target_modules",
                 default_value=None,
                 meta=dict(
-                    desc=f"Precise choices of which modules to quantize. "
+                    desc="Precise choices of which modules to quantize, "
+                    "e.g. {include: ['transformer.*']} to quantize only the transformer in a diffusion pipeline. "
                     f"See the {TargetModules.documentation_name_with_link} documentation for more details."
                 ),
             ),

--- a/src/pruna/algorithms/quantization/quanto.py
+++ b/src/pruna/algorithms/quantization/quanto.py
@@ -71,7 +71,10 @@ class QuantoQuantizer(PrunaQuantizer):
             TargetModules(
                 name="target_modules",
                 default_value=None,
-                meta=dict(desc="Precise choices of which modules to quantize."),
+                meta=dict(
+                    desc=f"Precise choices of which modules to quantize. "
+                    f"See the {TargetModules.documentation_name_with_link} documentation for more details."
+                ),
             ),
         ]
 

--- a/src/pruna/config/target_modules.py
+++ b/src/pruna/config/target_modules.py
@@ -40,6 +40,8 @@ class TargetModules(UnconstrainedHyperparameter):
         Meta data describing the hyperparameter.
     """
 
+    documentation_name_with_link = ":ref:`Target Modules <target_modules>`"
+
     def __init__(self, name: str, default_value: Optional[TARGET_MODULES_TYPE] = None, meta: Any = None) -> None:
         super().__init__(name, default_value, meta=meta)
 


### PR DESCRIPTION
## Description
Add documentation for target modules:
- a documentation page target_modules.rst, referenced as a drop-down from SmashConfig
- change printed hyperparameters so that TargetModules are correctly shown on the algorithm page
- provide a documentation_name_with_link attribute in target modules to easily link to the doc in algorithms
- add a target modules tutorial with demonstration on quanto

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Building the documentation

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
I think an other documentation page about how to use the `map_targeted_nn_roots` function would have its place somewhere in the "Customize components" section, but this is left for an other PR