### PR TITLE
feat: extend moe model check to multimodal ones and add block quantization parameters

### DIFF
--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -178,6 +178,11 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         model_config = getattr(model, "config", None)
         if model_config is None:
             raise ValueError(f"Model {model.__class__.__name__} has no config.")
+        # Multimodal MoE (e.g. Qwen3_5MoeForConditionalGeneration): MoE parameters live on text_config.
+        if getattr(model_config, "num_experts", None) is None:
+            text_cfg = getattr(model_config, "text_config", None)
+            if text_cfg is not None and getattr(text_cfg, "num_experts", None) is not None:
+                model_config = text_cfg
 
         tensor_parallel_size = int(smash_config["tensor_parallel_size"])
         if model.__class__.__name__ == "HunyuanImage3ForCausalMM":

--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -130,6 +130,18 @@ class MoeKernelTuner(PrunaAlgorithmBase):
                 default_value=8,
                 meta={"desc": "Maximum (log) block size for tiling through intermediate dimension."},
             ),
+            OrdinalHyperparameter(
+                "block_quant_shape_n",
+                sequence=[32, 64, 128, 256, 512, 1024, 2048, 4096, None],
+                default_value=None,
+                meta={"desc": "Block size for quantization through input dimension."},
+            ),
+            OrdinalHyperparameter(
+                "block_quant_shape_k",
+                sequence=[32, 64, 128, 256, 512, 1024, 2048, 4096, None],
+                default_value=None,
+                meta={"desc": "Block size for quantization through intermediate dimension."},
+            ),
         ]
 
     def model_check_fn(self, model: Any) -> bool:
@@ -199,13 +211,10 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         dtype = torch.bfloat16 if dtype == "bfloat16" else torch.float16
         use_fp8_w8a8 = smash_config["weight_dtype"] == "fp8_w8a8"
         use_int8_w8a16 = smash_config["weight_dtype"] == "int8_w8a16"
-
-        # (ii.b) Extract block quantization shape so the tuned config file
-        # name matches what vLLM looks for at serving time (e.g.
-        # ``E=256,N=512,...,block_shape=[128,128].json``).
-        block_quant_shape = _get_block_quant_shape(getattr(model, "config", None))
-        if block_quant_shape is None:
-            block_quant_shape = _get_block_quant_shape(model_config)
+        block_quant_shape = [
+            smash_config["block_quant_shape_n"],
+            smash_config["block_quant_shape_k"],
+        ]
 
         # (iii) Tune the kernel over a range of batch sizes (single GPU per Ray worker).
         batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
@@ -219,13 +228,19 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         ray.init(ignore_reinit_error=True)
         search_space = get_configs_compute_bound(smash_config)
 
-        # Remove configs incompatible with block quantisation constraints
-        # (BLOCK_SIZE_K must be divisible by block_k, BLOCK_SIZE_N by block_n).
-        if block_quant_shape is not None and use_fp8_w8a8:
-            bq_n, bq_k = block_quant_shape[0], block_quant_shape[1]
+        # Remove configs incompatible with block quantisation constraints:
+        # - BLOCK_SIZE_K must be divisible by block_quant_shape_k
+        # - BLOCK_SIZE_N must be divisible by block_quant_shape_n
+        if (
+            smash_config["block_quant_shape_n"] is not None
+            and smash_config["block_quant_shape_k"] is not None
+            and use_fp8_w8a8
+        ):
             search_space = [
-                cfg for cfg in search_space
-                if cfg["BLOCK_SIZE_K"] % bq_k == 0 and cfg["BLOCK_SIZE_N"] % bq_n == 0
+                cfg
+                for cfg in search_space
+                if cfg["BLOCK_SIZE_K"] % smash_config["block_quant_shape_k"] == 0
+                and cfg["BLOCK_SIZE_N"] % smash_config["block_quant_shape_n"] == 0
             ]
 
         pruna_logger.info(f"Start tuning over {len(search_space)} configurations...")
