### PR TITLE
test: skip janus tests requiring specific transformers version

### DIFF
--- a/tests/algorithms/test_combinations.py
+++ b/tests/algorithms/test_combinations.py
@@ -59,7 +59,9 @@ class CombinationsTester(AlgorithmTesterBase):
         ("flux_tiny_random", ["fora", "diffusers_int8"], False, 'cmmd'),
         ("flux_tiny_random", ["fora", "torch_compile"], False, 'cmmd'),
         pytest.param("flux_tiny_random", ["fora", "stable_fast"], False, 'cmmd', marks=pytest.mark.requires_stable_fast),
-        ("tiny_janus", ["hqq", "torch_compile"], False, 'cmmd'),
+        pytest.param("tiny_janus", ["hqq", "torch_compile"], False, 'cmmd', marks=pytest.mark.skip(
+            reason="Current Janus inference requires transformer 4.51.3 which is incompatible with the test environment."
+        )),
         pytest.param("flux_tiny", ["fora", "flash_attn3", "torch_compile"], False, 'cmmd', marks=pytest.mark.high_gpu),
     ],
     indirect=["model_fixture"],

--- a/tests/algorithms/testers/hqq.py
+++ b/tests/algorithms/testers/hqq.py
@@ -1,3 +1,5 @@
+import pytest
+
 from pruna import PrunaModel
 from pruna.algorithms.hqq import HQQ
 
@@ -14,6 +16,9 @@ class TestHQQ(AlgorithmTesterBase):
     metrics = ["perplexity"]
 
 
+@pytest.mark.skip(
+    reason="Current Janus inference requires transformer 4.51.3 which is incompatible with the test environment."
+)
 class TestHQQJanus(AlgorithmTesterBase):
     """Test the HQQ quantizer."""
 


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
Janus has a custom inference implementation that relies on transformers version 4.51.3 which is far older than the version used in the CI.
This PR skips the test because it has no chance of actually running until we update the JanusGenerator.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.

---

## First Prune (1-year OSS anniversary)

**First Prune** marks one year of Pruna’s open-source work. During the initiative window, qualifying merged contributions count toward **First Prune**. You can earn credits for our **performance models** via our **API**.

If you’d like your contribution to count toward **First Prune**, here’s how it works:

- **Initiative window:** First Prune starts on **March 31**.
- **Issue assignment:** For your PR to count toward First Prune, the related issue must be assigned to the contributor opening the PR. Issues are labeled with **first-prune**.
- **Open for review:** Please **open your PR and mark it ready for review by April 30** (end of April).
- **Review priority:** We’ll make our best effort to review quickly any PR that is open and has a review request before April 30.
- **Credits:** Each qualifying merged PR earns **30 credits**. We’ll be in touch after all qualifying PRs for **First Prune** have been merged.
- **To get started:** Have a look at [all models](https://www.pruna.ai/all-models). You’ll need to **sign up** on the [dashboard](https://dashboard.pruna.ai/login) before you can redeem your credits.
