### PR TITLE
fix: memory related issues in the nightlies for 3 tests

### DIFF
--- a/src/pruna/engine/handler/handler_utils.py
+++ b/src/pruna/engine/handler/handler_utils.py
@@ -22,6 +22,7 @@ from pruna.engine.handler.handler_inference import InferenceHandler
 from pruna.engine.handler.handler_pipeline import PipelineHandler
 from pruna.engine.handler.handler_standard import StandardHandler
 from pruna.engine.handler.handler_transformer import TransformerHandler
+from pruna.logging.logger import pruna_logger
 
 HANDLER_EXCEPTIONS: dict[type[InferenceHandler], list[str]] = {
     TransformerHandler: ["AutoHQQHFModel", "TranslatorWrapper", "GeneratorWrapper", "GPTQ"],
@@ -60,7 +61,10 @@ def register_inference_handler(model: Any) -> InferenceHandler:
         if "TextGeneration" in type(model).__name__:
             return PipelineHandler(pipeline=model)
         else:
-            raise ValueError("Unsupported pipeline type. Only text generation pipelines are currently supported.")
+            pruna_logger.warning(
+                "Only text generation pipelines are currently fully supported. Defaulting to StandardHandler."
+            )
+            return StandardHandler()
     elif "transformers" in model_module:
         return TransformerHandler()
     else:

--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -160,7 +160,7 @@ class GPUMemoryStats(BaseMetric):
 
             # Perform forward pass if required by the mode
             if self.mode in {INFERENCE_MEMORY, TRAINING_MEMORY}:
-                self._perform_forward_pass(model, dataloader)
+                self._perform_forward_pass(metric_model, dataloader)
 
             memory_after_model_run = gpu_manager.get_memory_usage()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -79,6 +79,11 @@ def get_diffusers_model(model_id: str, **kwargs: dict[str, Any]) -> tuple[Any, S
     # snapshot download of the model
     model_path = snapshot_download(model_id)
     model = load_diffusers_model(model_path, smash_config=SmashConfig(device="cpu"), **kwargs)
+    # safely enable attention slicing if supported
+    # the gpus of the CI do not support efficient attention backends.
+    # we try to avoid OOM errors by using attention slicing.
+    if hasattr(model, "enable_attention_slicing"):
+        model.enable_attention_slicing("auto")
     smash_config = SmashConfig()
     smash_config.add_data("LAION256")
     return model, smash_config


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

- The Transformers pipelines were incorrectly configured to raise an error for non–text-generation models. Instead, it should always fall back to the standard inference handler.
- Memory metrics were being collected from a CPU copy of the model, rather than the active model instance.
- Certain models triggered out-of-memory (OOM) errors in nightly tests because the machine lacked support for efficient attention. To mitigate this, attention slicing has been added to the test fixtures.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
