### PR TITLE
feat: add pre-commit `trufflehog`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,5 +51,5 @@ repos:
         name: TruffleHog
         description: Detect secrets in your data.
         entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail'
-        language: python
+        language: system
         stages: ["pre-commit", "pre-push"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,9 @@ repos:
         stages: [pre-commit]
         types: [python]
         exclude: "^docs/"
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data.
+        entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail'
+        language: python
+        stages: ["pre-commit", "pre-push"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,8 @@ You can then also install the pre-commit hooks with:
 pre-commit install
 ```
 
+**Note:** The pre-commit hooks include TruffleHog for secret detection. TruffleHog must be installed separately as a binary tool. See the [TruffleHog installation instructions](https://github.com/trufflesecurity/trufflehog) for your platform.
+
 ### 3. Develop your contribution
 
 You are now ready to work on your contribution. Check out a branch on your forked repository and start coding! When committing your changes, we recommend following the [Conventional Commit Guidelines](https://www.conventionalcommits.org/en/v1.0.0/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ dev = [
     "blobfile",
     "pillow>=9.5.0",
     "pre-commit",
-    "trufflehog",
     "twine",
     "pyc-wheel",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ dev = [
     "blobfile",
     "pillow>=9.5.0",
     "pre-commit",
+    "trufflehog",
     "twine",
     "pyc-wheel",
     "ruff",


### PR DESCRIPTION
## Description

This PR adds trufflehog to the pre-commit hooks to prevent API keys/tokens leaks. 

## Related Issue



## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add TruffleHog secret scanning to pre-commit/pre-push hooks and document its installation in CONTRIBUTING.
> 
> - **Tooling: pre-commit hooks**
>   - Add `trufflehog` hook in `.pre-commit-config.yaml` with stages `pre-commit` and `pre-push`, running `trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail`.
> - **Docs**
>   - Update `CONTRIBUTING.md` to note TruffleHog is included in hooks and must be installed separately, with link to installation instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b2a050eefd4d674db3470dc48916e7e19b18f5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->