### PR TITLE
docs: removing `pruna_pro` mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 [![Replicate](https://img.shields.io/badge/replicate-black?style=flat-square)][replicate]
 
 <br>
-
+<!---
 <img src="./docs/assets/images/triple_line.png" alt="Pruna AI Logo" width=600, height=30></img>
-
+--->
 </div>
 
 ## <img src="./docs/assets/images/pruna_cool.png" alt="Pruna Cool" width=20></img> Introduction
@@ -126,7 +126,7 @@ eval_agent.evaluate(smashed_model)
 ```
 
 This was the minimal example, but you are looking for the maximal example? You can check out our [documentation][documentation] for an overview of all supported [algorithms][docs-algorithms] as well as our tutorials for more use-cases and examples.
-
+<!--
 ## <img src="./docs/assets/images/pruna_heart.png" alt="Pruna Heart" width=20></img> Pruna Pro
 
 Pruna has everything you need to get started on optimizing your own models. To push the efficiency of your models even further, we offer Pruna Pro. To give you a glimpse of what is possible with Pruna Pro, let us consider three of the most widely used diffusers pipelines and see how much smaller and faster we can make them. In addition to popular open-source algorithms, we use our proprietary Auto Caching algorithm. We compare the fidelity of the compressed models. Fidelity measures the similarity between the images of the compressed models and the images of the original model.
@@ -147,7 +147,7 @@ For [HunyuanVideo](https://huggingface.co/tencent/HunyuanVideo), we compare Auto
 
 <img src="./docs/assets/plots/benchmark_hunyuan.svg" alt="HunyuanVideo Benchmark"/>
 
-
+-->
 
 ## <img src="./docs/assets/images/pruna_cool.png" alt="Pruna Cool" width=20></img> Algorithm Overview
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 [![Replicate](https://img.shields.io/badge/replicate-black?style=flat-square)][replicate]
 
 <br>
-<!---
+
 <img src="./docs/assets/images/triple_line.png" alt="Pruna AI Logo" width=600, height=30></img>
---->
+
 </div>
 
 ## <img src="./docs/assets/images/pruna_cool.png" alt="Pruna Cool" width=20></img> Introduction
@@ -46,12 +46,12 @@ Pruna is a model optimization framework built for developers, enabling you to de
 
 The toolkit is designed with simplicity in mind - requiring just a few lines of code to optimize your models. It supports various model types including LLMs, Diffusion and Flow Matching Models, Vision Transformers, Speech Recognition Models and more.
 
-
+<!--
 <img align="left" width="40" src="docs/assets/images/highlight.png" alt="Pruna Pro"/>
 
 **To move at top speed**, we offer [Pruna Pro](https://docs.pruna.ai/en/stable/docs_pruna_pro/user_manual/pruna_pro.html), our enterprise solution that unlocks advanced optimization features, our `OptimizationAgent`, priority support, and much more.
 <br clear="left"/>
-
+-->
 
 ## <img src="./docs/assets/images/pruna_cool.png" alt="Pruna Cool" width=20></img> Installation
 

--- a/README.md
+++ b/README.md
@@ -158,13 +158,9 @@ Since Pruna offers a broad range of optimization algorithms, the following table
 | `batcher`    | Groups multiple inputs together to be processed simultaneously, improving computational efficiency and reducing processing time. | ✅    | ❌     | ➖      |
 | `cacher`     | Stores intermediate results of computations to speed up subsequent operations.               | ✅    | ➖     | ➖      |
 | `compiler`   | Optimises the model with instructions for specific hardware.                                 | ✅    | ➖     | ➖      |
-| `distiller`  | Trains a smaller, simpler model to mimic a larger, more complex model.                       | ✅    | ✅     | ❌      |
 | `quantizer`  | Reduces the precision of weights and activations, lowering memory requirements.              | ✅    | ✅     | ❌      |
 | `pruner`     | Removes less important or redundant connections and neurons, resulting in a sparser, more efficient network. | ✅    | ✅     | ❌      |
-| `recoverer`  | Restores the performance of a model after compression.                                       | ➖    | ➖     | ✅      |
 | `factorizer` | Factorization batches several small matrix multiplications into one large fused operation. | ✅ | ➖ | ➖ |
-| `enhancer`   | Enhances the model output by applying post-processing algorithms such as denoising or upscaling. | ❌ | ➖ | ✅ |
-| `distributer`   | Distributes the inference, the model or certain calculations across multiple devices. | ✅ | ❌ | ➖ |
 | `kernel`   | Kernels are specialized GPU routines that speed up parts of the computation.  | ✅ | ➖ | ➖ |
 
 ✅ (improves), ➖ (approx. the same), ❌ (worsens)


### PR DESCRIPTION
## Description
I commented on the Pruna Pro and the Pruna Pro sections since we are deprecating this product.


## Type of Change
- [X] This change requires a documentation update

## How Has This Been Tested?
previewing markdown

## Checklist
- [X] My code follows the style guidelines of this project



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Comments out all `Pruna Pro` promotional content and benchmarks in `README.md`.
> 
> - **Documentation**
>   - **`README.md`**:
>     - Commented out the highlighted `Pruna Pro` promo blurb near the introduction.
>     - Commented out the full `Pruna Pro` section, including SDXL, FLUX [dev], and HunyuanVideo benchmark subsections and images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47ec2d0ac4e72a72ae3c415ae8373ef7d19fcc6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->