### PR TITLE
feat(evaluation): Add lm-eval to Pruna Metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,9 @@ dev = [
     "pytest-xdist>=3.8.0",
 ]
 cpu = []
+evalharness = [
+    "lm-eval>=0.4.0"
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/pruna/evaluation/metrics/metric_evalharness.py
+++ b/src/pruna/evaluation/metrics/metric_evalharness.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+from typing import Any, List, Dict, Union
+
+import torch
+from pruna.evaluation.metrics.metric_base import BaseMetric
+from pruna.evaluation.metrics.registry import MetricRegistry
+from pruna.evaluation.metrics.result import MetricResult
+from pruna.logging.logger import pruna_logger
+
+
+METRIC_EVALHARNESS = "eval_harness"
+
+
+@MetricRegistry.register(METRIC_EVALHARNESS)
+class EvalHarnessMetric(BaseMetric):
+    """
+    Wraps the EleutherAI LM Evaluation Harness as a Pruna metric.
+
+    This allows you to run benchmark tasks (HellaSwag, MMLU, GSM8k, etc.)
+    and return a scalar score usable in Pruna’s pipeline.
+
+    Parameters
+    ----------
+    tasks : list[str]
+        List of eval harness tasks to run.
+    model_args : dict
+        Arguments for the backend model in eval harness.
+    device : str | torch.device
+        Device to run evaluation on (cuda, cpu, etc.).
+    call_type : str
+        The call type (default "y").
+    """
+
+    metric_name: str = METRIC_EVALHARNESS
+    default_call_type: str = "y"
+    higher_is_better: bool = True
+    metric_units: str = "score"
+
+    def __init__(
+        self,
+        tasks: List[str],
+        model_args: Dict[str, Any],
+        device: Union[str, torch.device] = "cuda:0",
+        call_type: str = "y",
+        **kwargs,
+    ):
+        super().__init__()
+        self.tasks = tasks
+        self.model_args = model_args
+        self.device = torch.device(device) if isinstance(device, str) else device
+        self.call_type = call_type
+
+    def compute(self, model, dataloader) -> MetricResult:
+        """
+        Run LM Eval Harness and return the aggregated result.
+        """
+        try:
+            from lm_eval import evaluator
+        except ImportError:
+            raise ImportError(
+                "lm_eval package is not installed. Please install it with `pip install lm-eval`."
+            )
+
+        try:
+            eval_results = evaluator.simple_evaluate(
+                model="hf",
+                model_args=self.model_args,
+                tasks=self.tasks,
+                device=str(self.device),
+                batch_size=1,
+            )
+        except Exception as e:
+            pruna_logger.error(f"Eval Harness failed: {e}")
+            raise
+
+        scores, task_scores = [], {}
+
+        preferred_keys = ["acc,none", "acc", "f1", "em"]
+
+        for task in self.tasks:
+            if task not in eval_results["results"]:
+                pruna_logger.warning(f"Task {task} not found in eval results")
+                continue
+
+            task_results = eval_results["results"][task]
+            metric_keys = [
+                k
+                for k in task_results.keys()
+                if k not in {"alias", "samples", "higher_is_better"}
+            ]
+
+            if not metric_keys:
+                pruna_logger.warning(f"No metrics found for task {task}")
+                continue
+
+            key = next((k for k in preferred_keys if k in metric_keys), metric_keys[0])
+            score = task_results[key]
+            task_scores[task] = score
+            scores.append(score)
+
+        final_score = sum(scores) / len(scores) if scores else 0.0
+
+        return MetricResult(
+            self.metric_name,
+            {**self.__dict__, "task_scores": task_scores},
+            final_score,
+            higher_is_better=self.higher_is_better,
+            metric_units=self.metric_units,
+        )

--- a/tests/evaluation/test_evalharness_metrics.py
+++ b/tests/evaluation/test_evalharness_metrics.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from pruna.evaluation.metrics.metric_evalharness import EvalHarnessMetric
+from pruna.evaluation.metrics.result import MetricResult
+
+
+@pytest.mark.cpu
+def test_eval_harness_basic():
+    """Test EvalHarnessMetric on a tiny HF model + task."""
+
+    # Use a very small HF model for speed
+    model_args = {
+        "pretrained": "sshleifer/tiny-gpt2",
+        "revision": "main",
+    }
+
+    metric = EvalHarnessMetric(
+        tasks=["lambada_openai"],  # lightweight benchmark
+        model_args=model_args,
+        device=torch.device("cpu"),
+    )
+
+    # compute ignores Pruna dataloader/model, so pass None
+    result: MetricResult = metric.compute(model=None, dataloader=None)
+
+    print(f"Result: {result}")
+
+    # Assertions
+    assert isinstance(result, MetricResult)
+    assert "task_scores" in result.params
+    assert "lambada_openai" in result.params["task_scores"]
+    # Result should be a float between 0 and 1 for accuracy-like tasks
+    score = result.params["task_scores"]["lambada_openai"]
+    assert isinstance(score, float)
+    assert 0.0 <= score <= 1.0
+    # Final score matches average
+    assert result.result == pytest.approx(score, abs=1e-6)
+
+
+@pytest.mark.cpu
+def test_eval_harness_multiple_tasks():
+    """Test EvalHarnessMetric with multiple tasks aggregated."""
+
+    model_args = {
+        "pretrained": "sshleifer/tiny-gpt2",
+    }
+
+    tasks = ["lambada_openai", "hellaswag"]
+
+    metric = EvalHarnessMetric(
+        tasks=tasks,
+        model_args=model_args,
+        device=torch.device("cpu"),
+    )
+
+    result = metric.compute(model=None, dataloader=None)
+
+    # It should produce scores for all requested tasks
+    for task in tasks:
+        assert task in result.params["task_scores"]
+
+    # Final score is average of per-task scores
+    scores = list(result.params["task_scores"].values())
+    assert result.result == pytest.approx(sum(scores) / len(scores), rel=1e-6)


### PR DESCRIPTION
## Description
Adds [evaluation harness](https://github.com/EleutherAI/lm-evaluation-harness) to the metrics lineup.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #378 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Have added basic unit tests for two tasks from eval harness.
- Will add more tests as needed

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
- `EvalHarnessMetric` inherits from `BaseMetric` since eval harness metrics are model level metrics.
- Open to discuss and update code and tests. 
