### PR TITLE
Feat#319: Add aesthetic laion metric

### DIFF
--- a/src/pruna/evaluation/metrics/__init__.py
+++ b/src/pruna/evaluation/metrics/__init__.py
@@ -14,6 +14,7 @@
 
 from pruna.evaluation.metrics.registry import MetricRegistry  # isort:skip
 
+from pruna.evaluation.metrics.aesthetic_laion import AestheticLAION, CLIPVariantAesthetics
 from pruna.evaluation.metrics.metric_cmmd import CMMD
 from pruna.evaluation.metrics.metric_elapsed_time import LatencyMetric, ThroughputMetric, TotalTimeMetric
 from pruna.evaluation.metrics.metric_energy import CO2EmissionsMetric, EnergyConsumedMetric
@@ -37,4 +38,6 @@ __all__ = [
     "TotalMACsMetric",
     "PairwiseClipScore",
     "CMMD",
+    "AestheticLAION",
+    "CLIPVariantAesthetics",
 ]

--- a/src/pruna/evaluation/metrics/aesthetic_laion.py
+++ b/src/pruna/evaluation/metrics/aesthetic_laion.py
@@ -1,0 +1,186 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pathlib
+from enum import Enum
+from typing import Any, List
+from urllib.request import urlretrieve
+
+import torch
+import torch.nn as nn
+from huggingface_hub import model_info
+from huggingface_hub.utils import EntryNotFoundError
+from transformers import CLIPImageProcessor, CLIPVisionModelWithProjection
+
+from pruna.engine.utils import set_to_best_available_device
+from pruna.evaluation.metrics.metric_stateful import StatefulMetric
+from pruna.evaluation.metrics.registry import MetricRegistry
+from pruna.evaluation.metrics.result import MetricResult
+from pruna.evaluation.metrics.utils import metric_data_processor
+from pruna.logging.logger import pruna_logger
+
+
+class CLIPVariantAesthetics(Enum):
+    """Maps a CLIP variant supported by LAION Aesthetic Predictor v1 to a CLIP model name in the hugging face hub."""
+
+    vit_l_14 = "openai/clip-vit-large-patch14"
+    vit_b_32 = "openai/clip-vit-base-patch32"
+    vit_b_16 = "openai/clip-vit-base-patch16"
+
+
+METRIC_AESTHETIC_LAION = "aesthetic_laion"
+
+
+@MetricRegistry.register(METRIC_AESTHETIC_LAION)
+class AestheticLAION(StatefulMetric):
+    """
+    Calculates the CMMD metric, which is the Maximum Mean Discrepancy between CLIP embeddings of two sets of images.
+
+    from https://arxiv.org/abs/2401.09603, Rethinking FID: Towards a Better Evaluation metric for Image Generation
+
+    Parameters
+    ----------
+    *args : Any
+        Additional arguments to pass to the StatefulMetric constructor.
+    device : str | torch.device | None, optional
+        The device to be used, e.g., 'cuda' or 'cpu'. Default is None.
+        If None, the best available device will be used.
+    clip_model_name : CLIPVariantAesthetics
+        The variant of a CLIP model to be used.
+    **kwargs : Any
+        Additional keyword arguments to pass to the StatefulMetric constructor.
+    """
+
+    total: torch.Tensor
+    count: torch.Tensor
+    call_type: str = "y"
+    higher_is_better: bool = True
+    metric_name: str = METRIC_AESTHETIC_LAION
+
+    def __init__(
+        self,
+        *args,
+        device: str | torch.device | None = None,
+        clip_model_name: CLIPVariantAesthetics = CLIPVariantAesthetics.vit_l_14,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.device = set_to_best_available_device(device)
+        try:
+            model_info(clip_model_name.value)
+        except EntryNotFoundError:
+            # Should never happen since enum values are guaranteed to exist
+            pruna_logger.error(f"Model {clip_model_name.value} does not exist.")
+            raise ValueError(f"Model {clip_model_name.value} does not exist.")
+
+        self.clip_model = CLIPVisionModelWithProjection.from_pretrained(clip_model_name.value).to(self.device)
+        self.clip_processor = CLIPImageProcessor.from_pretrained(clip_model_name.value)
+        self.aesthetic_model = self._get_aesthetic_model(clip_model_name.name)
+
+        self.add_state("total", torch.zeros(1))
+        self.add_state("count", torch.zeros(1))
+
+    def update(self, x: List[Any] | torch.Tensor, gt: torch.Tensor, outputs: torch.Tensor) -> None:
+        """
+        Update the metric with new batch data.
+
+        Update computes the CLIP embeddings and aesthetic scores for the given inputs.
+
+        Parameters
+        ----------
+        x : List[Any] | torch.Tensor
+            The input data.
+        gt : torch.Tensor
+            The ground truth / cached images.
+        outputs : torch.Tensor
+            The output images.
+        """
+        inputs = metric_data_processor(x, gt, outputs, self.call_type)
+        image_features = self._get_embeddings(inputs[0])
+        with torch.no_grad():
+            prediction = self.aesthetic_model(image_features)
+            self.total += torch.sum(prediction)
+            self.count += prediction.shape[0]
+
+    def compute(self) -> MetricResult:
+        """
+        Compute the average Aesthetic LAION metric based on all previous updates.
+
+        Returns
+        -------
+        float
+            The average Aesthetic LAION metric.
+        """
+        result = self.total / self.count if self.count.item() != 0 else torch.zeros(1)
+        return MetricResult(self.metric_name, self.__dict__.copy(), result.item())
+
+    def _get_embeddings(self, images: torch.Tensor) -> torch.Tensor:
+        """
+        Get the CLIP embeddings for a set of images.
+
+        Parameters
+        ----------
+        images : torch.Tensor
+            The images to get the CLIP embeddings for.
+
+        Returns
+        -------
+        torch.Tensor
+            The CLIP embeddings for the images.
+        """
+        processed = self.clip_processor(images=images.cpu(), return_tensors="pt").to(self.device)
+        self.clip_model.to(self.device)
+        embeddings = self.clip_model(**processed).image_embeds
+        embeddings = embeddings / embeddings.norm(p=2, dim=-1, keepdim=True)
+        return embeddings
+
+    def _get_aesthetic_model(self, clip_model="vit_l_14"):
+        """
+        Load the aethetic model.
+
+        Parameters
+        ----------
+        clip_model : str
+            CLIP variant name.
+
+            see https://github.com/LAION-AI/aesthetic-predictor/tree/main for available variants
+
+        Returns
+        -------
+        torch.nn.Linear
+            Pretrained linear head which corresponds to the given CLIP model.
+        """
+        home = pathlib.Path("~").expanduser()
+        cache_folder = home / ".cache/aesthetic_laion_linear_heads"
+        path_to_model = cache_folder / ("sa_0_4_" + clip_model + "_linear.pth")
+        if not path_to_model.exists():
+            cache_folder.mkdir(exist_ok=True, parents=True)
+            url_model = (
+                "https://github.com/LAION-AI/aesthetic-predictor/blob/main/sa_0_4_" + clip_model + "_linear.pth?raw=true"
+            )
+            urlretrieve(url_model, path_to_model)
+        if clip_model == "vit_l_14":
+            m = nn.Linear(768, 1)
+        elif clip_model == "vit_b_32" or clip_model == "vit_b_16":
+            m = nn.Linear(512, 1)
+        else:
+            # Should not happen since the enum is used
+            pruna_logger.error(f"Model {clip_model} is not supported by aesthetic predictor.")
+            raise ValueError(f"Model {clip_model} is not supported by aesthetic predictor.")
+        s = torch.load(path_to_model)
+        m.load_state_dict(s)
+        m.eval()
+        return m

--- a/src/pruna/evaluation/metrics/aesthetic_laion.py
+++ b/src/pruna/evaluation/metrics/aesthetic_laion.py
@@ -34,7 +34,7 @@ from pruna.logging.logger import pruna_logger
 
 
 class CLIPVariantAesthetics(Enum):
-    """Maps a CLIP variant supported by LAION Aesthetic Predictor v1 to a CLIP model name in the hugging face hub."""
+    """Maps a CLIP variant supported by the LAION Aesthetic Predictor v1 to a CLIP model name in the Hugging Face Hub."""
 
     vit_l_14 = "openai/clip-vit-large-patch14"
     vit_b_32 = "openai/clip-vit-base-patch32"
@@ -47,9 +47,16 @@ METRIC_AESTHETIC_LAION = "aesthetic_laion"
 @MetricRegistry.register(METRIC_AESTHETIC_LAION)
 class AestheticLAION(StatefulMetric):
     """
-    Calculates the CMMD metric, which is the Maximum Mean Discrepancy between CLIP embeddings of two sets of images.
+     Predicts an image aesthetic quality score using LAION-Aesthetics_Predictor V1.
 
-    from https://arxiv.org/abs/2401.09603, Rethinking FID: Towards a Better Evaluation metric for Image Generation
+    This metric computes CLIP image embeddings and feeds them into a pretrained
+    linear head released by LAION (matched to the chosen CLIP variant). The model
+    returns a scalar score per image (on a ~1–10 scale). The metric
+    aggregates scores across updates by reporting their mean. Higher is better.
+
+    Reference
+    ---------
+    LAION-Aesthetics_Predictor V1: https://github.com/LAION-AI/aesthetic-predictor
 
     Parameters
     ----------
@@ -97,7 +104,7 @@ class AestheticLAION(StatefulMetric):
         """
         Update the metric with new batch data.
 
-        Update computes the CLIP embeddings and aesthetic scores for the given inputs.
+        This computes the CLIP embeddings and aesthetic scores for the given inputs.
 
         Parameters
         ----------
@@ -117,7 +124,7 @@ class AestheticLAION(StatefulMetric):
 
     def compute(self) -> MetricResult:
         """
-        Compute the average Aesthetic LAION metric based on all previous updates.
+        Compute the average Aesthetic LAION metric based on previous updates.
 
         Returns
         -------
@@ -161,7 +168,7 @@ class AestheticLAION(StatefulMetric):
         Returns
         -------
         torch.nn.Linear
-            Pretrained linear head which corresponds to the given CLIP model.
+            A pretrained linear head corresponding to the given CLIP model name.
         """
         home = pathlib.Path("~").expanduser()
         cache_folder = home / ".cache/aesthetic_laion_linear_heads"

--- a/tests/evaluation/test_aesthetics_liaon.py
+++ b/tests/evaluation/test_aesthetics_liaon.py
@@ -1,0 +1,49 @@
+import requests
+from PIL import Image
+from io import BytesIO
+import torch
+import numpy as np
+
+import pytest
+
+from pruna.data.pruna_datamodule import PrunaDataModule
+from pruna.evaluation.metrics.aesthetic_laion import AestheticLAION, CLIPVariantAesthetics
+
+
+@pytest.mark.parametrize(
+    "device, clip_model",
+    [
+        pytest.param("cpu", CLIPVariantAesthetics.vit_l_14, marks=pytest.mark.cpu),
+        pytest.param("cpu", CLIPVariantAesthetics.vit_b_32, marks=pytest.mark.cpu),
+        pytest.param("cpu", CLIPVariantAesthetics.vit_b_16, marks=pytest.mark.cpu),
+
+    ],
+)
+def test_aesthetic_laion(device: str, clip_model: str) -> None:
+    """Test the AestheticLAION metric."""
+    data_module = PrunaDataModule.from_string("LAION256")
+    data_module.limit_datasets(10)
+
+    metric = AestheticLAION(clip_model_name=clip_model, device=device)
+    for x, gt in data_module.test_dataloader():
+        metric.update(x, gt, gt)
+
+    score = metric.compute()
+    assert score.result > 1.0 and score.result < 10.0
+
+
+@pytest.mark.cpu
+def test_metric_aesthetic_laion_ipynb_sample() -> None:
+    """
+    Test the aesthetic_laion metric with an image taken from
+    https://github.com/LAION-AI/aesthetic-predictor/blob/main/asthetics_predictor.ipynb
+    Result in the original notebook is 4.0330. If you rerun it, you will get 4.4425.
+    Huggingface model, however, gets 5.049.
+    """
+    metric = AestheticLAION(device="cpu")
+    response = requests.get("https://thumbs.dreamstime.com/b/lovely-cat-as-domestic-animal-view-pictures-182393057.jpg")
+    img = np.array(Image.open(BytesIO(response.content)).convert("RGB"))
+    img = torch.from_numpy(img).permute(2, 0, 1).contiguous().unsqueeze(0)
+    metric.update("lovely cat as domestic animal view pictures", img, img)
+    score = metric.compute()
+    assert abs(score.result - 5.05) < 1e-2

--- a/tests/evaluation/test_aesthetics_liaon.py
+++ b/tests/evaluation/test_aesthetics_liaon.py
@@ -37,8 +37,8 @@ def test_metric_aesthetic_laion_ipynb_sample() -> None:
     """
     Test the aesthetic_laion metric with an image taken from
     https://github.com/LAION-AI/aesthetic-predictor/blob/main/asthetics_predictor.ipynb
-    Result in the original notebook is 4.0330. If you rerun it, you will get 4.4425.
-    Huggingface model, however, gets 5.049.
+    The result in the original notebook is 4.0330; if you rerun it, you will get 4.4425.
+    The Hugging Face model, however, gives 5.049.
     """
     metric = AestheticLAION(device="cpu")
     response = requests.get("https://thumbs.dreamstime.com/b/lovely-cat-as-domestic-animal-view-pictures-182393057.jpg")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
**Added a new evaluation metric — `AestheticLAION`:**
  * Implements an image aesthetic quality metric based on the [[LAION-AI aesthetic-predictor](https://github.com/LAION-AI/aesthetic-predictor)](https://github.com/LAION-AI/aesthetic-predictor).
  * Uses CLIP (various backbones: `vit-l-14`, `vit-b-32`, `vit-b-16`) to extract embeddings, then applies the pretrained LAION linear head to produce aesthetic scores.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #319 

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
* Added `test_aesthetic_laion` to validate scoring on a small LAION256 sample.
* Added `test_metric_aesthetic_laion_ipynb_sample` to verify consistency with the official LAION notebook example.

> **Note:** While trying to reproduce the numbers from the provided [notebook](https://github.com/LAION-AI/aesthetic-predictor/blob/main/asthetics_predictor.ipynb), I observed that the aesthetic score was originally around **4.0**, but re-running the notebook now yields about **4.4**. Using the Hugging Face model instead gives a score of roughly **5.0**.
> I suspect this difference comes from changes in the underlying CLIP models — the ones available for inference today may not match the exact versions used during training.
> Despite these shifts, the predicted aesthetic scores remain generally reasonable and comparable in scale.


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
* I can’t run CUDA tests on my machine.
* Using "wrong" CLIP models doesn't feel right
* I believe that [metrics overview documentation](https://docs.pruna.ai/en/stable/reference/evaluation.html#metrics-overview) is not a part of the repo