### PR TITLE
feat: enable save/load after recovery without additional steps

### DIFF
--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Iterable
 
 from transformers import Pipeline
@@ -355,8 +356,8 @@ class PrunaAlgorithmBase(ABC):
         Any
             The model after the algorithm has been applied.
         """
-        if self.save_fn == SAVE_FUNCTIONS.save_before_apply and smash_config._prepare_saving:
-            save_dir = smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
+        if self.save_fn == SAVE_FUNCTIONS.save_before_apply and smash_config.prepare_saving:
+            save_dir = self.get_save_before_smash_dir(smash_config)
             save_pruna_model(model, save_dir, smash_config)
 
         # save algorithms to reapply after loading
@@ -446,6 +447,11 @@ class PrunaAlgorithmBase(ABC):
             The required algorithms.
         """
         return _expand_tags_into_algorithm_names(self.disjointly_compatible_after)
+
+    @staticmethod
+    def get_save_before_smash_dir(smash_config: SmashConfig) -> Path:
+        """Get the save directory for the algorithm caches."""
+        return smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
 
 
 def wrap_handle_imports(func):

--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -450,8 +450,20 @@ class PrunaAlgorithmBase(ABC):
 
     @staticmethod
     def get_save_before_smash_dir(smash_config: SmashConfig) -> Path:
-        """Get the save directory for the algorithm caches."""
-        return smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
+        """
+        Get the save directory for the algorithm caches.
+
+        Parameters
+        ----------
+        smash_config : SmashConfig
+            The SmashConfig to check the cache directory against.
+
+        Returns
+        -------
+        Path
+            The absolute path of "SAVE_BEFORE_SMASH_CACHE_DIR".
+        """
+        return (smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR).resolve()
 
 
 def wrap_handle_imports(func):

--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -374,7 +374,7 @@ class PrunaAlgorithmBase(ABC):
         wrapped_config = SmashConfigPrefixWrapper(smash_config, prefix)
         result = self._apply(model, wrapped_config)
 
-        self.post_apply_hook(model, smash_config)
+        self.post_apply_hook(result, smash_config)
         return result
 
     def post_apply_hook(self, model: Any, smash_config: SmashConfig) -> None:

--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -452,8 +452,20 @@ class PrunaAlgorithmBase(ABC):
 
     @staticmethod
     def get_save_before_smash_dir(smash_config: SmashConfig) -> Path:
-        """Get the save directory for the algorithm caches."""
-        return smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
+        """
+        Get the save directory for the algorithm caches.
+
+        Parameters
+        ----------
+        smash_config : SmashConfig
+            The SmashConfig to check the cache directory against.
+
+        Returns
+        -------
+        Path
+            The absolute path of "SAVE_BEFORE_SMASH_CACHE_DIR".
+        """
+        return (smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR).resolve()
 
 
 def wrap_handle_imports(func):

--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -372,7 +372,23 @@ class PrunaAlgorithmBase(ABC):
 
         prefix = self.algorithm_name + "_"
         wrapped_config = SmashConfigPrefixWrapper(smash_config, prefix)
-        return self._apply(model, wrapped_config)
+        result = self._apply(model, wrapped_config)
+
+        self.post_apply_hook(model, smash_config)
+        return result
+
+    def post_apply_hook(self, model: Any, smash_config: SmashConfig) -> None:
+        """
+        Post apply hook called after _apply returns to run side effects after the algorithm applies.
+
+        Parameters
+        ----------
+        model : Any
+            The model applied with the algorithm.
+        smash_config : SmashConfig
+            The SmashConfig object.
+        """
+        return
 
     def get_compatible_algorithms(self) -> list[str]:
         """

--- a/src/pruna/algorithms/base/pruna_base.py
+++ b/src/pruna/algorithms/base/pruna_base.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import functools
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Dict, Iterable
 
 from transformers import Pipeline
@@ -356,8 +357,8 @@ class PrunaAlgorithmBase(ABC):
         Any
             The model after the algorithm has been applied.
         """
-        if self.save_fn == SAVE_FUNCTIONS.save_before_apply and smash_config._prepare_saving:
-            save_dir = smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
+        if self.save_fn == SAVE_FUNCTIONS.save_before_apply and smash_config.prepare_saving:
+            save_dir = self.get_save_before_smash_dir(smash_config)
             save_pruna_model(model, save_dir, smash_config)
 
         # save algorithms to reapply after loading
