### PR TITLE
feat: add new fixtures as pre-quantized llms

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -169,9 +169,10 @@ def get_autoregressive_text_to_image_model(model_id: str) -> tuple[Any, SmashCon
 
 def get_pre_quantized_model(model_id: str) -> tuple[Any, SmashConfig]:
     """
-    Get a pre-quantized model.
+    Create a SmashConfig with a new attribute for the path to the (already) quantized model.
 
-    The fixture emits a dummy model and a SmashConfig carrying path to quantized model.
+    The fixture emits a dummy model (for dtype and device checking) and a SmashConfig
+    carrying path to quantized model on the hub.
     """
 
     class DummyModel(torch.nn.Linear):


### PR DESCRIPTION
## Description
This PR just adds 2 new models in `fixtures.py`.
It is particular because it does not follow the standard way of handing fixtures (ie tied to hf original models, with an additional SmashConfig). Instead we load the path to a pre-quantized model. To fit with the current state of the codebase, we also load a dummy model, and put the pre-quantized model path into the SmashConfig.

Why this weird behaviour?
-> Because we implement some tests for vLLM in this [PR](https://github.com/PrunaAI/prunatree/pull/228). And vLLM can not 'smash' a model, but intend to run inference.


## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
