### PR TITLE
fix: Installation tests by pinning lm-eval extras.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,8 @@ dependencies = [
 vllm = [
     "vllm>=0.16.0",
     "ray",
+    "nvidia-cudnn-frontend; sys_platform == 'linux'",
+    "nvidia-cutlass-dsl-libs-base; sys_platform == 'linux'",
 ]
 stable-fast = [
     "xformers>=0.0.30",


### PR DESCRIPTION
## Description
Installation tests have been failing on `main` due to missing wheels for [nvidia-cutlass-dsl-libs-base](https://pypi.org/project/nvidia-cutlass-dsl-libs-base/#files) and [nvidia-cudnn-frontend](https://pypi.org/project/nvidia-cudnn-frontend/#files) since both of these deps publish wheels only for linux, not for MacOS and Windows. Could you please review?

cc: @johannaSommer 

ref:
https://github.com/PrunaAI/pruna/actions/runs/23354770495/job/67942686570
https://github.com/PrunaAI/pruna/actions/runs/23354770495/job/67942686541

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
