### PR TITLE
feat: added set_logging_level functionality

### DIFF
--- a/src/pruna/logging/logger.py
+++ b/src/pruna/logging/logger.py
@@ -142,7 +142,7 @@ def setup_pruna_logger() -> logging.Logger:
         The pruna_logger.
     """
     pruna_logger = logging.getLogger("pruna_logger")
-    pruna_logger.setLevel(logging.INFO)
+    set_logging_level()
 
     if not pruna_logger.handlers:
         console_handler = logging.StreamHandler()

--- a/src/pruna/logging/logger.py
+++ b/src/pruna/logging/logger.py
@@ -151,14 +151,16 @@ def set_logging_level(logger: logging.Logger, level: str | None = None) -> None:
         The logger to configure.
     level : str, optional
         The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
-        If None, read from PRUNA_LOG_LEVEL environment variable.
+        If None, read from the PRUNA_LOG_LEVEL environment variable.
     """
     if level is None:
         level = os.getenv("PRUNA_LOG_LEVEL", "INFO")
 
     level = level.upper()
-    log_level = _LOG_LEVELS.get(level, logging.INFO)
-    logger.setLevel(log_level)
+    if level not in _LOG_LEVELS:
+        raise ValueError(f"Invalid logging level: {level}. Must be one of {list(_LOG_LEVELS.keys())}")
+
+    logger.setLevel(_LOG_LEVELS[level])
 
 
 def setup_pruna_logger() -> logging.Logger:

--- a/src/pruna/logging/logger.py
+++ b/src/pruna/logging/logger.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import logging
+import os
 from typing import Any
 
 from colorama import Fore, Style, init
@@ -153,3 +156,31 @@ def setup_pruna_logger() -> logging.Logger:
 
 
 pruna_logger = setup_pruna_logger()
+
+_LOG_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def set_logging_level(level: str | None = None) -> None:
+    """
+    Set the logging level for the global pruna_logger.
+
+    Parameters
+    ----------
+    level : str, optional
+        The logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
+        If None, tries to read from the PRUNA_LOG_LEVEL environment variable.
+    """
+    if level is None:
+        level = os.getenv("PRUNA_LOG_LEVEL", "INFO")
+
+    level = level.upper()
+    if level not in _LOG_LEVELS:
+        raise ValueError(f"Invalid logging level: {level}. Must be one of {list(_LOG_LEVELS.keys())}")
+
+    pruna_logger.setLevel(_LOG_LEVELS[level])

--- a/tests/config/test_logging.py
+++ b/tests/config/test_logging.py
@@ -2,8 +2,7 @@ from typing import Any
 import logging
 import pytest
 
-from pruna.logging import pruna_logger, set_logging_level
-
+from pruna.logging.logger import pruna_logger, set_logging_level
 
 @pytest.mark.cpu
 @pytest.mark.parametrize(

--- a/tests/config/test_logging.py
+++ b/tests/config/test_logging.py
@@ -1,0 +1,44 @@
+from typing import Any
+import logging
+import pytest
+
+from pruna.logging import pruna_logger, set_logging_level
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "level, expected",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("INFO", logging.INFO),
+        ("WARNING", logging.WARNING),
+        ("ERROR", logging.ERROR),
+        ("CRITICAL", logging.CRITICAL),
+    ],
+)
+def test_set_logging_level_programmatic(level: str, expected: int) -> None:
+    """Test setting the pruna_logger level programmatically."""
+    set_logging_level(level)
+    assert pruna_logger.level == expected
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    "env_level, expected",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("WARNING", logging.WARNING),
+    ],
+)
+def test_set_logging_level_env(monkeypatch: Any, env_level: str, expected: int) -> None:
+    """Test setting the pruna_logger level via environment variable."""
+    monkeypatch.setenv("PRUNA_LOG_LEVEL", env_level)
+    set_logging_level()
+    assert pruna_logger.level == expected
+
+
+@pytest.mark.cpu
+def test_invalid_logging_level() -> None:
+    """Test that invalid logging levels raise ValueError."""
+    with pytest.raises(ValueError):
+        set_logging_level("INVALID_LEVEL")

--- a/tests/config/test_logging.py
+++ b/tests/config/test_logging.py
@@ -1,8 +1,10 @@
 from typing import Any
 import logging
 import pytest
+import os
 
 from pruna.logging.logger import pruna_logger, set_logging_level
+
 
 @pytest.mark.cpu
 @pytest.mark.parametrize(
@@ -17,7 +19,7 @@ from pruna.logging.logger import pruna_logger, set_logging_level
 )
 def test_set_logging_level_programmatic(level: str, expected: int) -> None:
     """Test setting the pruna_logger level programmatically."""
-    set_logging_level(level)
+    set_logging_level(pruna_logger, level)
     assert pruna_logger.level == expected
 
 
@@ -32,7 +34,7 @@ def test_set_logging_level_programmatic(level: str, expected: int) -> None:
 def test_set_logging_level_env(monkeypatch: Any, env_level: str, expected: int) -> None:
     """Test setting the pruna_logger level via environment variable."""
     monkeypatch.setenv("PRUNA_LOG_LEVEL", env_level)
-    set_logging_level()
+    set_logging_level(pruna_logger)
     assert pruna_logger.level == expected
 
 
@@ -40,4 +42,4 @@ def test_set_logging_level_env(monkeypatch: Any, env_level: str, expected: int) 
 def test_invalid_logging_level() -> None:
     """Test that invalid logging levels raise ValueError."""
     with pytest.raises(ValueError):
-        set_logging_level("INVALID_LEVEL")
+        set_logging_level(pruna_logger, "INVALID_LEVEL")


### PR DESCRIPTION
## Description
Added a utility function set_logging_level to configure the global pruna_logger logging level programmatically or via the PRUNA_LOG_LEVEL environment variable. Also added unit tests to verify correct behavior for valid and invalid logging levels.  

## Related Issue
Fixes #351 

## Type of Change
- [x] New feature

## How Has This Been Tested?
- Programmatically setting logging levels (`DEBUG`, INFO, WARNING, ERROR, `CRITICAL`)  
- Setting logging levels via environment variable (`PRUNA_LOG_LEVEL`)  
- Validation that invalid logging levels raise ValueError  
- All tests pass locally using pytest  

## Checklist
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my feature works  
- [x] New and existing unit tests pass locally with my changes  

## Additional Notes
- Default logging level is INFO if none is provided and environment variable is not set.  
- Function raises a clear error message if an invalid logging level is passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce set_logging_level to configure logger level via argument or PRUNA_LOG_LEVEL and update logger setup; add tests for valid/invalid levels.
> 
> - **Logging**:
>   - Add `set_logging_level(logger, level)` with validation and `_LOG_LEVELS` map; reads `PRUNA_LOG_LEVEL` when `level` is None.
>   - Update `setup_pruna_logger()` to use `set_logging_level` (defaulting via env) and adjust docstring accordingly.
> - **Tests**:
>   - Add `tests/config/test_logging.py` covering programmatic level setting, env-driven setting, and invalid level error.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5acaf264b1a32d053e20baee60f3d0b8ea1efb0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->