### PR TITLE
fix: add kernel version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
     "gliner; python_version >= '3.11'",
     "piq",
     "opencv-python",
-    "kernels<=0.14.1",
+    "kernels<=0.14.1", # until transformers compatibility with kernels>=0.15
     "aenum",
     "imageio-ffmpeg",
     "jaxtyping",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
     "gliner; python_version >= '3.11'",
     "piq",
     "opencv-python",
-    "kernels",
+    "kernels<=0.14.1",
     "aenum",
     "imageio-ffmpeg",
     "jaxtyping",

--- a/src/pruna/algorithms/flash_attn3.py
+++ b/src/pruna/algorithms/flash_attn3.py
@@ -166,7 +166,7 @@ class FlashAttn3(PrunaAlgorithmBase):
         Dict[str, Any]
             The algorithm packages.
         """
-        return {"flash_attention_3": get_kernel("kernels-community/flash-attn3")}
+        return {"flash_attention_3": get_kernel("kernels-community/flash-attn3", version=1)}
 
     def _has_backend_api(self, model: Any) -> bool:
         """Check if the model supports the diffusers attention backend API (>= 0.35)."""


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
Transformers (even dev or >=5.0) is not compatible with kernels>=0.15.
It raises the following error in tests:

```py

ImportError while loading conftest '/home/runner/work/prunatree/prunatree/pruna/tests/conftest.py'.
tests/conftest.py:6: in <module>
    from .fixtures import *  # noqa: F403, F401
    ^^^^^^^^^^^^^^^^^^^^^^^
tests/fixtures.py:9: in <module>
    from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoProcessor, AutoTokenizer, pipeline
../.venv/lib/python3.11/site-packages/transformers/utils/import_utils.py:2045: in __getattr__
    module = self._get_module(self._class_to_module[name])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../.venv/lib/python3.11/site-packages/transformers/utils/import_utils.py:2239: in _get_module
    raise e
../.venv/lib/python3.11/site-packages/transformers/utils/import_utils.py:2237: in _get_module
    return importlib.import_module("." + module_name, self.__name__)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../.venv/lib/python3.11/site-packages/transformers/models/auto/processing_auto.py:25: in <module>
    from ...image_processing_utils import ImageProcessingMixin
../.venv/lib/python3.11/site-packages/transformers/image_processing_utils.py:23: in <module>
    from .processing_utils import ImagesKwargs, Unpack
../.venv/lib/python3.11/site-packages/transformers/processing_utils.py:79: in <module>
    from .modeling_utils import PreTrainedAudioTokenizerBase
../.venv/lib/python3.11/site-packages/transformers/modeling_utils.py:73: in <module>
    from .integrations.hub_kernels import is_kernel
../.venv/lib/python3.11/site-packages/transformers/integrations/hub_kernels.py:88: in <module>
    "cuda": LayerRepository(
../.venv/lib/python3.11/site-packages/kernels/layer/layer.py:76: in __init__
    raise ValueError("Either a revision or a version must be specified.")
E   ValueError: Either a revision or a version must be specified.

```
This us due to the kernel version requirement: https://github.com/huggingface/kernels/releases/tag/v0.15.1

To fix it:
- Pin the kernels version until compatibility
- Add the version for following updates

Related in prunatree: https://github.com/PrunaAI/prunatree/pull/470

No fixes btm on HF: https://github.com/huggingface/transformers/issues/46291

<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.