### PR TITLE
style: move type ignore to its correct place

### DIFF
--- a/src/pruna/algorithms/flash_attn3.py
+++ b/src/pruna/algorithms/flash_attn3.py
@@ -268,9 +268,8 @@ def register_custom_backend(imported_packages: Dict[str, Any], use_fp8: bool = F
     enum_key = backend_name.upper()
 
     if enum_key not in attention_backend_name.__members__:
-
         # Pick the right custom op based on use_fp8
-        _ops = torch.ops.flash_attn_pruna  # ty: ignore[invalid-argument-type]
+        _ops = torch.ops.flash_attn_pruna
         _op_fn = _ops._flash_attn_forward_fp8 if use_fp8 else _ops._flash_attn_forward
 
         @attention_backend_registry.register(
@@ -315,9 +314,7 @@ def register_custom_backend(imported_packages: Dict[str, Any], use_fp8: bool = F
                     enable_gqa=enable_gqa,
                 )
             else:
-                out = _op_fn(
-                    q=query, k=key, v=value, softmax_scale=scale, causal=is_causal  # ty: ignore[invalid-argument-type]
-                )
+                out = _op_fn(q=query, k=key, v=value, softmax_scale=scale, causal=is_causal)  # ty: ignore[invalid-argument-type]
                 return out
 
         extend_enum(attention_backend_name, enum_key, backend_name)
@@ -519,7 +516,7 @@ def _quantize_fp8(t: torch.Tensor, descale_shape: Tuple[int, int]) -> Tuple[torc
     """
     amax = t.abs().amax()
     # E4M3 max representable value is 448.0
-    scale = (448.0 / amax.clamp(min=1e-12))
+    scale = 448.0 / amax.clamp(min=1e-12)
     t_fp8 = (t * scale).to(torch.float8_e4m3fn)
     descale = torch.full(descale_shape, 1.0 / scale.item(), dtype=torch.float32, device=t.device)
     return t_fp8, descale
@@ -556,7 +553,9 @@ def register_pruna_flash_attn_op(kernel_mod: Any, use_fp8: bool = False) -> None
             k, descale_k = _quantize_fp8(k, descale_shape)
             v, descale_v = _quantize_fp8(v, descale_shape)
             result = flash_attn_cuda(
-                q, k, v,
+                q,
+                k,
+                v,
                 softmax_scale=softmax_scale or None,
                 causal=causal,
                 deterministic=False,


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
This PR move the ignore comment in flash_attn3 to get rid of the "unused ignore comment" typing error that appeared in #552 because the kernel call was split into multiple lines and the wrong line inherited the ignore comment.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
The typing failed, it now passes.
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.