### PR TITLE
build: bump stable-fast-pruna requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ dependencies = [
 [project.optional-dependencies]
 stable-fast = [
     "xformers>=0.0.30",
-    "stable-fast-pruna==1.0.7",
+    "stable-fast-pruna==1.0.8",
 ]
 # dependencies are added here because the wheels aren't bundling them
 gptq = [
@@ -156,7 +156,7 @@ gptq = [
 ]
 full = [
     "xformers>=0.0.30",
-    "stable-fast-pruna==1.0.7",
+    "stable-fast-pruna==1.0.8",
 ]
 dev = [
     "wget",


### PR DESCRIPTION
## Description
This PR bumps the requirement on stable-fast-pruna from 1.0.7 to 1.0.8 which is built on torch 2.9 and cuda 12.8.
This implicitely pins the stable-fast extra to torch==2.9, builds requiring other versions should use the extra-index-url.

## Related Issue

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
