### PR TITLE
[Tests] Fix Warnings by replacing deprecated methods in Sphinx

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -10,6 +10,7 @@ import numpydoc_validation
 import pytest
 import torch
 from accelerate.utils import compute_module_sizes, infer_auto_device_map
+from docutils.core import publish_doctree
 from docutils.nodes import literal_block, section, title
 from transformers import Pipeline
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

In the tests log, I have observed a [similar warning(168 times)](https://github.com/PrunaAI/pruna/actions/runs/20172207012/job/57910787508) which is emitted:

```
  /home/runner/work/pruna/pruna/tests/common.py:339: PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
    for sec in document.traverse(section):
```

I have updated the utilites used with `common.py` with the newer methods in sphinx, so the [warnings](https://github.com/PrunaAI/pruna/actions/runs/20172207012/job/57910787508) have been fixed. Could you please review?

cc: @davidberenstein1957 

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
