### PR TITLE
fix: initialization of base tester class

### DIFF
--- a/tests/algorithms/testers/base_tester.py
+++ b/tests/algorithms/testers/base_tester.py
@@ -22,9 +22,10 @@ from pruna.logging.logger import pruna_logger
 class AlgorithmTesterBase:
     """Base class for testing algorithms."""
 
+    hyperparameters: dict[str, Any] = {}
+
     def __init__(self):
         self._saving_path = Path(tempfile.mkdtemp(prefix="pruna_saved_model_"))
-        self.hyperparameters = {}
 
     @property
     @abstractmethod


### PR DESCRIPTION
## Description
The base tester overwrites hyperparameters by assigning its values during `__init__`, which this PR fixes.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
