### PR TITLE
ci: separate extra installs

### DIFF
--- a/.github/actions/setup-uv-project/action.yml
+++ b/.github/actions/setup-uv-project/action.yml
@@ -19,4 +19,4 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - shell: bash
-      run: uv sync --extra dev --extra lmharness
+      run: uv sync --extra dev --extra lmharness --extra intel

--- a/.github/actions/setup-uv-project/action.yml
+++ b/.github/actions/setup-uv-project/action.yml
@@ -19,4 +19,4 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - shell: bash
-      run: uv sync --extra dev --extra lmharness
+      run: uv sync --extra dev

--- a/.github/actions/setup-uv-project/action.yml
+++ b/.github/actions/setup-uv-project/action.yml
@@ -19,4 +19,4 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - shell: bash
-      run: uv sync --extra dev --extra lmharness --extra intel
+      run: uv sync --extra dev --extra lmharness

--- a/.github/actions/setup-uv-project/action.yml
+++ b/.github/actions/setup-uv-project/action.yml
@@ -19,4 +19,4 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - shell: bash
-      run: uv sync --extra dev --extra lmharness --extra vllm
+      run: uv sync --extra dev --extra lmharness

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,6 +66,14 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
+        name: ["base", 'lmharness']
+        include:
+        - name: base
+          extras: ""
+          mark_filter: "cpu and not slow and not style and not requires_intel and not requires_lmharness"
+        - name: lmharness
+          extras: "--extra lmharness"
+          mark_filter: "requires_lmharness"
 
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -80,6 +88,10 @@ jobs:
       - uses: ./.github/actions/setup-uv-project
         with:
           python-version: ${{ matrix.python-version }}
+      
+      - name: Install additional extras
+        if: matrix.extras != ''
+        run: uv sync --extra dev ${{ matrix.extras }}
 
       - name: Cache Hugging Face datasets and models
         uses: actions/cache@v5
@@ -123,4 +135,4 @@ jobs:
       - name: Run tests with pytest-rerunfailures
         run: |
           echo "Running tests with up to 3 reruns on failure using $PYTEST_WORKERS workers..."
-          uv run pytest -n $PYTEST_WORKERS -m "cpu and not slow and not requires_intel" --reruns 3 --reruns-delay 10 --maxfail=1
+          uv run pytest -n $PYTEST_WORKERS -m "${{ matrix.mark_filter }}" --reruns 3 --reruns-delay 10 --maxfail=1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,4 +123,4 @@ jobs:
       - name: Run tests with pytest-rerunfailures
         run: |
           echo "Running tests with up to 3 reruns on failure using $PYTEST_WORKERS workers..."
-          uv run pytest -n $PYTEST_WORKERS -m "not (slow or style or high_cpu or cuda or distributed)" --reruns 3 --reruns-delay 10 --maxfail=1
+          uv run pytest -n $PYTEST_WORKERS -m "cpu and not slow" --reruns 3 --reruns-delay 10 --maxfail=1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -123,4 +123,4 @@ jobs:
       - name: Run tests with pytest-rerunfailures
         run: |
           echo "Running tests with up to 3 reruns on failure using $PYTEST_WORKERS workers..."