@@ -360,44 +375,6 @@ class MoeKernelTuner(PrunaAlgorithmBase):
             NoValidConfigError=NoValidConfigError,
             BenchmarkConfig=BenchmarkConfig,
         )
-
-
-def _get_block_quant_shape(config: Any) -> list[int] | None:
-    """
-    Extract block quantisation shape from a HuggingFace model config.
-
-    Mirrors vLLM's ``get_weight_block_size_safety`` in
-    ``benchmarks/kernels/benchmark_moe.py``.  Checks ``weight_block_size``
-    (AWQ / GPTQ / FP8 style) and ``config_groups.*.weights.block_structure``
-    (compressed-tensors style).
-
-    Parameters
-    ----------
-    config : Any
-        A HuggingFace ``PretrainedConfig`` (or its ``text_config``).
-
-    Returns
-    -------
-    list[int] | None
-        ``[block_n, block_k]`` if found, else ``None``.
-    """
-    if config is None:
-        return None
-    quantization_config = getattr(config, "quantization_config", None)
-    if quantization_config is None:
-        return None
-    if isinstance(quantization_config, dict):
-        wbs = quantization_config.get("weight_block_size")
-        if wbs is not None:
-            return list(wbs)
-        config_groups = quantization_config.get("config_groups", {})
-        for group_cfg in config_groups.values():
-            if isinstance(group_cfg, dict):
-                weights = group_cfg.get("weights", {})
-                bs = weights.get("block_structure")
-                if bs is not None:
-                    return list(bs)
-    return None
 
 
 def extract_hunyuan_dimensions(

--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -134,13 +134,27 @@ class MoeKernelTuner(PrunaAlgorithmBase):
                 "block_quant_shape_n",
                 sequence=[32, 64, 128, 256, 512, 1024, 2048, 4096, None],
                 default_value=None,
-                meta={"desc": "Block size for quantization through input dimension."},
+                meta={
+                    "desc": (
+                        "Block size for quantization along the N dimension when weight_dtype is "
+                        "fp8_w8a8. Must be set together with block_quant_shape_k: either both "
+                        "None or both an integer (mixing None with a value is invalid). "
+                        "Default None: no block-wise quant tiling."
+                    )
+                },
             ),
             OrdinalHyperparameter(
                 "block_quant_shape_k",
                 sequence=[32, 64, 128, 256, 512, 1024, 2048, 4096, None],
                 default_value=None,
-                meta={"desc": "Block size for quantization through intermediate dimension."},
+                meta={
+                    "desc": (
+                        "Block size for quantization along the K (intermediate) dimension when "
+                        "weight_dtype is fp8_w8a8. Must be set together with block_quant_shape_n: "
+                        "either both None or both an integer (mixing None with a value is invalid). "
+                        "Default None: no block-wise quant tiling."
+                    )
+                },
             ),
         ]
 
@@ -195,6 +209,14 @@ class MoeKernelTuner(PrunaAlgorithmBase):
             text_cfg = getattr(model_config, "text_config", None)
             if text_cfg is not None and getattr(text_cfg, "num_experts", None) is not None:
                 model_config = text_cfg
+            else:
+                raise ValueError(
+                    f"Cannot resolve MoE layout for {model.__class__.__name__}: "
+                    "`config.num_experts` is missing and no `config.text_config.num_experts` was "
+                    "found. This tuner expects a supported MoE model (e.g. Mixtral, Qwen-MoE, "
+                    "or multimodal MoE with experts in `text_config`). For custom or future "
+                    "architectures, extend config resolution in MoeKernelTuner._apply."
+                )
 
         tensor_parallel_size = int(smash_config["tensor_parallel_size"])
         if model.__class__.__name__ == "HunyuanImage3ForCausalMM":
