### PR TITLE
ci: migrate test models to pruna-test

### DIFF
--- a/tests/engine/test_load.py
+++ b/tests/engine/test_load.py
@@ -11,7 +11,7 @@ from pruna.config.smash_config import SmashConfig
 @pytest.mark.parametrize(
     "model_name, expected_output, should_raise",
     [
-        ("PrunaAI/test-load-tiny-stable-diffusion-pipe-smashed", "PrunaModel", False),
+        ("pruna-test/test-load-tiny-stable-diffusion-pipe-smashed", "PrunaModel", False),
         ("NonExistentRepo/model", None, True),
     ],
 )

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -13,10 +13,8 @@ from pruna.engine.load import load_pruna_model
 from pruna.config.smash_config import SmashConfig
 from diffusers import DiffusionPipeline
 from pruna.engine.pruna_model import PrunaModel
-from huggingface_hub import get_token
 
 
-@pytest.mark.skipif(get_token() is None, reason="HF_TOKEN environment variable is not set, skipping tests.")
 @pytest.mark.slow
 @pytest.mark.cpu
 def test_save_llm_to_hub() -> None:
@@ -31,7 +29,6 @@ def test_save_llm_to_hub() -> None:
     )
     pruna_model.push_to_hub(upload_repo_id, private=False)
 
-@pytest.mark.skipif(get_token() is None, reason="HF_TOKEN environment variable is not set, skipping tests.")
 @pytest.mark.slow
 @pytest.mark.cpu
 def test_save_diffusers_to_hub() -> None:

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -22,7 +22,7 @@ from huggingface_hub import get_token
 def test_save_llm_to_hub() -> None:
     """Test saving an LLM model to the Hugging Face Hub."""
     download_repo_id = "hf-internal-testing/tiny-random-llama4"
-    upload_repo_id = "PrunaAI/test-save-tiny-random-llama4-smashed"
+    upload_repo_id = "pruna-test/test-save-tiny-random-llama4-smashed"
     model = AutoModelForCausalLM.from_pretrained(download_repo_id)
     smash_config = SmashConfig(device="cpu")
     pruna_model = smash(
@@ -37,7 +37,7 @@ def test_save_llm_to_hub() -> None:
 def test_save_diffusers_to_hub() -> None:
     """Test saving a diffusers model to the Hugging Face Hub."""
     download_repo_id = "hf-internal-testing/tiny-stable-diffusion-pipe"
-    upload_repo_id = "PrunaAI/test-save-tiny-stable-diffusion-pipe-smashed"
+    upload_repo_id = "pruna-test/test-save-tiny-stable-diffusion-pipe-smashed"
     model = DiffusionPipeline.from_pretrained(download_repo_id)
     smash_config = SmashConfig(device="cpu")
     pruna_model = smash(

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -13,10 +13,10 @@ from pruna.engine.load import load_pruna_model
 from pruna.config.smash_config import SmashConfig
 from diffusers import DiffusionPipeline
 from pruna.engine.pruna_model import PrunaModel
+from huggingface_hub import get_token
 
 
-
-@pytest.mark.skipif("HF_TOKEN" not in os.environ, reason="HF_TOKEN environment variable is not set, skipping tests.")
+@pytest.mark.skipif(get_token() is None, reason="HF_TOKEN environment variable is not set, skipping tests.")
 @pytest.mark.slow
 @pytest.mark.cpu
 def test_save_llm_to_hub() -> None:
@@ -31,7 +31,7 @@ def test_save_llm_to_hub() -> None:
     )
     pruna_model.push_to_hub(upload_repo_id, private=False)
 
-@pytest.mark.skipif("HF_TOKEN" not in os.environ, reason="HF_TOKEN environment variable is not set, skipping tests.")
+@pytest.mark.skipif(get_token() is None, reason="HF_TOKEN environment variable is not set, skipping tests.")
 @pytest.mark.slow
 @pytest.mark.cpu
 def test_save_diffusers_to_hub() -> None:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -53,7 +53,7 @@ def dataloader_fixture(request: pytest.FixtureRequest) -> Any:
 
 def whisper_tiny_random_model() -> tuple[Any, SmashConfig]:
     """Whisper tiny random model for speech recognition."""
-    model_id = "PrunaAI/whisper-v3-tiny-random"
+    model_id = "pruna-test/whisper-v3-tiny-random"
     model = pipeline(
         "automatic-speech-recognition",
         model=model_id,
@@ -182,7 +182,7 @@ MODEL_FACTORY: dict[str, Callable] = {
     "dummy_lambda": dummy_model,
     # image generation AR models
     "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "loulou2/tiny_janus"),
-    "wan_tiny_random": partial(get_diffusers_model, "PrunaAI/wan-t2v-tiny-random", torch_dtype=torch.bfloat16),
+    "wan_tiny_random": partial(get_diffusers_model, "pruna-test/wan-t2v-tiny-random", torch_dtype=torch.bfloat16),
     "flux_tiny": partial(get_diffusers_model, "loulou2/tiny_flux", torch_dtype=torch.float16),
     "tiny_llama": partial(get_automodel_transformers, "loulou2/tiny_llama", torch_dtype=torch.bfloat16),
 }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -181,8 +181,8 @@ MODEL_FACTORY: dict[str, Callable] = {
     ),
     "dummy_lambda": dummy_model,
     # image generation AR models
-    "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "loulou2/tiny_janus"),
+    "tiny_janus_pro": partial(get_automodel_image_text_to_text_transformers, "pruna-test/tiny_janus"),
     "wan_tiny_random": partial(get_diffusers_model, "pruna-test/wan-t2v-tiny-random", torch_dtype=torch.bfloat16),
-    "flux_tiny": partial(get_diffusers_model, "loulou2/tiny_flux", torch_dtype=torch.float16),
-    "tiny_llama": partial(get_automodel_transformers, "loulou2/tiny_llama", torch_dtype=torch.bfloat16),
+    "flux_tiny": partial(get_diffusers_model, "pruna-test/tiny_flux", torch_dtype=torch.float16),
+    "tiny_llama": partial(get_automodel_transformers, "pruna-test/tiny_llama", torch_dtype=torch.bfloat16),
 }


### PR DESCRIPTION
## Description
This PR enacts the transfer of all test models previously stored in PrunaAI to the pruna-test organisation.
- PrunaAI/model-name in the tests were renamed to pruna-test/model-name
- same for loulou2/model-name

This PR also changes the condition for running the push-to-hub tests on pruna side in the nightlies so that it actually runs.

## Related Issue
This fixes the following errors when testing the push-to-hub functionalities: huggingface_hub._upload_large_folder:_upload_large_folder.py:395 Failed to commit

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Re-ran the nightly tests.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates test model repo IDs to `pruna-test` and removes HF token skip to run push-to-hub tests.
> 
> - **Tests**:
>   - **Model refs**: Update Hugging Face repo IDs from `PrunaAI/*` and `loulou2/*` to `pruna-test/*` in `tests/engine/test_load.py` and `tests/fixtures.py`.
>   - **Push-to-hub**: Remove `@pytest.mark.skipif("HF_TOKEN" not in os.environ, ...)` to allow running hub upload tests in `tests/engine/test_save.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 836d748d92f9cb2adfd2a0b9cae8b55cdc808231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->