### PR TITLE
docs: fix incorrect clone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pip install pruna
 You can also install Pruna directly from source by cloning the repository and installing the package in editable mode:
 
 ```bash
-git clone https://github.com/pruna-ai/pruna.git
+git clone https://github.com/PrunaAI/pruna.git
 cd pruna
 pip install -e .
 ```


### PR DESCRIPTION
## Description
Fixed the incorrect GitHub clone link in the README.  
Changed:  
`git clone https://github.com/pruna-ai/pruna.git`  
to  
`git clone https://github.com/PrunaAI/pruna.git`

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Verified that the corrected link successfully clones the repository.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
The previous clone link returned a 404 error.  
<img width="889" height="81" alt="wronglink" src="https://github.com/user-attachments/assets/ead2acf5-4963-4ba6-b35d-ba4c0e765bd8" />

<img width="1440" height="472" alt="invalid" src="https://github.com/user-attachments/assets/b4de0b13-c086-4174-bf46-ac1ef1c92b50" />
