### PR TITLE
fix: missing default parameters in smash config

### DIFF
--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -286,10 +286,14 @@ class SmashConfig:
         saved_values = {k: v for k, v in config_dict.items() if k in supported_hparam_names}
 
         # Seed with the defaults, then overlay the saved values
-        default_values = dict(SMASH_SPACE.get_default_configuration())
-        default_values.update(saved_values)
-
-        self._configuration = Configuration(SMASH_SPACE, values=default_values)
+        self._configuration = SMASH_SPACE.get_default_configuration()
+        # activate all algorithms already in the space to make children hyperparameters appear
+        saved_algorithm_keys = set(self._configuration.keys()) & set(saved_values.keys())
+        for key in saved_algorithm_keys:
+            self._configuration[key] = True
+        # register all saved hyperparameters
+        for key, value in saved_values.items():
+            self._configuration[key] = value
 
         tokenizer_path = Path(path) / TOKENIZER_SAVE_PATH
         if tokenizer_path.exists():


### PR DESCRIPTION
## Description
This PR fixes a legacy related bug where loading a saved SmashConfig with missing hyperparameters for an algorithm (e.g. target modules for hqq_diffusers) would result in an error from the load_from_json function stating that the hyperparameter is missing.

This was due to a discrepency between parent/children hyperparameter coverage between SMASH_SPACE's get_degault_configuration and Configurations's values argument.

## Related Issue

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
