### PR TITLE
fix: torch compile default to inductor on cpu

### DIFF
--- a/docs/tutorials/cv_cpu.ipynb
+++ b/docs/tutorials/cv_cpu.ipynb
@@ -1,177 +1,177 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Smash your model with a CPU only"
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "vscode": {
-     "languageId": "raw"
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Smash your model with a CPU only"
+      ]
+    },
+    {
+      "cell_type": "raw",
+      "metadata": {
+        "vscode": {
+          "languageId": "raw"
+        }
+      },
+      "source": [
+        "<a target=\"_blank\" href=\"https://colab.research.google.com/github/PrunaAI/pruna/blob/v|version|/docs/tutorials/cv_cpu.ipynb\">\n",
+        "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+        "</a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "This tutorial demonstrates how to use the `pruna` package to optimize any model on CPU. We will use the `vit_b_16` computer visionmodel as an example."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
+        "# the following command will install the latest version of pruna\n",
+        "%pip install pruna"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 1. Loading the CV Model\n",
+        "\n",
+        "First, load your ViT model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import torchvision\n",
+        "\n",
+        "model = torchvision.models.vit_b_16(weights=\"ViT_B_16_Weights.DEFAULT\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 2. Initializing the Smash Config\n",
+        "\n",
+        "Next, initialize the smash_config."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pruna import SmashConfig\n",
+        "\n",
+        "# Initialize the SmashConfig\n",
+        "smash_config = SmashConfig({\"torch_compile\": {\"backend\": \"inductor\"}})"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 3. Smashing the Model\n",
+        "\n",
+        "Now, smash the model. This will only take a few seconds."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pruna import smash\n",
+        "\n",
+        "# Smash the model\n",
+        "smashed_model = smash(\n",
+        "    model=model,\n",
+        "    smash_config=smash_config,\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4. Preparing the Input"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "from torchvision import transforms\n",
+        "\n",
+        "# Generating a random image\n",
+        "image = np.random.randint(0, 256, size=(224, 224, 3)).astype(dtype=np.float32)\n",
+        "input_tensor = transforms.ToTensor()(image).unsqueeze(0)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 5. Running the Model\n",
+        "\n",
+        "Finally, run the model to process the image."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Display the result\n",
+        "smashed_model(input_tensor)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Wrap Up\n",
+        "\n",
+        "Congratulations! You have successfully smashed a CV model on CPU. You can now use the `pruna` package to optimize any model on a CPU. The only parts that you should modify are step 1, 4 and 5 to fit your use case"
+      ]
     }
-   },
-   "source": [
-    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/PrunaAI/pruna/blob/v|version|/docs/tutorials/cv_cpu.ipynb\">\n",
-    "    <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
-    "</a>"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Pruna",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.11.13"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This tutorial demonstrates how to use the `pruna` package to optimize any model on CPU. We will use the `vit_b_16` computer visionmodel as an example."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# if you are not running the latest version of this tutorial, make sure to install the matching version of pruna\n",
-    "# the following command will install the latest version of pruna\n",
-    "%pip install pruna"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 1. Loading the CV Model\n",
-    "\n",
-    "First, load your ViT model."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import torchvision\n",
-    "\n",
-    "model = torchvision.models.vit_b_16(weights=\"ViT_B_16_Weights.DEFAULT\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2. Initializing the Smash Config\n",
-    "\n",
-    "Next, initialize the smash_config."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pruna import SmashConfig\n",
-    "\n",
-    "# Initialize the SmashConfig\n",
-    "smash_config = SmashConfig({\"torch_compile\": {\"backend\": \"openvino\"}})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3. Smashing the Model\n",
-    "\n",
-    "Now, smash the model. This will only take a few seconds."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pruna import smash\n",
-    "\n",
-    "# Smash the model\n",
-    "smashed_model = smash(\n",
-    "    model=model,\n",
-    "    smash_config=smash_config,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 4. Preparing the Input"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from torchvision import transforms\n",
-    "\n",
-    "# Generating a random image\n",
-    "image = np.random.randint(0, 256, size=(224, 224, 3)).astype(dtype=np.float32)\n",
-    "input_tensor = transforms.ToTensor()(image).unsqueeze(0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 5. Running the Model\n",
-    "\n",
-    "Finally, run the model to process the image."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Display the result\n",
-    "smashed_model(input_tensor)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Wrap Up\n",
-    "\n",
-    "Congratulations! You have successfully smashed a CV model on CPU. You can now use the `pruna` package to optimize any model on a CPU. The only parts that you should modify are step 1, 4 and 5 to fit your use case"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Pruna",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.13"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 2
 }

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -44,7 +44,7 @@ These tutorials will guide you through the process of using |pruna| to optimize 
       :text-align: center
       :link: ./cv_cpu.ipynb
 
