### PR TITLE
docs: update contributor setup instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,22 @@ git switch -c feat/new-feature
 
 ### 2. Installation
 
-You can now set up a virtual environment of your choice and install the dependencies by running the following command:
+You have two options for installing dependencies:
+
+#### Option A: Using uv with its own virtual environment (recommended)
+
+```bash
+uv sync --extra dev
+```
+This creates a virtual environment in `.venv/` and installs all dependencies there, including pruna itself in editable mode. **Important:** This does NOT install into your current conda environment! You’ll need to use `uv run` for all commands.
+
+#### Option B: Installing into your current environment (conda/pip)
+
+If you want to install directly into your current conda environment or use pip:
 
 ```bash
 pip install -e .
 pip install -e '.[dev]'
-pip install -e '.[tests]'
 ```
 
 You can then also install the pre-commit hooks with:
@@ -78,17 +88,33 @@ Make sure to develop your contribution in a way that is well documented, concise
 
 We have a comprehensive test suite that is designed to catch potential issues before they are merged into Pruna. When you make a contribution, it is highly recommended to not only run the existing tests but also to add new tests that cover your contribution.
 
-You can run the tests by running the following command:
+You can run the tests depending on which installation option you chose:
+
+#### If you used Option A (uv):
+
+```bash
+uv run pytest
+```
+
+For specific test markers:
+
+```bash
+uv run pytest -m "cpu and not slow"
+```
+
+#### If you used Option B (pip/conda):
 
 ```bash
 pytest
 ```
 
-If you want to run only the tests with a specific marker, e.g. fast CPU tests, you can do so by running:
+For specific test markers:
 
 ```bash
 pytest -m "cpu and not slow"
 ```
+
+Note: `uv run` automatically uses uv’s virtual environment in `.venv/`, not your conda environment.
 
 ### 5. Create a Pull Request
 

--- a/docs/contributions/how_to_contribute.rst
+++ b/docs/contributions/how_to_contribute.rst
@@ -68,7 +68,7 @@ You have two options for installing dependencies:
 
 .. code-block:: bash
 
-    uv sync --extra dev --extra stable-fast --extra gptq
+    uv sync --extra dev
 
 This creates a virtual environment in ``.venv/`` and installs all dependencies there, including pruna itself in editable mode. **Important**: This does NOT install into your current conda environment! You'll need to use ``uv run`` for all commands.
 
@@ -80,7 +80,6 @@ If you want to install directly into your current conda environment or use pip:
 
     pip install -e .
     pip install -e .[dev]
-    pip install -e .[tests]
 
 This installs dependencies directly in your current environment.
 


### PR DESCRIPTION
## Description
This PR updates both the documentation and the `CONTRIBUTING.md` with the correct setup instructions. In particular:
- both now contain both uv & pip as a setup option
- the deprecated `tests` extra is removed
- `stable-fast` and `gptq` are removed as suggested extras. Reasoning: These installations can be tricky and will not be required for 99% of contributions. In case they are required, the user will be informed about these missing installations, so it should be fine to remove them from the setup.

## Related Issue
None.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
None.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
None.