@@ -211,15 +233,17 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         dtype = torch.bfloat16 if dtype == "bfloat16" else torch.float16
         use_fp8_w8a8 = smash_config["weight_dtype"] == "fp8_w8a8"
         use_int8_w8a16 = smash_config["weight_dtype"] == "int8_w8a16"
+        block_quant_shape_n = smash_config["block_quant_shape_n"]
+        block_quant_shape_k = smash_config["block_quant_shape_k"]
+        if (block_quant_shape_n is None) ^ (block_quant_shape_k is None):
+            raise ValueError(
+                "block_quant_shape_n and block_quant_shape_k must both be None (default, "
+                "per-expert FP8 scales and no quant-block filtering) or both set to an integer; "
+                "setting only one 'None' is not supported."
+            )
         block_quant_shape = None
-        if (
-            smash_config["block_quant_shape_n"] is not None
-            and smash_config["block_quant_shape_k"] is not None
-        ):
-            block_quant_shape = [
-                smash_config["block_quant_shape_n"],
-                smash_config["block_quant_shape_k"],
-            ]
+        if block_quant_shape_n is not None and block_quant_shape_k is not None:
+            block_quant_shape = [block_quant_shape_n, block_quant_shape_k]
 
         # (iii) Tune the kernel over a range of batch sizes (single GPU per Ray worker).
         batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
@@ -236,16 +260,12 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         # Remove configs incompatible with block quantisation constraints:
         # - BLOCK_SIZE_K must be divisible by block_quant_shape_k
         # - BLOCK_SIZE_N must be divisible by block_quant_shape_n
-        if (
-            smash_config["block_quant_shape_n"] is not None
-            and smash_config["block_quant_shape_k"] is not None
-            and use_fp8_w8a8
-        ):
+        if block_quant_shape is not None and use_fp8_w8a8:
             search_space = [
                 cfg
                 for cfg in search_space
-                if cfg["BLOCK_SIZE_K"] % smash_config["block_quant_shape_k"] == 0
-                and cfg["BLOCK_SIZE_N"] % smash_config["block_quant_shape_n"] == 0
+                if cfg["BLOCK_SIZE_K"] % block_quant_shape_k == 0
+                and cfg["BLOCK_SIZE_N"] % block_quant_shape_n == 0
             ]
 
         pruna_logger.info(f"Start tuning over {len(search_space)} configurations...")

--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -211,10 +211,15 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         dtype = torch.bfloat16 if dtype == "bfloat16" else torch.float16
         use_fp8_w8a8 = smash_config["weight_dtype"] == "fp8_w8a8"
         use_int8_w8a16 = smash_config["weight_dtype"] == "int8_w8a16"
-        block_quant_shape = [
-            smash_config["block_quant_shape_n"],
-            smash_config["block_quant_shape_k"],
-        ]
+        block_quant_shape = None
+        if (
+            smash_config["block_quant_shape_n"] is not None
+            and smash_config["block_quant_shape_k"] is not None
+        ):
+            block_quant_shape = [
+                smash_config["block_quant_shape_n"],
+                smash_config["block_quant_shape_k"],
+            ]
 
         # (iii) Tune the kernel over a range of batch sizes (single GPU per Ray worker).
         batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]

--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -136,10 +136,16 @@ class MoeKernelTuner(PrunaAlgorithmBase):
                 default_value=None,
                 meta={
                     "desc": (
-                        "Block size for quantization along the N dimension when weight_dtype is "
-                        "fp8_w8a8. Must be set together with block_quant_shape_k: either both "
-                        "None or both an integer (mixing None with a value is invalid). "
-                        "Default None: no block-wise quant tiling."
+                        "Side length (in elements) of one FP8 quantization block along the GEMM "
+                        "N axis in the fused MoE matmuls (same N as Triton BLOCK_SIZE_N: the "
+                        "output / intermediate-expert dimension). This sets the layout of "
+                        "block-wise FP8 scale tensors in the benchmark; it is not a Triton tile "
+                        "size that this algorithm searches over (see block_size_n_max for the "
+                        "searched tile cap). When set, the tuner still searches kernel configs "
+                        "but only keeps those whose BLOCK_SIZE_N is divisible by this value. "
+                        "Must be set together with block_quant_shape_k: either both None or both "
+                        "an integer. Default None: per-expert (non-block) FP8 scales and no extra "
+                        "divisibility filter on BLOCK_SIZE_N."
                     )
                 },
             ),