@@ -448,6 +449,11 @@ class PrunaAlgorithmBase(ABC):
             The required algorithms.
         """
         return _expand_tags_into_algorithm_names(self.disjointly_compatible_after)
+
+    @staticmethod
+    def get_save_before_smash_dir(smash_config: SmashConfig) -> Path:
+        """Get the save directory for the algorithm caches."""
+        return smash_config.cache_dir / SAVE_BEFORE_SMASH_CACHE_DIR
 
 
 def wrap_handle_imports(func):

--- a/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
+++ b/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 from typing import Any, Dict
 
 import torch
@@ -23,7 +24,7 @@ from pruna.algorithms.global_utils.recovery.adapters.utils import freeze_paramet
 from pruna.algorithms.global_utils.recovery.finetuners import PrunaFinetuner
 from pruna.algorithms.global_utils.recovery.finetuners.diffusers.utils import get_denoiser_attr
 from pruna.algorithms.global_utils.recovery.utils import get_trainable_parameters
-from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.config.smash_config import SmashConfig, SmashConfigPrefixWrapper
 from pruna.engine.model_checks import (
     is_causal_lm,
     is_flux_pipeline,
@@ -31,7 +32,7 @@ from pruna.engine.model_checks import (
     is_sd_pipeline,
     is_sdxl_pipeline,
 )
-from pruna.engine.save import SAVE_FUNCTIONS
+from pruna.engine.save import SAVE_FUNCTIONS, save_pruna_model
 from pruna.logging.logger import pruna_logger
 
 
@@ -52,7 +53,7 @@ class PERPRecoverer(PrunaAlgorithmBase):
     """
 
     group_tags: list[AlgorithmTag] = [AlgorithmTag.RECOVERER]  # type: ignore[attr-defined]
