### PR TITLE
build: add dependencies cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,8 @@ explicit = true
 [tool.uv]
 index-strategy = "first-index"
 exclude-newer = "1 week"  # protection against compromised dependencies
+# trusted dev wheels that are missing an upload date
+exclude-newer-package = { gptqmodel = false, "stable-fast-pruna" = false }
 
 conflicts = [
     [{ extra = "awq" }, { extra = "vbench" }],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ explicit = true
 
 [tool.uv]
 index-strategy = "first-index"
+exclude-newer = "1 week"  # protection against compromised dependencies
 
 conflicts = [
     [{ extra = "awq" }, { extra = "vbench" }],


### PR DESCRIPTION
## Description
This PR adds a 1 week cooldown for dependencies to protect against compromised packages. This gives us a 1 week delay to get any news about compromised packages and
- confirm that they have removed the compromised version, or
- restrict the version until we have found a better solution.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I checked the uv pip install behavior for torch 2.11 dating back from march 23 (<2 months ago) with a no filter (is the version selected), 1 week filter (no change), 8 weeks filter (torch 2.10 is selected instead).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
<!-- Add any other information about the PR here -->