@@ -149,10 +155,15 @@ class MoeKernelTuner(PrunaAlgorithmBase):
                 default_value=None,
                 meta={
                     "desc": (
-                        "Block size for quantization along the K (intermediate) dimension when "
-                        "weight_dtype is fp8_w8a8. Must be set together with block_quant_shape_n: "
-                        "either both None or both an integer (mixing None with a value is invalid). "
-                        "Default None: no block-wise quant tiling."
+                        "Side length (in elements) of one FP8 quantization block along the GEMM "
+                        "K axis (same K as Triton BLOCK_SIZE_K: the inner / reduction dimension, "
+                        "e.g. hidden size in the expert up-projection). This is not automatically "
+                        "tuned: you choose it (or leave both quant block params None) to match the "
+                        "desired block-wise FP8 scale layout; the tuner only filters candidate "
+                        "kernels so BLOCK_SIZE_K divides evenly by this value when both are set. "
+                        "Must be set together with block_quant_shape_n: either both None or both "
+                        "an integer. Default None: per-expert FP8 scales and no extra "
+                        "divisibility filter on BLOCK_SIZE_K."
                     )
                 },
             ),

--- a/src/pruna/algorithms/moe_kernel_tuner.py
+++ b/src/pruna/algorithms/moe_kernel_tuner.py
@@ -200,6 +200,13 @@ class MoeKernelTuner(PrunaAlgorithmBase):
         use_fp8_w8a8 = smash_config["weight_dtype"] == "fp8_w8a8"
         use_int8_w8a16 = smash_config["weight_dtype"] == "int8_w8a16"
 
+        # (ii.b) Extract block quantization shape so the tuned config file
+        # name matches what vLLM looks for at serving time (e.g.
+        # ``E=256,N=512,...,block_shape=[128,128].json``).
+        block_quant_shape = _get_block_quant_shape(getattr(model, "config", None))
+        if block_quant_shape is None:
+            block_quant_shape = _get_block_quant_shape(model_config)
+
         # (iii) Tune the kernel over a range of batch sizes (single GPU per Ray worker).
         batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192]
         ray = imported_packages["ray"]
@@ -211,6 +218,16 @@ class MoeKernelTuner(PrunaAlgorithmBase):
 
         ray.init(ignore_reinit_error=True)
         search_space = get_configs_compute_bound(smash_config)
+
+        # Remove configs incompatible with block quantisation constraints
+        # (BLOCK_SIZE_K must be divisible by block_k, BLOCK_SIZE_N by block_n).
+        if block_quant_shape is not None and use_fp8_w8a8:
+            bq_n, bq_k = block_quant_shape[0], block_quant_shape[1]
+            search_space = [
+                cfg for cfg in search_space
+                if cfg["BLOCK_SIZE_K"] % bq_k == 0 and cfg["BLOCK_SIZE_N"] % bq_n == 0
+            ]
+
         pruna_logger.info(f"Start tuning over {len(search_space)} configurations...")
 
         start = time.time()
@@ -231,7 +248,7 @@ class MoeKernelTuner(PrunaAlgorithmBase):
                     use_fp8_w8a8,
                     use_int8_w8a16,
                     search_space,
-                    None,
+                    block_quant_shape,
                     False,
                     imported_packages,
                     0,  # fixed seed for reproducibility
@@ -271,7 +288,7 @@ class MoeKernelTuner(PrunaAlgorithmBase):
             dtype,
             use_fp8_w8a8,
             use_int8_w8a16,
