### PR TITLE
docs: limit execution time of smash tutorial

### DIFF
--- a/docs/user_manual/smash.rst
+++ b/docs/user_manual/smash.rst
@@ -52,7 +52,7 @@ Let's see what that looks like in code.
     # Evaluate the model
     metrics = ["clip_score", "psnr"]
     datamodule = PrunaDataModule.from_string("LAION256")
-    datamodule.limit_datasets(10) # You can limit the number of samples.
+    datamodule.limit_datasets(5) # You can limit the number of samples.
     task = Task(metrics, datamodule=datamodule)
     eval_agent = EvaluationAgent(task)
     eval_agent.evaluate(optimized_model)
@@ -141,7 +141,9 @@ To evaluate the optimized model, we can use the same interface as the original m
     metrics = ['clip_score', 'psnr']
 
     # Define task
-    task = Task(metrics, datamodule=PrunaDataModule.from_string('LAION256'))
+    datamodule = PrunaDataModule.from_string('LAION256')
+    datamodule.limit_datasets(5)
+    task = Task(metrics, datamodule=datamodule)
 
     # Evaluate the model
     eval_agent = EvaluationAgent(task)


### PR DESCRIPTION
## Description
This PR adjust the tutorial on smashing by limiting the dataloaders for a reduced execution time when this is run during the documentation tests.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
