### PR TITLE
build: switch back to unsafe-best-match for easy torch install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ url = "https://prunaai.pythonanywhere.com/simple/"
 explicit = true
 
 [tool.uv]
-index-strategy = "first-index"
+index-strategy = "unsafe-best-match"
 
 conflicts = [
     [{ extra = "awq" }, { extra = "vbench" }],


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
This PR re-introduces the "unsafe-best-match" index resolution strategy that was replaced by "first-index" in #613

The reason for this is that torch used to ship some packages on its index. With first-index, uv only see those outdated versions, the first-index, and doesn't look on pypi for newer versions, leading to an unresolvable environment.

The reason for moving away in the first place was to avoid pinging the pythonanywhere index on every public package. However, this was already accomplished by the line "explicit = true" in the same PR. With explicit=true, the python-anywhere index is only checked when explicitely stated, as in `stable-fast-pruna = { index = "pruna_internal", extra = "stable-fast-extraindex" }`.

With the change in this PR, we should be able to run `uv pip install -e .[dev] torch==2.12 torchvision --extra-index-url https://download.pytorch.org/whl/cu126` (currently fails), without pinging the python-anywhere index on every package causing the HTTP errors.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
running `uv pip install -e .[dev] torch==2.12 torchvision --extra-index-url https://download.pytorch.org/whl/cu126` currently fails, but passes after this change.

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.