-    save_fn = SAVE_FUNCTIONS.pickled
+    save_fn = None
     references: dict[str, str] = {
         "GitHub": "https://github.com/huggingface/peft",
         "Paper": "https://arxiv.org/pdf/2312.15230",
@@ -180,6 +181,45 @@ class PERPRecoverer(PrunaAlgorithmBase):
         for adapter, adapter_seed in zip(adapters, adapter_seeds):
             adapter_smash_config = SmashConfigPrefixWrapper(smash_config, adapter.adapter_prefix + "_")
             adapter.pre_smash_hook(model_recovery, adapter_smash_config, seed=adapter_seed)
+
+    def apply(self, model: Any, smash_config: SmashConfig) -> Any:
+        """
+        Apply the recovery algorithm and refresh the save cache if needed.
+
+        Recovery modifies weights in-place without changing the model's serialization
+        format. If a prior algorithm used ``save_before_apply`` (caching the model before
+        its transformation), the cached snapshot is now stale because recovery changed
+        the weights. This override refreshes that cache so the already saved model includes
+        the recovered weights.
+
+        Parameters
+        ----------
+        model : Any
+            The model to apply the algorithm to.
+        smash_config : SmashConfig
+            The SmashConfig object containing the save and load functions.
+
+        Returns
+        -------
+        Any
+            The model after recovery has been applied.
+        """
+        result = super().apply(model, smash_config)
+
+        if smash_config.prepare_saving:
+            save_dir = self.get_save_before_smash_dir(smash_config)
+            if not save_dir.exists():
+                return result
+
+            ori_save_fns = smash_config.save_fns[:]
+            smash_config.save_fns = [fn for fn in smash_config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
+            # Re-save with recovered weights
+            shutil.rmtree(save_dir, ignore_errors=True)
+            save_dir.mkdir(parents=True)
+            save_pruna_model(model, save_dir, smash_config)
+            # Restore save_fns
+            smash_config.save_fns = ori_save_fns
+        return result
 
     def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         """

--- a/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
+++ b/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 from typing import Any, Dict
 
 import torch
@@ -23,7 +24,7 @@ from pruna.algorithms.global_utils.recovery.adapters.utils import freeze_paramet
 from pruna.algorithms.global_utils.recovery.finetuners import PrunaFinetuner
 from pruna.algorithms.global_utils.recovery.finetuners.diffusers.utils import get_denoiser_attr
 from pruna.algorithms.global_utils.recovery.utils import get_trainable_parameters
-from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.config.smash_config import SmashConfig, SmashConfigPrefixWrapper
 from pruna.engine.model_checks import (
     is_causal_lm,
     is_flux_pipeline,
@@ -31,7 +32,7 @@ from pruna.engine.model_checks import (
     is_sd_pipeline,
     is_sdxl_pipeline,
 )
-from pruna.engine.save import SAVE_FUNCTIONS
+from pruna.engine.save import SAVE_FUNCTIONS, save_pruna_model
 from pruna.logging.logger import pruna_logger
 
 
@@ -52,7 +53,7 @@ class PERPRecoverer(PrunaAlgorithmBase):
     """
 
     group_tags: list[AlgorithmTag] = [AlgorithmTag.RECOVERER]  # type: ignore[attr-defined]
-    save_fn = SAVE_FUNCTIONS.pickled
+    save_fn = None
     required_install: str = "``pip install pruna[transformers-legacy]``"
     references: dict[str, str] = {
         "GitHub": "https://github.com/huggingface/peft",
@@ -181,6 +182,45 @@ class PERPRecoverer(PrunaAlgorithmBase):
         for adapter, adapter_seed in zip(adapters, adapter_seeds):
             adapter_smash_config = SmashConfigPrefixWrapper(smash_config, adapter.adapter_prefix + "_")
             adapter.pre_smash_hook(model_recovery, adapter_smash_config, seed=adapter_seed)
+
+    def apply(self, model: Any, smash_config: SmashConfig) -> Any:
+        """
+        Apply the recovery algorithm and refresh the save cache if needed.
+
+        Recovery modifies weights in-place without changing the model's serialization
+        format. If a prior algorithm used ``save_before_apply`` (caching the model before
+        its transformation), the cached snapshot is now stale because recovery changed
+        the weights. This override refreshes that cache so the already saved model includes
+        the recovered weights.
+
+        Parameters
+        ----------
+        model : Any
+            The model to apply the algorithm to.
+        smash_config : SmashConfig
+            The SmashConfig object containing the save and load functions.
+
+        Returns
+        -------
+        Any
+            The model after recovery has been applied.
+        """
+        result = super().apply(model, smash_config)
+
+        if smash_config.prepare_saving:
+            save_dir = self.get_save_before_smash_dir(smash_config)
+            if not save_dir.exists():
+                return result
+
+            ori_save_fns = smash_config.save_fns[:]
+            smash_config.save_fns = [fn for fn in smash_config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
+            # Re-save with recovered weights
+            shutil.rmtree(save_dir, ignore_errors=True)
+            save_dir.mkdir(parents=True)
+            save_pruna_model(model, save_dir, smash_config)
+            # Restore save_fns
+            smash_config.save_fns = ori_save_fns
+        return result
 
     def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         """

--- a/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
+++ b/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import shutil
+from abc import ABCMeta
 from typing import Any, Dict
 
 import torch
@@ -32,11 +32,11 @@ from pruna.engine.model_checks import (
     is_sd_pipeline,
     is_sdxl_pipeline,
 )
-from pruna.engine.save import SAVE_FUNCTIONS, save_pruna_model
+from pruna.engine.save import refresh_saved_model
 from pruna.logging.logger import pruna_logger
 
 
-class PERPRecoverer(PrunaAlgorithmBase):
+class PERPRecoverer(PrunaAlgorithmBase, metaclass=ABCMeta):
     """
     General purpose PERP recoverer using norm, head and bias finetuning and optionally HuggingFace's LoRA.
 
@@ -65,7 +65,6 @@ class PERPRecoverer(PrunaAlgorithmBase):
 
     def __init__(self, task_name: str, use_lora: bool, use_in_place: bool, is_distillation: bool) -> None:
         self.task_name = task_name
-        self.tokenizer_required = task_name == "text_to_text"  # type: ignore[misc]
 
         if not use_lora and not use_in_place:
             raise ValueError("Arguments use_lora and use_in_place cannot both be False, please use one of the two.")
@@ -90,6 +89,11 @@ class PERPRecoverer(PrunaAlgorithmBase):
         self.seed_generator: torch.Generator | None = None
 
         super().__init__()  # self.adapters need to be set before calling get_hyperparameters
+
+    @property
+    def tokenizer_required(self) -> bool:
+        """Overwritten ``tokenizer_required`` property."""
+        return self.task_name == "text_to_text"
 
     def get_hyperparameters(self) -> list:
         """
@@ -183,44 +187,10 @@ class PERPRecoverer(PrunaAlgorithmBase):
             adapter_smash_config = SmashConfigPrefixWrapper(smash_config, adapter.adapter_prefix + "_")
             adapter.pre_smash_hook(model_recovery, adapter_smash_config, seed=adapter_seed)
 
-    def apply(self, model: Any, smash_config: SmashConfig) -> Any:
-        """
-        Apply the recovery algorithm and refresh the save cache if needed.
-
-        Recovery modifies weights in-place without changing the model's serialization
-        format. If a prior algorithm used ``save_before_apply`` (caching the model before
-        its transformation), the cached snapshot is now stale because recovery changed
-        the weights. This override refreshes that cache so the already saved model includes
-        the recovered weights.
-
-        Parameters
-        ----------
-        model : Any
-            The model to apply the algorithm to.
-        smash_config : SmashConfig
-            The SmashConfig object containing the save and load functions.
-
-        Returns
-        -------
-        Any
-            The model after recovery has been applied.
-        """
-        result = super().apply(model, smash_config)
-
+    def post_apply_hook(self, model: Any, smash_config: SmashConfig):
+        """Override to run side effects after the algorithm has been applied."""
         if smash_config.prepare_saving:
-            save_dir = self.get_save_before_smash_dir(smash_config)
-            if not save_dir.exists():
-                return result
-
-            ori_save_fns = smash_config.save_fns[:]
-            smash_config.save_fns = [fn for fn in smash_config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
-            # Re-save with recovered weights
-            shutil.rmtree(save_dir, ignore_errors=True)
-            save_dir.mkdir(parents=True)
-            save_pruna_model(model, save_dir, smash_config)
-            # Restore save_fns
-            smash_config.save_fns = ori_save_fns
-        return result
+            refresh_saved_model(model, self.get_save_before_smash_dir(smash_config), smash_config)
 
     def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         """

--- a/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
+++ b/src/pruna/algorithms/global_utils/recovery/perp_recoverer.py
@@ -188,7 +188,16 @@ class PERPRecoverer(PrunaAlgorithmBase, metaclass=ABCMeta):
             adapter.pre_smash_hook(model_recovery, adapter_smash_config, seed=adapter_seed)
 
     def post_apply_hook(self, model: Any, smash_config: SmashConfig):
-        """Override to run side effects after the algorithm has been applied."""
+        """
+        Override to run side effects after the algorithm has been applied.
+
+        Parameters
+        ----------
+        model : Any
+            The model.
+        smash_config : SmashConfig
+            The SmashConfig configuration to apply.
+        """
         if smash_config.prepare_saving:
             refresh_saved_model(model, self.get_save_before_smash_dir(smash_config), smash_config)
 

--- a/src/pruna/config/smash_config.py
+++ b/src/pruna/config/smash_config.py
@@ -119,6 +119,11 @@ class SmashConfig:
             raise ValueError(f"Unsupported configuration type: {type(configuration)}")
         self.config_space: ConfigurationSpace = self._configuration.config_space
 
+    @property
+    def prepare_saving(self):
+        """Getter of _prepare_saving as an object's internal data."""
+        return self._prepare_saving
+
     @classmethod
     def from_list(
         cls,

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -355,9 +355,7 @@ def save_model_hqq(model: Any, model_path: str | Path, smash_config: SmashConfig
         # save pipeline info so we can call transformers.pipeline at load time
         save_pipeline_info(model, str(model_path))
         # pipeline loading requires a safetensor file so we save a fake, lightweight one
-        save_model(
-            torch.nn.Linear(1, 1), str(model_path / "model.safetensors"), metadata={"format": "pt"}
-        )
+        save_model(torch.nn.Linear(1, 1), str(model_path / "model.safetensors"), metadata={"format": "pt"})
 
         save_model_hqq(model.model, model_path, smash_config)
     elif is_janus_llamagen_ar(model):
@@ -468,6 +466,37 @@ def save_model_hqq_diffusers(model: Any, model_path: str | Path, smash_config: S
                 setattr(model, attr_name, module_backup)
 
     smash_config.load_fns.append(LOAD_FUNCTIONS.hqq_diffusers.name)
+
+
+def refresh_saved_model(model: Any, model_path: Path, smash_config: SmashConfig) -> None:
+    """
+    Refresh the saved save-before-apply model, and the cache will reflect the current model state.
+
+    Recovery modifies weights in-place without changing the model's serialization
+    format. If a prior algorithm used ``save_before_apply`` (caching the model before
+    its transformation), the cached snapshot is now stale because recovery changed
+    the weights. This override refreshes that cache so the already saved model includes
+    the recovered weights.
+
+    Parameters
+    ----------
+    model : Any
+        The model to apply the algorithm to.
+    model_path: Path
+        The model path to be saved.
+    smash_config : SmashConfig
+        The SmashConfig object containing the save and load functions.
+    """
+    if not model_path.exists():
+        return None
+
+    ori_save_fns = smash_config.save_fns[:]
+    smash_config.save_fns = [fn for fn in smash_config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
+    # Re-save with recovered weights
+    shutil.rmtree(model_path, ignore_errors=True)
+    save_pruna_model(model, model_path, smash_config)
+    # Restore save_fns
+    smash_config.save_fns = ori_save_fns
 
 
 def save_model_llama_cpp(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:

--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -482,7 +482,7 @@ def refresh_saved_model(model: Any, model_path: Path, smash_config: SmashConfig)
     ----------
     model : Any
         The model to apply the algorithm to.
-    model_path: Path
+    model_path : Path
         The model path to be saved.
     smash_config : SmashConfig
         The SmashConfig object containing the save and load functions.

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -1,18 +1,18 @@
 import os
-import pytest
-import torch
+import shutil
 from pathlib import Path
 from unittest.mock import patch
-from transformers import AutoModelForCausalLM
-from pruna.config.smash_config import SmashConfig
-from pruna import smash
-from pruna.engine.save import save_pruna_model
-from pruna.engine.save import save_pruna_model_to_hub
-from pruna.engine.save import SAVE_FUNCTIONS
-from pruna.engine.load import load_pruna_model
-from pruna.config.smash_config import SmashConfig
+
+import pytest
+import torch
 from diffusers import DiffusionPipeline
+from transformers import AutoModelForCausalLM
+
+from pruna import smash
+from pruna.config.smash_config import SmashConfig
+from pruna.engine.load import PICKLED_FILE_NAME, load_pruna_model
 from pruna.engine.pruna_model import PrunaModel
+from pruna.engine.save import SAVE_FUNCTIONS, save_pruna_model, save_pruna_model_to_hub
 
 
 @pytest.mark.slow
@@ -160,3 +160,68 @@ def test_push_to_hub_path_types(tmp_path) -> None:
             private=True
         )
         assert mock_upload.called
+
+
+@pytest.mark.cpu
+def test_recovery_save_fn_is_none() -> None:
+    """Test that recovery algorithms use save_fn=None, preserving the prior algorithm's save format."""
+    from pruna.algorithms.global_utils.recovery.perp_recoverer import PERPRecoverer
+
+    assert PERPRecoverer.save_fn is None
+
+
+@pytest.mark.cpu
+def test_recovery_does_not_add_to_save_fns(tmp_path) -> None:
+    """Test that recovery's apply() does not append to save_fns when save_fn is None."""
+
+    config = SmashConfig()
+    config.save_fns = ["hqq"]  # simulate a prior algorithm's save_fn
+
+    save_fn = None
+
+    # PrunaAlgorithmBase apply logic
+    if save_fn is not None and save_fn != SAVE_FUNCTIONS.reapply:
+        config.save_fns.append(save_fn.name)
+
+    assert config.save_fns == ["hqq"], "Recovery should not add to save_fns"
+
+
+@pytest.mark.cpu
+def test_recovery_refresh_save_cache(tmp_path) -> None:
+    """Test that recovery refreshes a stale save_before_apply cache with recovered weights."""
+    from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
+
+    model = AutoModelForCausalLM.from_pretrained("yujiepan/opt-tiny-random")
+
+    config = SmashConfig(device="cpu")
+
+    # Simulate a save_before_apply algorithm having run before recovery:
+    # 1. Save original (pre-transformation) model to cache
+    save_dir = PrunaAlgorithmBase.get_save_before_smash_dir(config)
+    save_dir.mkdir(parents=True)
+    save_pruna_model(model, save_dir, config)
+
+    # 2. Mark save_before_apply in save_fns (as the algorithm would)
+    config.save_fns.append(SAVE_FUNCTIONS.save_before_apply.name)
+
+    # 3. Simulate the transformation (e.g., half) + recovery modifying weights
+    model.lm_head.weight.data.fill_(0.99)  # "recovered" weights
+
+    # 4. Simulate what recovery's apply() does: refresh the stale cache
+    ori_save_fns = config.save_fns[:]
+    config.save_fns = [fn for fn in config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
+    shutil.rmtree(save_dir, ignore_errors=True)
+    save_dir.mkdir(parents=True)
+    save_pruna_model(model, save_dir, config)
+    config.save_fns = ori_save_fns
+
+    # 5. Verify the cache was refreshed: save_before_apply should copy updated files
+    save_path = tmp_path / "final_model"
+    save_pruna_model(model, save_path, config)
+
+    # Load and verify the recovered weights survived the round-trip
+    loaded_model, _ = load_pruna_model(save_path)
+    loaded_model = loaded_model.cpu()
+    assert torch.allclose(
+        loaded_model.lm_head.weight, torch.full_like(loaded_model.lm_head.weight, 0.99)
+    ), "Recovered weights should survive save/load through save_before_apply"

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -10,7 +10,7 @@ from transformers import AutoModelForCausalLM
 
 from pruna import smash
 from pruna.config.smash_config import SmashConfig
-from pruna.engine.load import PICKLED_FILE_NAME, load_pruna_model
+from pruna.engine.load import load_pruna_model
 from pruna.engine.pruna_model import PrunaModel
 from pruna.engine.save import SAVE_FUNCTIONS, save_pruna_model, save_pruna_model_to_hub
 

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
-import shutil
 import torch
 from diffusers import DiffusionPipeline
 from transformers import AutoModelForCausalLM
@@ -161,39 +163,36 @@ def test_push_to_hub_path_types(tmp_path) -> None:
 
 
 @pytest.mark.cpu
-def test_recovery_refresh_save_cache(tmp_path) -> None:
-    """Test that recovery refreshes a stale save_before_apply cache with recovered weights."""
+def test_perp_post_apply_hook_round_trip(tmp_path) -> None:
+    """Test whether PERPRecoverer saves the correct model and load from it."""
     from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
+    from pruna.algorithms.global_utils.recovery.perp_recoverer import PERPRecoverer
 
-    model = AutoModelForCausalLM.from_pretrained("yujiepan/opt-tiny-random")
+    class FakeRecoverer(PERPRecoverer):
+        algorithm_name = "test_fake_recoverer"
 
+        def __init__(self):  # noqa: D107
+            pass
+
+        def _apply(self, model, smash_config):  # noqa: D401
+            model.weight.data.fill_(0.99)
+            return model
+
+    model = torch.nn.Linear(3, 2)
+    model.weight.data.fill_(0.1)
     config = SmashConfig(device="cpu")
 
-    # Simulate a save_before_apply algorithm having run before recovery:
-    # 1. Save original (pre-transformation) model to cache
     save_dir = PrunaAlgorithmBase.get_save_before_smash_dir(config)
     save_pruna_model(model, save_dir, config)
-
-    # 2. Mark save_before_apply in save_fns (as the algorithm would)
     config.save_fns.append(SAVE_FUNCTIONS.save_before_apply.name)
 
-    # 3. Simulate the transformation (e.g., half) + recovery modifying weights
-    model.lm_head.weight.data.fill_(0.99)  # "recovered" weights
+    model = FakeRecoverer().apply(model, config)
 
-    # 4. Simulate what recovery's apply() does: refresh the stale cache
-    ori_save_fns = config.save_fns[:]
-    config.save_fns = [fn for fn in config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
-    shutil.rmtree(save_dir, ignore_errors=True)
-    save_pruna_model(model, save_dir, config)
-    config.save_fns = ori_save_fns
-
-    # 5. Verify the cache was refreshed: save_before_apply should copy updated files
     save_path = tmp_path / "final_model"
     save_pruna_model(model, save_path, config)
 
-    # Load and verify the recovered weights survived the round-trip
     loaded_model, _ = load_pruna_model(save_path)
     loaded_model = loaded_model.cpu()
     assert torch.allclose(
-        loaded_model.lm_head.weight, torch.full_like(loaded_model.lm_head.weight, 0.99)
+        loaded_model.weight, torch.full_like(loaded_model.weight, 0.99)
     ), "Recovered weights should survive save/load through save_before_apply"

--- a/tests/engine/test_save.py
+++ b/tests/engine/test_save.py
@@ -1,9 +1,6 @@
 import os
-import shutil
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
+import shutil
 import torch
 from diffusers import DiffusionPipeline
 from transformers import AutoModelForCausalLM
@@ -28,6 +25,7 @@ def test_save_llm_to_hub() -> None:
         smash_config=smash_config,
     )
     pruna_model.push_to_hub(upload_repo_id, private=False)
+
 
 @pytest.mark.slow
 @pytest.mark.cpu
@@ -163,30 +161,6 @@ def test_push_to_hub_path_types(tmp_path) -> None:
 
 
 @pytest.mark.cpu
-def test_recovery_save_fn_is_none() -> None:
-    """Test that recovery algorithms use save_fn=None, preserving the prior algorithm's save format."""
-    from pruna.algorithms.global_utils.recovery.perp_recoverer import PERPRecoverer
-
-    assert PERPRecoverer.save_fn is None
-
-
-@pytest.mark.cpu
-def test_recovery_does_not_add_to_save_fns(tmp_path) -> None:
-    """Test that recovery's apply() does not append to save_fns when save_fn is None."""
-
-    config = SmashConfig()
-    config.save_fns = ["hqq"]  # simulate a prior algorithm's save_fn
-
-    save_fn = None
-
-    # PrunaAlgorithmBase apply logic
-    if save_fn is not None and save_fn != SAVE_FUNCTIONS.reapply:
-        config.save_fns.append(save_fn.name)
-
-    assert config.save_fns == ["hqq"], "Recovery should not add to save_fns"
-
-
-@pytest.mark.cpu
 def test_recovery_refresh_save_cache(tmp_path) -> None:
     """Test that recovery refreshes a stale save_before_apply cache with recovered weights."""
     from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
@@ -198,7 +172,6 @@ def test_recovery_refresh_save_cache(tmp_path) -> None:
     # Simulate a save_before_apply algorithm having run before recovery:
     # 1. Save original (pre-transformation) model to cache
     save_dir = PrunaAlgorithmBase.get_save_before_smash_dir(config)
-    save_dir.mkdir(parents=True)
     save_pruna_model(model, save_dir, config)
 
     # 2. Mark save_before_apply in save_fns (as the algorithm would)
@@ -211,7 +184,6 @@ def test_recovery_refresh_save_cache(tmp_path) -> None:
     ori_save_fns = config.save_fns[:]
     config.save_fns = [fn for fn in config.save_fns if fn != SAVE_FUNCTIONS.save_before_apply.name]
     shutil.rmtree(save_dir, ignore_errors=True)
-    save_dir.mkdir(parents=True)
     save_pruna_model(model, save_dir, config)
     config.save_fns = ori_save_fns
 


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
Extend save and load to also allow saving and loading after recovery without additional steps.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #603

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [x] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.

---

## First Prune (1-year OSS anniversary)

**First Prune** marks one year of Pruna’s open-source work. During the initiative window, qualifying merged contributions count toward **First Prune**. You can earn credits for our **performance models** via our **API**.

If you’d like your contribution to count toward **First Prune**, here’s how it works:

- **Initiative window:** First Prune starts on **March 31**.
- **Issue assignment:** For your PR to count toward First Prune, the related issue must be assigned to the contributor opening the PR. Issues are labeled with **first-prune**.
- **Open for review:** Please **open your PR and mark it ready for review by April 30** (end of April).
- **Review priority:** We’ll make our best effort to review quickly any PR that is open and has a review request before April 30.
- **Credits:** Each qualifying merged PR earns **30 credits**. We’ll be in touch after all qualifying PRs for **First Prune** have been merged.
- **To get started:** Have a look at [all models](https://www.pruna.ai/all-models). You’ll need to **sign up** on the [dashboard](https://dashboard.pruna.ai/login) before you can redeem your credits.
