### PR TITLE
build: restrict dependency cooldown to pypi index

### DIFF
--- a/.github/actions/setup-uv-project/action.yml
+++ b/.github/actions/setup-uv-project/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@v6
       with:
-        version: ">=0.8.0"
+        version: ">=0.11.5"  # introduction of per-index exclude-newer support
         activate-environment: true
         enable-cache: true
         github-token: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,12 @@ testpaths = [
     "tests/",
 ]
 
+# Dependency cooldown applies only to PyPI; trusted extra indexes (pruna_internal, user --extra-index-url) are unaffected.
+[[tool.uv.index]]
+name = "pypi"
+url = "https://pypi.org/simple"
+default = true
+exclude-newer = "1 week"
 
 [[tool.uv.index]]
 name = "pruna_internal"
@@ -73,9 +79,6 @@ explicit = true
 
 [tool.uv]
 index-strategy = "first-index"
-exclude-newer = "1 week"  # protection against compromised dependencies
-# trusted dev wheels that are missing an upload date
-exclude-newer-package = { gptqmodel = false, "stable-fast-pruna" = false }
 
 conflicts = [
     [{ extra = "awq" }, { extra = "vbench" }],


### PR DESCRIPTION
## Description
This PR changes the scope of the dependency cooldown introduced in #660 because the cooldown was affecting extra indices which contain wheels without a release date.

Doing `uv pip install torch==2.12 torchvision --index-url https://download.pytorch.org/whl/cu126` (or any extra index) would fail because the wheels on the extra index lack a release date and therefore are excluded by the cooldown condition.
This means only the blackwell-specific cu130 pypi wheels for torch 2.11 and 2.12 are currently considered compatible.

The fix consists in applying the cooldown only to the pypi index instead of globally
```
[[tool.uv.index]]
name = "pypi"
url = "https://pypi.org/simple"
default = true
exclude-newer = "1 week"
```
Since pypi doesn't allow wheels to specify external urls, this is carried recursively to all pypi dependencies. In pruna the only extra index url is our pythonanywhere index which we trust, and other indices would have been manually added by the user and therefore their responsability.

This requires uv>=0.11.5 hence the uv version bump in the CI, and the early versions after 0.11.5 raise an experimental warning for the per-index exclude-newer feature.

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
`uv pip install torch==2.12 torchvision --index-url https://download.pytorch.org/whl/cu126` now runs.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.