-            None,
+            block_quant_shape,
             smash_config["path_to_huggingface_hub_cache"],
             smash_config["path_to_vllm_cache"],
             imported_packages,
@@ -343,6 +360,44 @@ class MoeKernelTuner(PrunaAlgorithmBase):
             NoValidConfigError=NoValidConfigError,
             BenchmarkConfig=BenchmarkConfig,
         )
+
+
+def _get_block_quant_shape(config: Any) -> list[int] | None:
+    """
+    Extract block quantisation shape from a HuggingFace model config.
+
+    Mirrors vLLM's ``get_weight_block_size_safety`` in
+    ``benchmarks/kernels/benchmark_moe.py``.  Checks ``weight_block_size``
+    (AWQ / GPTQ / FP8 style) and ``config_groups.*.weights.block_structure``
+    (compressed-tensors style).
+
+    Parameters
+    ----------
+    config : Any
+        A HuggingFace ``PretrainedConfig`` (or its ``text_config``).
+
+    Returns
+    -------
+    list[int] | None
+        ``[block_n, block_k]`` if found, else ``None``.
+    """
+    if config is None:
+        return None
+    quantization_config = getattr(config, "quantization_config", None)
+    if quantization_config is None:
+        return None
+    if isinstance(quantization_config, dict):
+        wbs = quantization_config.get("weight_block_size")
+        if wbs is not None:
+            return list(wbs)
+        config_groups = quantization_config.get("config_groups", {})
+        for group_cfg in config_groups.values():
+            if isinstance(group_cfg, dict):
+                weights = group_cfg.get("weights", {})
+                bs = weights.get("block_structure")
+                if bs is not None:
+                    return list(bs)
+    return None
 
 
 def extract_hunyuan_dimensions(

--- a/src/pruna/algorithms/reduce_noe.py
+++ b/src/pruna/algorithms/reduce_noe.py
@@ -127,10 +127,7 @@ class ReduceNOE(PrunaAlgorithmBase):
                     config_json = json.load(f)
                 target_name = smash_config["target_name"]
                 # if VLM MoE, the config that contains moe is the text_config one.
-                if "text_config" in config_json:
-                    text_config_json = config_json["text_config"]
-                else:
-                    text_config_json = config_json
+                text_config_json = config_json["text_config"] if "text_config" in config_json else config_json
                 if target_name not in text_config_json:
                     raise KeyError(f"Target name '{target_name}' not found in config file at {config_path}")
                 text_config_json[target_name] = smash_config["num_experts_per_token"]

--- a/src/pruna/algorithms/reduce_noe.py
+++ b/src/pruna/algorithms/reduce_noe.py
@@ -127,7 +127,7 @@ class ReduceNOE(PrunaAlgorithmBase):
                     config_json = json.load(f)
                 target_name = smash_config["target_name"]
                 # if VLM MoE, the config that contains moe is the text_config one.
-                text_config_json = config_json["text_config"] if "text_config" in config_json else config_json
+                text_config_json = config_json.get("text_config", config_json)
                 if target_name not in text_config_json:
                     raise KeyError(f"Target name '{target_name}' not found in config file at {config_path}")
                 text_config_json[target_name] = smash_config["num_experts_per_token"]

--- a/src/pruna/algorithms/reduce_noe.py
+++ b/src/pruna/algorithms/reduce_noe.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Any
 
 from ConfigSpace import UniformIntegerHyperparameter
+from pydantic import config
 from transformers import AutoModelForCausalLM
 
 from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
@@ -126,6 +127,9 @@ class ReduceNOE(PrunaAlgorithmBase):
                 with config_path.open("r", encoding="utf-8") as f:
                     config_json = json.load(f)
                 target_name = smash_config["target_name"]
+                # if VLM MoE, the config that contains moe is the text_config one.
+                if "text_config" in config_json:
+                    config_json = config_json["text_config"]
                 if target_name not in config_json:
                     raise KeyError(f"Target name '{target_name}' not found in config file at {config_path}")
                 config_json[target_name] = smash_config["num_experts_per_token"]

--- a/src/pruna/algorithms/reduce_noe.py
+++ b/src/pruna/algorithms/reduce_noe.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any
 
 from ConfigSpace import UniformIntegerHyperparameter
-from pydantic import config
 from transformers import AutoModelForCausalLM
 
 from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
@@ -129,10 +128,12 @@ class ReduceNOE(PrunaAlgorithmBase):
                 target_name = smash_config["target_name"]
                 # if VLM MoE, the config that contains moe is the text_config one.
                 if "text_config" in config_json:
-                    config_json = config_json["text_config"]
-                if target_name not in config_json:
+                    text_config_json = config_json["text_config"]
+                else:
+                    text_config_json = config_json
+                if target_name not in text_config_json:
                     raise KeyError(f"Target name '{target_name}' not found in config file at {config_path}")
-                config_json[target_name] = smash_config["num_experts_per_token"]
+                text_config_json[target_name] = smash_config["num_experts_per_token"]
                 with config_path.open("w", encoding="utf-8") as f:
                     json.dump(config_json, f, indent=2)
                 safe_memory_cleanup()

--- a/src/pruna/engine/model_checks.py
+++ b/src/pruna/engine/model_checks.py
@@ -25,7 +25,7 @@ from transformers.models.auto.modeling_auto import (
     MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
 )
 from transformers.pipelines.automatic_speech_recognition import AutomaticSpeechRecognitionPipeline
-from transformers.pipelines.text2text_generation import Text2TextGenerationPipeline
+#from transformers.pipelines.text2text_generation import Text2TextGenerationPipeline
 from transformers.pipelines.text_generation import TextGenerationPipeline
 
 from pruna.engine.utils import ModelContext
@@ -109,7 +109,9 @@ def is_moe_lm(model: Any) -> bool:
     """
     Check if the model is a MoE LM.
 
-    Currently all MoE LMs are based on Mixtral in transformers.
+    Detects MoE via ``config.num_experts`` (e.g. Mixtral, Qwen-MoE text-only)
+    or via nested ``config.text_config.num_experts`` (e.g. multimodal
+    ``*ForConditionalGeneration`` wrappers).
 
     Parameters
     ----------
@@ -121,7 +123,13 @@ def is_moe_lm(model: Any) -> bool:
     bool
         True if the model is a MoE LM, False otherwise.
     """
-    return hasattr(getattr(model, "config", None), "num_experts")
+    config = getattr(model, "config", None)
+    if config is None:
+        return False
+    if getattr(config, "num_experts", None) is not None:
+        return True
+    text_cfg = getattr(config, "text_config", None)
+    return text_cfg is not None and getattr(text_cfg, "num_experts", None) is not None
 
 
 def is_transformers_pipeline_with_causal_lm(model: Any) -> bool:

--- a/src/pruna/engine/model_checks.py
+++ b/src/pruna/engine/model_checks.py
@@ -25,7 +25,7 @@ from transformers.models.auto.modeling_auto import (
     MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING,
 )
 from transformers.pipelines.automatic_speech_recognition import AutomaticSpeechRecognitionPipeline
-#from transformers.pipelines.text2text_generation import Text2TextGenerationPipeline
+from transformers.pipelines.text2text_generation import Text2TextGenerationPipeline
 from transformers.pipelines.text_generation import TextGenerationPipeline
 
 from pruna.engine.utils import ModelContext


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
Just extend the model check, and the logic inside the `moe_kernel_tuner.py`, so that one can tune multimodel MoE (eg. model that contains a vision tower and a text model nested, as qwen3.5-32b).
And make the block quant shape (ie the size of the block on which the scales are computed for re-normalization before quantization) usable from the user.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---