### PR TITLE
Fix generic loading function for benchmarking

### DIFF
--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -216,7 +216,7 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
+def load_transformers_model(path: str | Path, smash_config: SmashConfig | None = None, **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
@@ -249,12 +249,16 @@ def load_transformers_model(path: str | Path, smash_config: SmashConfig, **kwarg
         architecture = config["architectures"][0]
         cls = getattr(transformers, architecture)
         # transformers discards kwargs automatically, no need for filtering
-        device = smash_config.device if smash_config.device != "cuda" else "cuda:0"
-        device_map = smash_config.device_map if smash_config.device == "accelerate" else device
+        if smash_config is not None:
+            device = smash_config.device if smash_config.device != "cuda" else "cuda:0"
+            device_map = smash_config.device_map if smash_config.device == "accelerate" else device
+        else:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+            device_map = "auto"
         return cls.from_pretrained(path, device_map=device_map, **kwargs)
 
 
-def load_diffusers_model(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
+def load_diffusers_model(path: str | Path, smash_config: SmashConfig | None = None, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
@@ -296,7 +300,8 @@ def load_diffusers_model(path: str | Path, smash_config: SmashConfig, **kwargs) 
     # diffusers discards kwargs automatically, no need for filtering
     # diffusers does not support device_maps as dicts at the moment, we load on cpu and cast it ourselves
     model = cls.from_pretrained(path, device_map=None, **kwargs)
-    move_to_device(model, smash_config.device, device_map=smash_config.device_map)
+    if smash_config is not None:
+        move_to_device(model, smash_config.device, device_map=smash_config.device_map)
     return model
 
 


### PR DESCRIPTION
## Description
This PR enables to load any diffusers and transformers models even if they do not have smash configs. This is useful for benchmarking of all models regardless if they are wrapped or not with Pruna.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
