### PR TITLE
fix: update model card tags to include 'pruna-ai' by default

### DIFF
--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -170,7 +170,7 @@ def save_pruna_model_to_hub(
         template_path = Path(__file__).parent / "hf_hub_utils" / "model_card_template.md"
         # Get the pruna library version from initalized module as OSS or paid so we can use the same method for both
         pruna_library = instance.__module__.split(".")[0] if "." in instance.__module__ else None
-        model_card_data["tags"] = [f"{pruna_library}-ai", "safetensors"]
+        model_card_data["tags"] = list({f"{pruna_library}-ai", "safetensors", "pruna-ai"})
         # Build the template parameters dictionary for clarity and maintainability
         template_params: dict = {
             "repo_id": repo_id,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Enforces `pruna-ai` to be added by default and `pruna_pro-ai` if pro is present, so we can use one entrypoint in the HF.js library.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes requirement https://github.com/huggingface/huggingface.js/pull/1733

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
