### PR TITLE
fix: torch compile bugs hqq

### DIFF
--- a/src/pruna/algorithms/hqq_diffusers.py
+++ b/src/pruna/algorithms/hqq_diffusers.py
@@ -270,11 +270,7 @@ class HQQDiffusers(PrunaAlgorithmBase):
                 # We default to the torch backend if the input backend is not applicable
                 imported_modules["prepare_for_inference"](module)
 
-            unet_types = get_diffusers_unet_models()
-            if isinstance(module, tuple(unet_types)):
-                for layer in module.up_blocks:
-                    if layer.upsamplers is not None:
-                        layer.upsamplers[0].name = "conv"
+            sync_unet_upsampler_names(module)
 
             return module
 
@@ -455,6 +451,10 @@ def construct_base_class(imported_modules: Dict[str, Any], extra_ignore_modules:
             # before the HQQ attempt to move them from meta device to cpu/gpu
             if hasattr(model, "save_dir"):
                 cls.load_hqq_missed_parameters(model, model.save_dir)
+            if hasattr(model, "unet"):
+                sync_unet_upsampler_names(model.unet)
+            else:
+                sync_unet_upsampler_names(model)
 
     return AutoHQQHFDiffusersModel
 
@@ -536,3 +536,28 @@ def _rename_attribute(path: str, old: str, new: str) -> str:
         return path.replace(f"{old}.", f"{new}.", 1)
     else:
         return path
+
+
+def sync_unet_upsampler_names(module: torch.nn.Module) -> None:
+    """
+    Align Upsample2D.name with the conv submodule that is actually present.
+
+    Diffusers forward uses ``self.name`` to choose between ``self.conv`` and
+    ``self.Conv2d_0``. Quantization and reload can change submodule keys without
+    updating ``name``; infer the correct value from ``_modules`` instead of
+    hard-coding it at smash time only.
+    """
+    unet_types = get_diffusers_unet_models()
+    if not isinstance(module, tuple(unet_types)) or not hasattr(module, "up_blocks"):
+        return
+    for layer in module.up_blocks:
+        if layer.upsamplers is None:
+            continue
+        upsampler = layer.upsamplers[0]
+        if not upsampler.use_conv:
+            continue
+        if "conv" in upsampler._modules:
+            upsampler.name = "conv"
+        elif "Conv2d_0" in upsampler._modules:
+            # Legacy diffusers key (forward uses Conv2d_0 when name != "conv").
+            upsampler.name = "Conv2d_0"

--- a/src/pruna/algorithms/hqq_diffusers.py
+++ b/src/pruna/algorithms/hqq_diffusers.py
@@ -540,12 +540,20 @@ def _rename_attribute(path: str, old: str, new: str) -> str:
 
 def sync_unet_upsampler_names(module: torch.nn.Module) -> None:
     """
-    Align Upsample2D.name with the conv submodule that is actually present.
+    Sync Upsample2D.name with the conv submodule key present on the UNet.
 
-    Diffusers forward uses ``self.name`` to choose between ``self.conv`` and
-    ``self.Conv2d_0``. Quantization and reload can change submodule keys without
-    updating ``name``; infer the correct value from ``_modules`` instead of
-    hard-coding it at smash time only.
+    Diffusers Upsample2D.forward selects conv or Conv2d_0 from name. HQQ and
+    reload can change submodule keys without updating name; set name from _modules.
+
+    Parameters
+    ----------
+    module : torch.nn.Module
+        A diffusers UNet, or a module that exposes up_blocks with upsamplers.
+
+    Returns
+    -------
+    None
+        Upsample2D.name on each upsampler is set in place to match its conv submodule.
     """
     unet_types = get_diffusers_unet_models()
     if not isinstance(module, tuple(unet_types)) or not hasattr(module, "up_blocks"):

--- a/src/pruna/engine/load.py
+++ b/src/pruna/engine/load.py
@@ -253,9 +253,7 @@ def resmash(model: Any, smash_config: SmashConfig) -> Any:
     return smash(model=model, smash_config=smash_config_subset)
 
 
-def load_transformers_model(
-    path: str | Path, smash_config: SmashConfig | None = None, **kwargs
-) -> Any:
+def load_transformers_model(path: str | Path, smash_config: SmashConfig | None = None, **kwargs) -> Any:
     """
     Load a transformers model or pipeline from the given model path.
 
@@ -297,17 +295,11 @@ def load_transformers_model(
             device_map = "auto"
         else:
             device = smash_config.device if smash_config.device != "cuda" else "cuda:0"
-            device_map = (
-                smash_config.device_map
-                if smash_config.device == "accelerate"
-                else device
-            )
+            device_map = smash_config.device_map if smash_config.device == "accelerate" else device
         return cls.from_pretrained(path, device_map=device_map, **kwargs)
 
 
-def load_diffusers_model(
-    path: str | Path, smash_config: SmashConfig | None = None, **kwargs
-) -> Any:
+def load_diffusers_model(path: str | Path, smash_config: SmashConfig | None = None, **kwargs) -> Any:
     """
     Load a diffusers model from the given model path.
 
@@ -383,9 +375,7 @@ def load_pickled(path: str | Path, smash_config: SmashConfig, **kwargs) -> Any:
         The loaded pickled model.
     """
     # torch load has a target device but no interface to reproduce an accelerate-distributed model, we first map to cpu
-    target_device = (
-        "cpu" if smash_config.device == "accelerate" else smash_config.device
-    )
+    target_device = "cpu" if smash_config.device == "accelerate" else smash_config.device
     model = torch.load(
         Path(path) / PICKLED_FILE_NAME,
         weights_only=False,
@@ -425,17 +415,11 @@ def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any
     else:
         saved_smash_config = SmashConfig()
         saved_smash_config.load_from_json(model_path)
-        compute_dtype = (
-            torch.float16
-            if saved_smash_config["hqq_compute_dtype"] == "torch.float16"
-            else torch.bfloat16
-        )
+        compute_dtype = torch.float16 if saved_smash_config["hqq_compute_dtype"] == "torch.float16" else torch.bfloat16
 
     has_config = (model_path / "config.json").exists()
     is_janus_model = (
-        has_config
-        and load_json_config(model_path, "config.json")["architectures"][0]
-        == "JanusForConditionalGeneration"
+        has_config and load_json_config(model_path, "config.json")["architectures"][0] == "JanusForConditionalGeneration"
     )
 
     def load_quantized_model(quantized_path: str | Path) -> Any:
@@ -443,21 +427,15 @@ def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any
             quantized_model = algorithm_packages["HQQModelForCausalLM"].from_quantized(
                 str(quantized_path),
                 device=smash_config.device,
-                **filter_load_kwargs(
-                    algorithm_packages["HQQModelForCausalLM"].from_quantized, kwargs
-                ),
+                **filter_load_kwargs(algorithm_packages["HQQModelForCausalLM"].from_quantized, kwargs),
             )
         except Exception:  # Default to generic HQQ pipeline if it fails
-            pruna_logger.info(
-                "Could not load HQQ model using HQQModelForCausalLM, trying generic AutoHQQHFModel..."
-            )
+            pruna_logger.info("Could not load HQQ model using HQQModelForCausalLM, trying generic AutoHQQHFModel...")
             quantized_model = algorithm_packages["AutoHQQHFModel"].from_quantized(
                 str(quantized_path),
                 device=smash_config.device,
                 compute_dtype=compute_dtype,
-                **filter_load_kwargs(
-                    algorithm_packages["AutoHQQHFModel"].from_quantized, kwargs
-                ),
+                **filter_load_kwargs(algorithm_packages["AutoHQQHFModel"].from_quantized, kwargs),
             )
         return quantized_model
 
@@ -465,9 +443,7 @@ def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any
         # load the pipeline with a fake model on meta device
         with (model_path / PIPELINE_INFO_FILE_NAME).open("r") as f:
             task = json.load(f)["task"]
-        pipe = pipeline(
-            task=task, model=str(model_path), model_kwargs={"device_map": "meta"}
-        )
+        pipe = pipeline(task=task, model=str(model_path), model_kwargs={"device_map": "meta"})
         # load the quantized model
         pipe.model = load_quantized_model(model_path)
         move_to_device(pipe, smash_config.device)
@@ -483,9 +459,7 @@ def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any
         # Janus language model must be patched to match HQQ's causal LM assumption
         quantized_path = str(hqq_model_dir / "qmodel.pt")
         weights = torch.load(quantized_path, map_location="cpu", weights_only=True)
-        is_already_patched = all(
-            k == "lm_head" or k.startswith("model.") for k in weights
-        )
+        is_already_patched = all(k == "lm_head" or k.startswith("model.") for k in weights)
         if not is_already_patched:
             # load the weight on cpu to rename attr -> model.attr,
             weights = {f"model.{k}": v for k, v in weights.items()}
@@ -494,9 +468,7 @@ def load_hqq(model_path: str | Path, smash_config: SmashConfig, **kwargs) -> Any
             torch.save(weights, quantized_path)  # patch weights
 
         quantized_causal_lm = load_quantized_model(hqq_model_dir)
-        model.model.language_model = (
-            quantized_causal_lm.model
-        )  # drop the lm_head and causal_lm wrapper
+        model.model.language_model = quantized_causal_lm.model  # drop the lm_head and causal_lm wrapper
         # some weights of the language_model are not on the correct device, so we move it afterwards.
         move_to_device(model, smash_config.device)
         return model
@@ -527,6 +499,7 @@ def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) ->
     from pruna.algorithms.hqq_diffusers import (
         HQQDiffusers,
         construct_base_class,
+        sync_unet_upsampler_names,
     )
 
     pruna_logger.warning(
@@ -535,12 +508,8 @@ def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) ->
     )
 
     hf_quantizer = HQQDiffusers()
-    auto_hqq_hf_diffusers_model = construct_base_class(
-        hf_quantizer.import_algorithm_packages(), []
-    )
-    quantized_load_kwargs = filter_load_kwargs(
-        auto_hqq_hf_diffusers_model.from_quantized, kwargs
-    )
+    auto_hqq_hf_diffusers_model = construct_base_class(hf_quantizer.import_algorithm_packages(), [])
+    quantized_load_kwargs = filter_load_kwargs(auto_hqq_hf_diffusers_model.from_quantized, kwargs)
 
     path = Path(path)
     if "compute_dtype" not in kwargs and (path / "dtype_info.json").exists():
@@ -549,13 +518,12 @@ def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) ->
         kwargs.setdefault("torch_dtype", dtype)
 
     qmodel_path = path / "qmodel.pt"
-    if (
-        qmodel_path.exists()
-    ):  # the whole model was quantized, not a pipeline, load it directly
+    if qmodel_path.exists():  # the whole model was quantized, not a pipeline, load it directly
         model = auto_hqq_hf_diffusers_model.from_quantized(path, **kwargs)
         # force dtype if specified, from_quantized does not set it properly
         if "torch_dtype" in kwargs:
             model.to(kwargs["torch_dtype"])
+        sync_unet_upsampler_names(model)
     else:  # save directory is for a pipeline, of which some components were quantized
         model_index = load_json_config(path, "model_index.json")
 
@@ -563,9 +531,7 @@ def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) ->
         # that can be quantized and saved separately.
         # by convention, each component has been saved in a directory f"{attr_name}_quantized".
         quantized_components: dict[str, Any] = {}
-        for quantized_path in [
-            qpath for qpath in path.iterdir() if qpath.name.endswith("_quantized")
-        ]:
+        for quantized_path in [qpath for qpath in path.iterdir() if qpath.name.endswith("_quantized")]:
             attr_name = quantized_path.name.replace("_quantized", "")
 
             # legacy behavior: backbone_quantized -> target the transformer or unet attribute
@@ -598,6 +564,8 @@ def load_hqq_diffusers(path: str | Path, smash_config: SmashConfig, **kwargs) ->
                 setattr(model, attr_name, quantized_component)
     # HQQ does not support direct loading on the correct device, so we move it afterwards
     move_to_device(model, smash_config.device, device_map=smash_config.device_map)
+    if hasattr(model, "unet"):
+        sync_unet_upsampler_names(model.unet)
     return model
 
 
@@ -681,10 +649,7 @@ def filter_load_kwargs(func: Callable, kwargs: dict) -> dict:
     signature = inspect.signature(func)
 
     # Check if function accepts arbitrary kwargs
-    has_kwargs = any(
-        param.kind == inspect.Parameter.VAR_KEYWORD
-        for param in signature.parameters.values()
-    )
+    has_kwargs = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values())
 
     if has_kwargs:
         return kwargs
@@ -696,8 +661,6 @@ def filter_load_kwargs(func: Callable, kwargs: dict) -> dict:
 
     # Log the discarded kwargs
     if invalid_kwargs:
-        pruna_logger.info(
-            f"Discarded unused loading kwargs: {list(invalid_kwargs.keys())}"
-        )
+        pruna_logger.info(f"Discarded unused loading kwargs: {list(invalid_kwargs.keys())}")
 
     return valid_kwargs


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
This PR fixes a torch-compile related bug: sd_tiny_random-hqq_diffusers+torch_compile-False-cmmd : AttributeError: 'Upsample2D' object has no attribute 'Conv2d_0' -> comes from the loss of the called module when saving and loading after hqq+torch-compile on unet-based models (which trigger a legacy naming).

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.