-          uv run pytest -n $PYTEST_WORKERS -m "cpu and not slow" --reruns 3 --reruns-delay 10 --maxfail=1
+          uv run pytest -n $PYTEST_WORKERS -m "cpu and not slow and not requires_intel" --reruns 3 --reruns-delay 10 --maxfail=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,8 +147,6 @@ dependencies = [
     "timm",
     "bitsandbytes; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "optimum-quanto>=0.2.5",
-    "ctranslate2==4.6.0",
-    "whisper-s2t==1.3.1",
     "hqq==0.2.7.post1",
     "torchao>=0.12.0,<0.16.0", # 0.16.0 breaks diffusers 0.36.0, torch+torch: https://github.com/pytorch/ao/issues/2919#issue-3375688762
     "gliner; python_version >= '3.11'",
@@ -165,6 +163,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# whisper-s2t and ctranslate2 are isolated because importing whisper_s2t
+# at test time causes side-effects that break unrelated tests.
+
+whisper = [
+    "ctranslate2==4.6.0",
+    "whisper-s2t==1.3.1",
+]
 vllm = [
     "vllm>=0.16.0",
     "ray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,22 +76,14 @@ explicit = true
 index-strategy = "first-index"
 
 conflicts = [
-    [
-        { extra = "awq" },
-        { extra = "vbench" },
-    ],
-    [
-        { extra = "vllm" },
-        { extra = "vbench" },
-    ],
-    [
-        { extra = "stable-fast-extraindex" },
-        { extra = "stable-fast" },
-    ],
-    [
-        { extra = "stable-fast-extraindex" },
-        { extra = "full" },
-    ],
+    [{ extra = "awq" }, { extra = "vbench" }],
+    [{ extra = "vllm" }, { extra = "vbench" }],
+    [{ extra = "intel" }, { extra = "awq" }],
+    [{ extra = "gptq" }, { extra = "awq" }],
+    # intel is incompatible with all stable-fast variants and vllm
+    [{ extra = "intel" }, { extra = "stable-fast" }, { extra = "stable-fast-extraindex" }],
+    [{ extra = "intel" }, { extra = "full" }, { extra = "stable-fast-extraindex" }],
+    [{ extra = "intel" }, { extra = "vllm" }],
 ]
 
 [tool.uv.sources]
@@ -235,8 +227,12 @@ cpu = []
 lmharness = [
     "lm-eval>=0.4.0"
 ]
+
+# Intel extension is tightly coupled with the torch version
 intel = [
     "intel-extension-for-pytorch>=2.7.0",
+    "torch>=2.7.0,<2.9.0",
+    "torchvision>=0.22.0,<0.24.0",
 ]
 
 [build-system]

--- a/src/pruna/algorithms/llm_compressor.py
+++ b/src/pruna/algorithms/llm_compressor.py
@@ -53,6 +53,7 @@ class LLMCompressor(PrunaAlgorithmBase):
     runs_on: list[str] = ["cuda"]
     compatible_before: Iterable[str] = ["moe_kernel_tuner"]
     compatible_after: Iterable[str] = ["sage_attn", "moe_kernel_tuner"]
+    required_install = "``uv pip install 'pruna[awq]'``"
 
     def get_hyperparameters(self) -> list:
         """

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -60,7 +60,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("flux_tiny_random", ["fora", "torch_compile"], False, 'cmmd'),
         ("flux_tiny_random", ["fora", "stable_fast"], False, 'cmmd'),
         ("tiny_janus", ["hqq", "torch_compile"], False, 'cmmd'),
-        pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high_vram),
+        pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high_gpu),
     ],
     indirect=["model_fixture"],
     ids=lambda val: "+".join(val) if isinstance(val, list) else None,

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -44,12 +44,12 @@ class CombinationsTester(AlgorithmTesterBase):
 @pytest.mark.parametrize(
     "model_fixture, algorithms, allow_pickle_files, metric",
     [
-        ("sd_tiny_random", ["deepcache", "stable_fast"], False, 'cmmd'),
+        pytest.param("sd_tiny_random", ["deepcache", "stable_fast"], False, 'cmmd', marks=pytest.mark.requires_stable_fast),
         ("mobilenet_v2", ["torch_unstructured", "half"], True, 'latency'),
         ("sd_tiny_random", ["hqq_diffusers", "torch_compile"], False, 'cmmd'),
         ("flux_tiny_random", ["hqq_diffusers", "torch_compile"], False, 'cmmd'),
         ("sd_tiny_random", ["diffusers_int8", "torch_compile"], False, 'cmmd'),
-        ("tiny_llama", ["gptq", "torch_compile"], True, 'perplexity'),
+        pytest.param("tiny_llama", ["gptq", "torch_compile"], True, 'perplexity', marks=pytest.mark.requires_gptq),
         ("llama_3_tiny_random_as_pipeline", ["llm_int8", "torch_compile"], True, 'perplexity'),
         ("flux_tiny_random", ["pab", "hqq_diffusers"], False, 'cmmd'),
         ("flux_tiny_random", ["pab", "diffusers_int8"], False, 'cmmd'),
@@ -58,7 +58,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("flux_tiny_random", ["fora", "hqq_diffusers"], False, 'cmmd'),
         ("flux_tiny_random", ["fora", "diffusers_int8"], False, 'cmmd'),
         ("flux_tiny_random", ["fora", "torch_compile"], False, 'cmmd'),
-        ("flux_tiny_random", ["fora", "stable_fast"], False, 'cmmd'),
+        pytest.param("flux_tiny_random", ["fora", "stable_fast"], False, 'cmmd', marks=pytest.mark.requires_stable_fast),
         ("tiny_janus", ["hqq", "torch_compile"], False, 'cmmd'),
         pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high_gpu),
     ],

--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -60,7 +60,7 @@ class CombinationsTester(AlgorithmTesterBase):
         ("flux_tiny_random", ["fora", "torch_compile"], False, 'cmmd'),
         ("flux_tiny_random", ["fora", "stable_fast"], False, 'cmmd'),
         ("tiny_janus", ["hqq", "torch_compile"], False, 'cmmd'),
-        pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high),
+        pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high_vram),
     ],
     indirect=["model_fixture"],
     ids=lambda val: "+".join(val) if isinstance(val, list) else None,

--- a/tests/algorithms/test_compatibility_symmetry.py
+++ b/tests/algorithms/test_compatibility_symmetry.py
@@ -2,6 +2,8 @@ import pytest
 
 from pruna.algorithms import AlgorithmRegistry
 
+pytestmark = pytest.mark.cpu
+
 
 def test_compatibility_symmetry():
     pruna_algorithms = AlgorithmRegistry._registry

--- a/tests/algorithms/testers/awq.py
+++ b/tests/algorithms/testers/awq.py
@@ -5,7 +5,7 @@ from pruna.algorithms.llm_compressor import LLMCompressor
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.slow
+@pytest.mark.requires_awq
 class TestLLMCompressor(AlgorithmTesterBase):
     """Test the LLM Compressor quantizer."""
 

--- a/tests/algorithms/testers/cgenerate.py
+++ b/tests/algorithms/testers/cgenerate.py
@@ -1,9 +1,12 @@
+import pytest
+
 from pruna import PrunaModel
 from pruna.algorithms.c_translate import CGenerate
 
 from .base_tester import AlgorithmTesterBase
 
 
+@pytest.mark.requires_whisper
 class TestCGenerate(AlgorithmTesterBase):
     """Test the c_generate algorithm."""
 

--- a/tests/algorithms/testers/flash_attn3.py
+++ b/tests/algorithms/testers/flash_attn3.py
@@ -5,7 +5,7 @@ from pruna.algorithms.flash_attn3 import FlashAttn3
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.high
+@pytest.mark.high_vram
 class TestFlashAttn3(AlgorithmTesterBase):
     """Test the flash attention 3 kernel."""
 

--- a/tests/algorithms/testers/flash_attn3.py
+++ b/tests/algorithms/testers/flash_attn3.py
@@ -5,7 +5,7 @@ from pruna.algorithms.flash_attn3 import FlashAttn3
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 class TestFlashAttn3(AlgorithmTesterBase):
     """Test the flash attention 3 kernel."""
 

--- a/tests/algorithms/testers/gptq.py
+++ b/tests/algorithms/testers/gptq.py
@@ -7,7 +7,8 @@ from .base_tester import AlgorithmTesterBase
 
 
 @pytest.mark.slow
-@pytest.mark.high
+@pytest.mark.high_vram
+@pytest.mark.requires_gptq
 class TestGPTQ(AlgorithmTesterBase):
     """Test the GPTQ quantizer."""
 

--- a/tests/algorithms/testers/gptq.py
+++ b/tests/algorithms/testers/gptq.py
@@ -7,7 +7,7 @@ from .base_tester import AlgorithmTesterBase
 
 
 @pytest.mark.slow
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.requires_gptq
 class TestGPTQ(AlgorithmTesterBase):
     """Test the GPTQ quantizer."""

--- a/tests/algorithms/testers/ipex_llm.py
+++ b/tests/algorithms/testers/ipex_llm.py
@@ -9,8 +9,8 @@ from .base_tester import AlgorithmTesterBase
 class TestIPEXLLM(AlgorithmTesterBase):
     """Test the IPEX LLM algorithm."""
 
-    models = ["opt_tiny_random"]
+    models = ["opt_125m"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = IPEXLLM
-    metrics = ["latency"]
+    metrics = []

--- a/tests/algorithms/testers/ipex_llm.py
+++ b/tests/algorithms/testers/ipex_llm.py
@@ -5,7 +5,6 @@ from pruna.algorithms.ipex_llm import IPEXLLM
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.high_cpu
 @pytest.mark.requires_intel
 class TestIPEXLLM(AlgorithmTesterBase):
     """Test the IPEX LLM algorithm."""

--- a/tests/algorithms/testers/ipex_llm.py
+++ b/tests/algorithms/testers/ipex_llm.py
@@ -5,8 +5,8 @@ from pruna.algorithms.ipex_llm import IPEXLLM
 from .base_tester import AlgorithmTesterBase
 
 
-# this prevents the test from running on GitHub Actions, which does not reliably provide Intel CPUs
 @pytest.mark.high_cpu
+@pytest.mark.requires_intel
 class TestIPEXLLM(AlgorithmTesterBase):
     """Test the IPEX LLM algorithm."""
 

--- a/tests/algorithms/testers/moe_kernel_tuner.py
+++ b/tests/algorithms/testers/moe_kernel_tuner.py
@@ -36,7 +36,6 @@ class TestMoeKernelTuner(AlgorithmTesterBase):
 
     def _resolve_hf_cache_config_path(self) -> Path:
         """Read the saved artifact and compute the expected HF cache config path."""
-
         imported_packages = MoeKernelTuner().import_algorithm_packages()
 
         smash_cfg = SmashConfig()

--- a/tests/algorithms/testers/moe_kernel_tuner.py
+++ b/tests/algorithms/testers/moe_kernel_tuner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 import torch
 
 from pruna import PrunaModel, SmashConfig
@@ -11,6 +12,7 @@ from pruna.algorithms.moe_kernel_tuner import MoeKernelTuner
 from .base_tester import AlgorithmTesterBase
 
 
+@pytest.mark.requires_vllm
 class TestMoeKernelTuner(AlgorithmTesterBase):
     """Test the MoeKernelTuner."""
 

--- a/tests/algorithms/testers/ring_distributer.py
+++ b/tests/algorithms/testers/ring_distributer.py
@@ -21,7 +21,7 @@ from pruna.engine.pruna_model import PrunaModel
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 class TestRingAttn(AlgorithmTesterBase):
     """Test the RingAttn algorithm."""
 

--- a/tests/algorithms/testers/sage_attn.py
+++ b/tests/algorithms/testers/sage_attn.py
@@ -5,7 +5,7 @@ from pruna.algorithms.sage_attn import SageAttn
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.high
+@pytest.mark.high_vram
 class TestSageAttn(AlgorithmTesterBase):
     """Test the sage attention kernel."""
 

--- a/tests/algorithms/testers/sage_attn.py
+++ b/tests/algorithms/testers/sage_attn.py
@@ -5,7 +5,7 @@ from pruna.algorithms.sage_attn import SageAttn
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 class TestSageAttn(AlgorithmTesterBase):
     """Test the sage attention kernel."""
 

--- a/tests/algorithms/testers/stable_fast.py
+++ b/tests/algorithms/testers/stable_fast.py
@@ -1,8 +1,11 @@
+import pytest
+
 from pruna.algorithms.stable_fast import StableFast
 
 from .base_tester import AlgorithmTesterBase
 
 
+@pytest.mark.requires_stable_fast
 class TestStableFast(AlgorithmTesterBase):
     """Test the stable_fast algorithm."""
 

--- a/tests/algorithms/testers/tti_inplace_perp.py
+++ b/tests/algorithms/testers/tti_inplace_perp.py
@@ -27,7 +27,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 # Our nightlies machine does not support efficient attention mechanisms and causes OOM errors with this test.
 # This test do pass on modern architectures.
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.slow
 class TestTTIInPlacePerp(AlgorithmTesterBase):
     """Test the TTI InPlace Perp recovery algorithm."""

--- a/tests/algorithms/testers/tti_inplace_perp.py
+++ b/tests/algorithms/testers/tti_inplace_perp.py
@@ -27,7 +27,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 # Our nightlies machine does not support efficient attention mechanisms and causes OOM errors with this test.
 # This test do pass on modern architectures.
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.slow
 class TestTTIInPlacePerp(AlgorithmTesterBase):
     """Test the TTI InPlace Perp recovery algorithm."""

--- a/tests/algorithms/testers/tti_lora.py
+++ b/tests/algorithms/testers/tti_lora.py
@@ -27,7 +27,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 # Our nightlies machine does not support efficient attention mechanisms and causes OOM errors with this test.
 # This test do pass on modern architectures.
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.slow
 class TestTTILoRA(AlgorithmTesterBase):
     """Test the TTI LoRA recovery algorithm."""

--- a/tests/algorithms/testers/tti_lora.py
+++ b/tests/algorithms/testers/tti_lora.py
@@ -27,7 +27,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 # Our nightlies machine does not support efficient attention mechanisms and causes OOM errors with this test.
 # This test do pass on modern architectures.
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.slow
 class TestTTILoRA(AlgorithmTesterBase):
     """Test the TTI LoRA recovery algorithm."""

--- a/tests/algorithms/testers/tti_perp.py
+++ b/tests/algorithms/testers/tti_perp.py
@@ -26,7 +26,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 
 @pytest.mark.slow
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 class TestTTIPerp(AlgorithmTesterBase):
     """Test the TTI Perp recovery algorithm."""
 

--- a/tests/algorithms/testers/tti_perp.py
+++ b/tests/algorithms/testers/tti_perp.py
@@ -26,7 +26,7 @@ def assert_no_nan_values(module: Any) -> None:
 
 
 @pytest.mark.slow
-@pytest.mark.high
+@pytest.mark.high_vram
 class TestTTIPerp(AlgorithmTesterBase):
     """Test the TTI Perp recovery algorithm."""
 

--- a/tests/algorithms/testers/upscale.py
+++ b/tests/algorithms/testers/upscale.py
@@ -1,12 +1,9 @@
-import pytest
-
 from pruna.algorithms.upscale import RealESRGAN
 
 from .base_tester import AlgorithmTesterBase
 
 
-# Takes too long to run on CPU, so we mark it as slow
-@pytest.mark.slow
+# Takes too long to run on CPU, so we explicitly exclude it
 class TestUpscale(AlgorithmTesterBase):
     """Test the Upscale algorithm."""
 
@@ -15,3 +12,8 @@ class TestUpscale(AlgorithmTesterBase):
     allow_pickle_files = False
     algorithm_class = RealESRGAN
     metrics = ["cmmd"]
+
+    @classmethod
+    def compatible_devices(cls) -> list[str]:
+        """Exclude CPU (too slow)."""
+        return [d for d in super().compatible_devices() if d != "cpu"]

--- a/tests/algorithms/testers/upscale.py
+++ b/tests/algorithms/testers/upscale.py
@@ -5,7 +5,8 @@ from pruna.algorithms.upscale import RealESRGAN
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.cuda
+# Takes too long to run on CPU, so we mark it as slow
+@pytest.mark.slow
 class TestUpscale(AlgorithmTesterBase):
     """Test the Upscale algorithm."""
 

--- a/tests/algorithms/testers/whispers2t.py
+++ b/tests/algorithms/testers/whispers2t.py
@@ -6,7 +6,7 @@ from pruna.algorithms.ws2t import WS2T, WhisperS2TWrapper
 from .base_tester import AlgorithmTesterBase
 
 
-@pytest.mark.skip(reason="This test / the importing of whisper_s2t is affecting other tests.")
+@pytest.mark.requires_whisper
 @pytest.mark.slow
 class TestWhisperS2T(AlgorithmTesterBase):
     """Test the WhisperS2T batcher."""

--- a/tests/algorithms/testers/x_fast.py
+++ b/tests/algorithms/testers/x_fast.py
@@ -1,8 +1,11 @@
+import pytest
+
 from pruna.algorithms.x_fast import XFast
 
 from .base_tester import AlgorithmTesterBase
 
 
+@pytest.mark.requires_stable_fast
 class TestXFast(AlgorithmTesterBase):
     """Test the X-Fast algorithm."""
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -30,7 +30,7 @@ def device_parametrized(cls: Any) -> Any:
             pytest.param("cuda", marks=pytest.mark.cuda),
             pytest.param(
                 "accelerate",
-                marks=pytest.mark.distributed,
+                marks=pytest.mark.multi_gpu,
             ),
             pytest.param("cpu", marks=pytest.mark.cpu),
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import importlib.util
 from typing import Any
 
 import pytest
@@ -5,16 +6,35 @@ import torch
 
 # import all fixtures to make them avaliable for pytest
 from .fixtures import *  # noqa: F403, F401
-from .fixtures import HIGH_RESOURCE_FIXTURES, HIGH_RESOURCE_FIXTURES_CPU
+
+EXTRA_SKIP_MAP = {
+    "requires_gptq": ("gptqmodel", "pruna[gptq]"),
+    "requires_awq": ("llmcompressor", "pruna[awq]"),
+    "requires_stable_fast": ("sfast", "pruna[stable-fast]"),
+    "requires_vllm": ("vllm", "pruna[vllm]"),
+    "requires_intel": ("intel_extension_for_pytorch", "pruna[intel]"),
+    "requires_lmharness": ("lm_eval", "pruna[lmharness]"),
+    "requires_whisper": ("whisper", "pruna[whisper]"),
+
+}
 
 
 def pytest_configure(config: Any) -> None:
     """Configure the pytest markers."""
+    # Hardware marks
     config.addinivalue_line("markers", "cpu: mark test to run on CPU")
     config.addinivalue_line("markers", "cuda: mark test to run only on GPU machines")
-    config.addinivalue_line("markers", "distributed: mark test to run only on multi-GPU machines")
-    config.addinivalue_line("markers", "high: mark test to run only on large GPUs")
-    config.addinivalue_line("markers", "high_cpu: mark test to run only on large CPU systems")
+    config.addinivalue_line("markers", "multi_gpu: mark test to run only on multi-GPU machines")
+    config.addinivalue_line("markers", "high_vram: mark test to run only on large GPUs")  # e.g. H100
+    # Dependency marks for external dependencies
+    config.addinivalue_line("markers", "requires_gptq: mark test that needs pruna[gptq]")
+    config.addinivalue_line("markers", "requires_awq: mark test that needs pruna[awq]")
+    config.addinivalue_line("markers", "requires_stable_fast: mark test that needs pruna[stable-fast]")
+    config.addinivalue_line("markers", "requires_vllm: mark test that needs pruna[vllm]")
+    config.addinivalue_line("markers", "requires_intel: mark test that needs pruna[intel]")
+    config.addinivalue_line("markers", "requires_lmharness: mark test that needs pruna[lmharness]")
+    config.addinivalue_line("markers", "requires_whisper: mark test that needs pruna[whisper]")
+    # Category marks
     config.addinivalue_line("markers", "slow: mark test that run rather long")
     config.addinivalue_line("markers", "style: mark test that only check style")
     config.addinivalue_line("markers", "integration: mark test that is an integration test")
@@ -29,22 +49,28 @@ def _has_gpu() -> bool:
 
 
 def pytest_collection_modifyitems(session: Any, config: Any, items: list) -> None:
-    """Hook that is called after test collection. Automatically adds markers to tests that use high-resource fixtures."""
+    """Hook that is called after test collection."""
     cuda_skip = not _has_gpu()
-    distributed_skip = not _has_multi_gpu()
+    multi_gpu_skip = not _has_multi_gpu()
+
+    # Build skip markers for missing optional dependencies
+    extra_skips: dict[str, pytest.Mark] = {}
+    for mark_name, (pkg, install_hint) in EXTRA_SKIP_MAP.items():
+        if importlib.util.find_spec(pkg) is None:
+            extra_skips[mark_name] = pytest.mark.skip(
+                reason=f"{pkg} not installed. Install with: pip install '{install_hint}'"
+            )
+
     for item in items:
-        if "model_fixture" in item.fixturenames:
-            model_value = item.callspec.params["model_fixture"]
-            # Convert model_value to a string or a hashable identifier
-            if model_value in HIGH_RESOURCE_FIXTURES:
-                item.add_marker("high")
-            if model_value in HIGH_RESOURCE_FIXTURES_CPU:
-                item.add_marker("high_cpu")
-        if cuda_skip:
-            cuda_skip_mark = pytest.mark.skip(reason="CUDA not available")
-            if "cuda" in item.keywords:
-                item.add_marker(cuda_skip_mark)
-        if distributed_skip:
-            distributed_skip_mark = pytest.mark.skip(reason="Accelerate requires multiple GPUs")
-            if "distributed" in item.keywords:
-                item.add_marker(distributed_skip_mark)
+        # Skip CUDA tests when no GPU
+        if cuda_skip and "cuda" in item.keywords:
+            item.add_marker(pytest.mark.skip(reason="CUDA not available"))
+
+        # Skip multi-GPU tests when < 2 GPUs
+        if multi_gpu_skip and "multi_gpu" in item.keywords:
+            item.add_marker(pytest.mark.skip(reason="Requires multiple GPUs"))
+
+        # Skip tests whose optional dependencies are not installed
+        for mark_name, skip_marker in extra_skips.items():
+            if mark_name in item.keywords:
+                item.add_marker(skip_marker)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,11 @@
-import importlib.util
 from typing import Any
 
 import pytest
-import torch
 
 # import all fixtures to make them avaliable for pytest
 from .fixtures import *  # noqa: F403, F401
 
-EXTRA_SKIP_MAP = {
-    "requires_gptq": ("gptqmodel", "pruna[gptq]"),
-    "requires_awq": ("llmcompressor", "pruna[awq]"),
-    "requires_stable_fast": ("sfast", "pruna[stable-fast]"),
-    "requires_vllm": ("vllm", "pruna[vllm]"),
-    "requires_intel": ("intel_extension_for_pytorch", "pruna[intel]"),
-    "requires_lmharness": ("lm_eval", "pruna[lmharness]"),
-    "requires_whisper": ("whisper", "pruna[whisper]"),
-
-}
+HARDWARE_MARKS = {"cpu", "cuda", "multi_gpu"}
 
 
 def pytest_configure(config: Any) -> None:
@@ -25,7 +14,7 @@ def pytest_configure(config: Any) -> None:
     config.addinivalue_line("markers", "cpu: mark test to run on CPU")
     config.addinivalue_line("markers", "cuda: mark test to run only on GPU machines")
     config.addinivalue_line("markers", "multi_gpu: mark test to run only on multi-GPU machines")
-    config.addinivalue_line("markers", "high_vram: mark test to run only on large GPUs")  # e.g. H100
+    config.addinivalue_line("markers", "high_gpu: mark test to run only on large GPUs")  # e.g. H100
     # Dependency marks for external dependencies
     config.addinivalue_line("markers", "requires_gptq: mark test that needs pruna[gptq]")
     config.addinivalue_line("markers", "requires_awq: mark test that needs pruna[awq]")
@@ -40,37 +29,9 @@ def pytest_configure(config: Any) -> None:
     config.addinivalue_line("markers", "integration: mark test that is an integration test")
 
 
-def _has_multi_gpu() -> bool:
-    return torch.cuda.device_count() > 1
-
-
-def _has_gpu() -> bool:
-    return torch.cuda.is_available()
-
-
 def pytest_collection_modifyitems(session: Any, config: Any, items: list) -> None:
     """Hook that is called after test collection."""
-    cuda_skip = not _has_gpu()
-    multi_gpu_skip = not _has_multi_gpu()
-
-    # Build skip markers for missing optional dependencies
-    extra_skips: dict[str, pytest.Mark] = {}
-    for mark_name, (pkg, install_hint) in EXTRA_SKIP_MAP.items():
-        if importlib.util.find_spec(pkg) is None:
-            extra_skips[mark_name] = pytest.mark.skip(
-                reason=f"{pkg} not installed. Install with: pip install '{install_hint}'"
-            )
-
     for item in items:
-        # Skip CUDA tests when no GPU
-        if cuda_skip and "cuda" in item.keywords:
-            item.add_marker(pytest.mark.skip(reason="CUDA not available"))
-
-        # Skip multi-GPU tests when < 2 GPUs
-        if multi_gpu_skip and "multi_gpu" in item.keywords:
-            item.add_marker(pytest.mark.skip(reason="Requires multiple GPUs"))
-
-        # Skip tests whose optional dependencies are not installed
-        for mark_name, skip_marker in extra_skips.items():
-            if mark_name in item.keywords:
-                item.add_marker(skip_marker)
+        # Auto-tag unmarked tests as CPU
+        if not any(mark in item.keywords for mark in HARDWARE_MARKS):
+            item.add_marker(pytest.mark.cpu)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,24 @@ def pytest_configure(config: Any) -> None:
 
 def pytest_collection_modifyitems(session: Any, config: Any, items: list) -> None:
     """Hook that is called after test collection."""
+    selected = []
+    deselected = []
     for item in items:
         # Auto-tag unmarked tests as CPU
         if not any(mark in item.keywords for mark in HARDWARE_MARKS):
             item.add_marker(pytest.mark.cpu)
+        # device_parametrized generates cpu/cuda/accelerate variants for every
+        # algorithm test, even when the algorithm's runs_on excludes that device.
+        # The incompatible variants get collected by the CI (e.g. -m "cpu") and
+        # skip at runtime after expensive fixture setup. Deselecting them here
+        # avoids that wasted overhead.
+        if hasattr(item, "callspec") and "algorithm_tester" in item.callspec.params:
+            tester = item.callspec.params["algorithm_tester"]
+            device = item.callspec.params.get("device")
+            if device and device not in tester.compatible_devices():
+                deselected.append(item)
+                continue
+        selected.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = selected

--- a/tests/documentation/test_tutorials.py
+++ b/tests/documentation/test_tutorials.py
@@ -13,7 +13,7 @@ TUTORIAL_PATH = Path(__file__).parent.parent.parent / "docs"
 @pytest.mark.parametrize(
     "notebook_name",
     [
-        pytest.param(notebook_name, marks=(pytest.mark.cuda, pytest.mark.high))
+        pytest.param(notebook_name, marks=(pytest.mark.cuda, pytest.mark.high_vram))
         for notebook_name in glob.glob(str(TUTORIAL_PATH / "tutorials" / "*.ipynb"))
     ],
 )

--- a/tests/documentation/test_tutorials.py
+++ b/tests/documentation/test_tutorials.py
@@ -13,7 +13,7 @@ TUTORIAL_PATH = Path(__file__).parent.parent.parent / "docs"
 @pytest.mark.parametrize(
     "notebook_name",
     [
-        pytest.param(notebook_name, marks=(pytest.mark.cuda, pytest.mark.high_vram))
+        pytest.param(notebook_name, marks=(pytest.mark.cuda, pytest.mark.high_gpu))
         for notebook_name in glob.glob(str(TUTORIAL_PATH / "tutorials" / "*.ipynb"))
     ],
 )

--- a/tests/engine/test_device.py
+++ b/tests/engine/test_device.py
@@ -66,7 +66,7 @@ def test_device_casting(input_device: str | torch.device, target_device: str | t
 
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.parametrize("target_device", ["cuda", "cpu"])
 @pytest.mark.parametrize("model_fixture", ["sd_tiny_random"], indirect=True)
 def test_accelerate_diffusers_casting(target_device: str | torch.device, model_fixture: Any) -> None:
@@ -85,7 +85,7 @@ def test_accelerate_diffusers_casting(target_device: str | torch.device, model_f
     model("an elf on a shelf", num_inference_steps=2, width=16, height=16)
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.parametrize("target_device", ["cuda", "cpu"])
 @pytest.mark.parametrize("model_fixture", ["opt_tiny_random"], indirect=True)
 def test_accelerate_autocausallm_casting(target_device: str | torch.device, model_fixture: Any) -> None:
@@ -103,7 +103,7 @@ def test_accelerate_autocausallm_casting(target_device: str | torch.device, mode
     model(**dummy)
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.parametrize("target_device", ["cuda", "cpu"])
 def test_accelerate_diffusers_model_casting(target_device: str | torch.device) -> None:
     """Test that a diffusers model can be cast to the target device."""
@@ -127,7 +127,7 @@ def test_accelerate_diffusers_model_casting(target_device: str | torch.device) -
     full_pipe("an elf on a shelf", num_inference_steps=2, width=16, height=16)
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.parametrize("target_device", ["cuda", "cpu"])
 @pytest.mark.parametrize("model_fixture", ["whisper_tiny_random"], indirect=True)
 def test_accelerate_transformer_pipeline_casting(target_device: str | torch.device, model_fixture: Any) -> None:

--- a/tests/evaluation/test_device_compatibility.py
+++ b/tests/evaluation/test_device_compatibility.py
@@ -14,7 +14,7 @@ from pruna.evaluation.metrics.metric_cmmd import CMMD
 from pruna.evaluation.metrics.registry import MetricRegistry
 from typing import Any, List
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
 @pytest.mark.parametrize(
     "datamodule_fixture, model_fixture, evaluation_request, low_memory",
@@ -112,7 +112,7 @@ def test_ensure_task_model_device_mismatch_raises(datamodule_fixture: PrunaDataM
     with pytest.raises(ValueError):
         model = agent.prepare_model(model)
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
 @pytest.mark.parametrize(
     "datamodule_fixture,model_fixture,task_device",
@@ -134,7 +134,7 @@ def test_ensure_task_model_accelerate_device_mismatch_raises(datamodule_fixture:
         agent.prepare_model(model)
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
 @pytest.mark.parametrize(
     "datamodule_fixture,model_fixture",

--- a/tests/evaluation/test_evalharness_metrics.py
+++ b/tests/evaluation/test_evalharness_metrics.py
@@ -1,13 +1,15 @@
 import pytest
 from pruna.evaluation.metrics.metric_evalharness import LMEvalMetric
 from pruna.evaluation.metrics.result import MetricResult
-import pytest
 from pruna.evaluation.task import (
     Task,
     _process_single_request,
     _get_lm_eval_task_metrics,
 )
 from pruna.data.pruna_datamodule import PrunaDataModule
+
+# apply this mark to all tests in this file
+pytestmark = pytest.mark.requires_lmharness
 
 
 @pytest.mark.cpu

--- a/tests/evaluation/test_inference_time_metrics.py
+++ b/tests/evaluation/test_inference_time_metrics.py
@@ -30,7 +30,7 @@ def test_latency_metric(model_fixture: tuple[Any, SmashConfig], device: str) -> 
     assert results.result > 0  # Assuming latency should be positive
 
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
 @pytest.mark.parametrize(
     "model_fixture",
@@ -55,7 +55,7 @@ def test_latency_metric_distributed(model_fixture: tuple[Any, SmashConfig]):
     assert get_device_map(model) == device_map
     assert results.result > 0  # Assuming latency should be positive
 
-@pytest.mark.distributed
+@pytest.mark.multi_gpu
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="needs ≥2 GPUs to build a split model")
 @pytest.mark.parametrize(
     "model_fixture",

--- a/tests/evaluation/test_memory_metrics.py
+++ b/tests/evaluation/test_memory_metrics.py
@@ -7,8 +7,7 @@ from pruna.engine.utils import move_to_device
 from pruna.evaluation.metrics.metric_memory import DiskMemoryMetric, InferenceMemoryMetric, TrainingMemoryMetric
 
 @pytest.mark.cuda
-# We need to mark this test as high because it requires modern architectures
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.parametrize(
     "model_fixture",
     [
@@ -28,8 +27,7 @@ def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     assert disk_memory_results.result > 0
 
 @pytest.mark.cuda
-# We need to mark this test as high because it requires modern architectures
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.parametrize(
     "model_fixture",
     [
@@ -49,8 +47,7 @@ def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None
     assert inference_memory_results.result > 0
 
 @pytest.mark.cuda
-# We need to mark this test as high because it requires modern architectures
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.parametrize(
     "model_fixture",
     [

--- a/tests/evaluation/test_memory_metrics.py
+++ b/tests/evaluation/test_memory_metrics.py
@@ -7,7 +7,7 @@ from pruna.engine.utils import move_to_device
 from pruna.evaluation.metrics.metric_memory import DiskMemoryMetric, InferenceMemoryMetric, TrainingMemoryMetric
 
 @pytest.mark.cuda
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.parametrize(
     "model_fixture",
     [
@@ -27,7 +27,7 @@ def test_disk_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None:
     assert disk_memory_results.result > 0
 
 @pytest.mark.cuda
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.parametrize(
     "model_fixture",
     [
@@ -47,7 +47,7 @@ def test_inference_memory_metric(model_fixture: tuple[Any, SmashConfig]) -> None
     assert inference_memory_results.result > 0
 
 @pytest.mark.cuda
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.parametrize(
     "model_fixture",
     [

--- a/tests/evaluation/test_registry.py
+++ b/tests/evaluation/test_registry.py
@@ -5,6 +5,8 @@ import pytest
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 
+pytestmark = pytest.mark.cpu
+
 
 class MockMetric(BaseMetric):
     """A simple mock metric for testing the registry."""

--- a/tests/evaluation/test_registry.py
+++ b/tests/evaluation/test_registry.py
@@ -5,8 +5,6 @@ import pytest
 from pruna.evaluation.metrics.metric_base import BaseMetric
 from pruna.evaluation.metrics.registry import MetricRegistry
 
-pytestmark = pytest.mark.cpu
-
 
 class MockMetric(BaseMetric):
     """A simple mock metric for testing the registry."""

--- a/tests/evaluation/test_task.py
+++ b/tests/evaluation/test_task.py
@@ -56,7 +56,7 @@ def test_device_is_set_correctly_for_metrics(device:str):
 
 
 @pytest.mark.cuda
-@pytest.mark.high_vram
+@pytest.mark.high_gpu
 @pytest.mark.parametrize(
     "inference_device, stateful_metric_device, task_device",
     [

--- a/tests/evaluation/test_task.py
+++ b/tests/evaluation/test_task.py
@@ -56,8 +56,7 @@ def test_device_is_set_correctly_for_metrics(device:str):
 
 
 @pytest.mark.cuda
-# We need to mark this test as cuda because it requires modern architectures
-@pytest.mark.high
+@pytest.mark.high_vram
 @pytest.mark.parametrize(
     "inference_device, stateful_metric_device, task_device",
     [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,9 +13,6 @@ from pruna.data.pruna_datamodule import PrunaDataModule
 from pruna.engine.load import load_diffusers_model
 from pruna.engine.utils import safe_memory_cleanup
 
-HIGH_RESOURCE_FIXTURES = []
-HIGH_RESOURCE_FIXTURES_CPU = HIGH_RESOURCE_FIXTURES + []
-
 
 @pytest.fixture(scope="function")
 def model_fixture(request: pytest.FixtureRequest) -> Any:

--- a/tests/telemetry/test_metrics.py
+++ b/tests/telemetry/test_metrics.py
@@ -26,9 +26,6 @@ from pruna.telemetry.metrics import (
     set_opentelemetry_log_level,
 )
 
-pytestmark = pytest.mark.cpu
-
-
 @pytest.fixture
 def mock_config():
     return {

--- a/tests/telemetry/test_metrics.py
+++ b/tests/telemetry/test_metrics.py
@@ -26,6 +26,8 @@ from pruna.telemetry.metrics import (
     set_opentelemetry_log_level,
 )
 
+pytestmark = pytest.mark.cpu
+
 
 @pytest.fixture
 def mock_config():


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
- Isolated whisper dependencies into a dedicated [whisper] extra. Moved ctranslate2 and whisper-s2t out of the default full install group into [whisper] to prevent side-effects from whisper_s2t imports breaking unrelated tests at collection time. The previously hard-skipped TestWhisperS2T is now gated behind requires_whisper instead.

- Pin torch/torchvision bounds on the [intel] extra. intel-extension-for-pytorch is tightly coupled to the torch version; added explicit torch>=2.7.0,<2.9.0 and torchvision>=0.22.0,<0.24.0 constraints so installs don't silently break.
- Also switch TestIPEXLLM to use opt_125m model and drop latency metric. The algorithm didn't work on a tiny model due to latent size being small; we also need a specific inference handler for it for the metrics, which can be done later, so removed the evaluation part for now. 
- IPEX is strictly coupled with the torch version and is not maintained. So makes sense to run it in the nightlies but not on the CI, as it requires its own setup.

- Declared packaging conflicts between intel/awq and gptq/awq. These extras pull in incompatible transitive deps; the new [tool.uv.conflicts] entries surface the error at resolve time instead of runtime.

- Added requires_* markers for optional-extra tests. New markers requires_awq, requires_gptq, requires_stable_fast, requires_vllm, requires_intel, requires_lmharness, and requires_whisper let CI select/deselect tests based on what's installed rather than relying on implicit skips or collection errors.

- Removed the old HIGH_RESOURCE_FIXTURES list and runtime CUDA/multi-GPU detection. Tests without an explicit hardware mark are now auto-tagged cpu. Incompatible device_parametrized variants (e.g. a CUDA-only algorithm's CPU test) are deselected at collection time instead of skipping after expensive fixture setup. Added explicit pytestmark = pytest.mark.cpu to pure-CPU test modules (test_compatibility_symmetry, test_evalharness_metrics, test_registry, test_metrics) so they're correctly selected by -m "cpu".

- Updated CI workflow. Dropped --extra vllm from the default uv sync in the setup action. Changed the pytest filter from -m "not (slow or style or high_cpu or cuda or distributed)" to the positive-selection form -m "cpu and not slow and not requires_intel".



## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.

---

## First Prune (1-year OSS anniversary)

**First Prune** marks one year of Pruna’s open-source work. During the initiative window, qualifying merged contributions count toward **First Prune**. You can earn credits for our **performance models** via our **API**.

If you’d like your contribution to count toward **First Prune**, here’s how it works:

- **Initiative window:** First Prune starts on **March 31**.
- **Issue assignment:** For your PR to count toward First Prune, the related issue must be assigned to the contributor opening the PR. Issues are labeled with **first-prune**.
- **Open for review:** Please **open your PR and mark it ready for review by April 30** (end of April).
- **Review priority:** We’ll make our best effort to review quickly any PR that is open and has a review request before April 30.
- **Credits:** Each qualifying merged PR earns **30 credits**. We’ll be in touch after all qualifying PRs for **First Prune** have been merged.
- **To get started:** Have a look at [all models](https://www.pruna.ai/all-models). You’ll need to **sign up** on the [dashboard](https://dashboard.pruna.ai/login) before you can redeem your credits.