-      ``Compile`` your model with ``torch_compile`` and ``openvino`` for faster inference.
+      ``Compile`` your model with ``torch_compile`` for faster inference.
 
    .. grid-item-card:: Speedup and Quantize any Diffusion Model
       :text-align: center

--- a/src/pruna/algorithms/torch_compile/torch_compile.py
+++ b/src/pruna/algorithms/torch_compile/torch_compile.py
@@ -42,6 +42,10 @@ from pruna.logging.logger import pruna_logger
 torch._dynamo.config.cache_size_limit = 128
 
 
+DEFAULT_BACKEND = "inductor"
+CPU_COMPATIBLE_BACKENDS = ["inductor", "openvino"]
+
+
 class TorchCompile(PrunaAlgorithmBase):
     """
     Implement Torch Compile compilation using torch.compile.
@@ -107,8 +111,8 @@ class TorchCompile(PrunaAlgorithmBase):
             CategoricalHyperparameter(
                 "backend",
                 choices=["inductor", "cudagraphs", "onnxrt", "tvm", "openvino", "openxla"],
-                default_value="inductor",
-                meta={"desc": "Compilation backend."},
+                default_value=DEFAULT_BACKEND,
+                meta={"desc": "Compilation backend. Only inductor (default) and openvino are supported on CPU."},
             ),
             Boolean(
                 "fullgraph",
@@ -267,6 +271,18 @@ def get_model_device(model: Callable[..., Any]) -> torch.device:
     return torch.device("cpu")
 
 
+def _resolve_compile_backend(backend: str, device: str) -> str:
+    """
+    Resolve the torch.compile backend for the target device.
+
+    GPU-only backends are replaced with inductor on CPU.
+    """
+    if device != "cpu" or backend in CPU_COMPATIBLE_BACKENDS:
+        return backend
+    pruna_logger.warning(f"Backend '{backend}' is not supported on CPU; falling back to 'inductor'.")
+    return DEFAULT_BACKEND
+
+
 def compile_callable(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
     """
     Compile a callable model using torch.compile.
@@ -284,9 +300,8 @@ def compile_callable(model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
         The compiled model.
     """
     backend = smash_config["backend"]
-    if smash_config["device"] == "cpu" or str(get_model_device(model)) == "cpu":
-        pruna_logger.info("Compiling for CPU")
-        backend = "openvino"
+    backend = _resolve_compile_backend(backend, smash_config["device"])
+
     if smash_config["target"] == "module_list":
         found_module_list = False
         for name, module in model.named_modules():


### PR DESCRIPTION
## Description
This PR makes inductor the default for torch compile on CPU. Doing this moves away from openvino which fails on some architectures due to some known shape checks in openvino.

With a very quick benchmark of `torchvision.models.vit_b_16` on CPU with both torch 2.11 and 2.12, the compiled model with inductor backend also runs slightly faster than the openvino one (41ms with 0.3ms uncertainty for openvino vs 39ms with 0.2ms uncertainty for inductor, on torch 2.12). Hence this change should not affect performance, or even improve them.


## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes tests/algorithms/test_algorithms.py::test_full_integration[TestTorchCompile_shufflenet-cpu]

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

The tests/algorithms/test_algorithms.py::test_full_integration[TestTorchCompile_shufflenet-cpu] usually only passes because of the retry, which for some reason uses cached states on the second run avoiding the faulty shape assumptions. This can be reproduced with the following bash code that needs to run at the root of the pruna project, with your venv activated:
```
set -euo pipefail

# Should be run from the root of the pruna repository.
if [[ "$(basename "$PWD")" != "pruna" ]]; then
  echo "Error: This script must be run from the 'pruna' directory." >&2
  exit 1
fi
if [[ ! -d "./src/pruna" ]]; then
  echo "Error: './src/pruna' directory does not exist. Are you in the correct directory?" >&2
  exit 1
fi

# Clean up compilation artifacts
USER_TAG="$(whoami | tr '/:*?"<>|\\' '_')"
INDUCTOR_CACHE="${TORCHINDUCTOR_CACHE_DIR:-/tmp/torchinductor_${USER_TAG}}"
rm -rf "$INDUCTOR_CACHE"

# This test fails with a backend error on openvino (something about list index out of range, symbol table,
# or s7 symbol, depending on the torch version).
pytest -o addopts="" tests/algorithms/test_algorithms.py::test_full_integration[TestTorchCompile_shufflenet-cpu]
```

This test reliably fails on main for me with different versions of torch (+cu126 versions), and passes with the torch inductor switch.

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.