### PR TITLE
fix: remove pruna-pro hook from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,24 +52,3 @@ repos:
         types: [python]
         pass_filenames: false
         files: \.py$
-
-  - repo: local
-    hooks:
-      - id: check-pruna-pro
-        name: Check for pruna_pro
-        entry: >
-          bash -c '
-          git diff --cached --name-status |
-          grep -v "^D" |
-          cut -f2- |
-          while IFS= read -r file; do
-            if [ -f "$file" ] && [ "$file" != ".pre-commit-config.yaml" ] && grep -q "pruna_pro" "$file"; then
-              echo "Error: pruna_pro found in staged file $file"
-              exit 1
-            fi
-          done
-          '
-        language: system
-        stages: [pre-commit]
-        types: [python]
-        files: \.py$


### PR DESCRIPTION
## Description
Since pruna-pro is being deprecated, I believe it makes sense to remove the pruna-pro hook to keep the CI checks efficient. Could you please review?

cc: @minettekaum 


## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
