### PR TITLE
fix: remove outdated prunamodel interface from deploying sana notebook

### DIFF
--- a/docs/tutorials/deploying_sana_tutorial.ipynb
+++ b/docs/tutorials/deploying_sana_tutorial.ipynb
@@ -453,7 +453,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -562,6 +562,7 @@
    "source": [
     "# Import required modules from Pruna\n",
     "from pruna.data.pruna_datamodule import PrunaDataModule\n",
+    "from pruna.engine.utils import move_to_device\n",
     "from pruna.evaluation.evaluation_agent import EvaluationAgent\n",
     "from pruna.evaluation.metrics import (\n",
     "    LatencyMetric,\n",
@@ -586,7 +587,7 @@
     "eval_agent = EvaluationAgent(task)\n",
     "\n",
     "# Move smashed model to evaluation device (GPU or CPU)\n",
-    "smashed_pipe.move_to_device(device)\n",
+    "move_to_device(smashed_pipe, device)\n",
     "\n",
     "# Evaluate the smashed model pipeline using the evaluation agent\n",
     "smashed_model_results = eval_agent.evaluate(smashed_pipe)\n",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
We recently stopped having a `move_to_device` function in `PrunaModel`. 
In `pruna.engine.utils` we already have a move_to_device function which now works with Any model (base, or smashed, PrunaModel or not)
This is a quick fix to refactor the tutorial notebook that was added recently in #322 

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
