### PR TITLE
fix: patch torchmetrics (transformers 5)

### DIFF
--- a/src/pruna/algorithms/flash_attn3.py
+++ b/src/pruna/algorithms/flash_attn3.py
@@ -270,7 +270,7 @@ def register_custom_backend(imported_packages: Dict[str, Any], use_fp8: bool = F
     if enum_key not in attention_backend_name.__members__:
 
         # Pick the right custom op based on use_fp8
-        _ops = torch.ops.flash_attn_pruna  # ty: ignore[invalid-argument-type]
+        _ops = torch.ops.flash_attn_pruna
         _op_fn = _ops._flash_attn_forward_fp8 if use_fp8 else _ops._flash_attn_forward
 
         @attention_backend_registry.register(

--- a/src/pruna/evaluation/metrics/metric_pairwise_clip.py
+++ b/src/pruna/evaluation/metrics/metric_pairwise_clip.py
@@ -142,6 +142,11 @@ def _process_image_data(images: Tensor) -> List[Tensor]:
     return list_images
 
 
+def _unwrap_clip_features(features: Any) -> Any:
+    """Unwrap transformers 5 CLIP feature outputs while preserving tensor returns."""
+    return features.pooler_output if hasattr(features, "pooler_output") else features
+
+
 def _get_features(
     data: List[Tensor],
     device: torch.device,
@@ -169,7 +174,7 @@ def _get_features(
     """
     # The processor expects the images to be on the CPU
     processed = processor(images=[i.cpu() for i in data], return_tensors="pt", padding=True)
-    return model.get_image_features(processed["pixel_values"].to(device))
+    return _unwrap_clip_features(model.get_image_features(processed["pixel_values"].to(device)))
 
 
 def _clip_score_update(

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from contextlib import suppress
 from enum import Enum
 from functools import partial
+from importlib import import_module
 from typing import Any, Callable, List, Optional, Union
 
 import torch
@@ -49,6 +50,29 @@ from pruna.evaluation.metrics.utils import (
     metric_data_processor,
 )
 from pruna.logging.logger import pruna_logger
+
+_torchmetrics_clip_score = import_module("torchmetrics.functional.multimodal.clip_score")
+
+
+def _unwrap_clip_features(features: Any) -> Any:
+    """Return the tensor inside Transformers 5 CLIP outputs or the original tensor."""
+    return features.pooler_output if hasattr(features, "pooler_output") else features
+
+
+def _patch_clip_score_feature_outputs() -> None:
+    """Patch TorchMetrics CLIPScore feature extraction for Transformers 5 outputs."""
+    get_features = getattr(_torchmetrics_clip_score, "_get_features", None)
+    if get_features is None or getattr(get_features, "_pruna_unwraps_pooler_output", False):
+        return
+
+    def _get_features_with_pooler_unwrap(*args: Any, **kwargs: Any) -> Any:
+        return _unwrap_clip_features(get_features(*args, **kwargs))
+
+    setattr(_get_features_with_pooler_unwrap, "_pruna_unwraps_pooler_output", True)
+    _torchmetrics_clip_score._get_features = _get_features_with_pooler_unwrap
+
+
+_patch_clip_score_feature_outputs()
 
 
 def default_update(metric: Metric, *args, **kwargs) -> None:

--- a/src/pruna/evaluation/metrics/metric_torch.py
+++ b/src/pruna/evaluation/metrics/metric_torch.py
@@ -69,7 +69,7 @@ def _patch_clip_score_feature_outputs() -> None:
         return _unwrap_clip_features(get_features(*args, **kwargs))
 
     setattr(_get_features_with_pooler_unwrap, "_pruna_unwraps_pooler_output", True)
-    _torchmetrics_clip_score._get_features = _get_features_with_pooler_unwrap
+    setattr(_torchmetrics_clip_score, "_get_features", _get_features_with_pooler_unwrap)
 
 
 _patch_clip_score_feature_outputs()


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

With Transformers 5, it is returned BaseModelOutputWithPooling instead of a tensor. This is a temporary patch so it extracts it if needed.

Related issue and PRs in torchmetrics: https://github.com/Lightning-AI/torchmetrics/issues/3407 and https://github.com/Lightning-AI/torchmetrics/pull/3408


```py
FAILED tests/evaluation/test_torch_metrics.py::test_clip_score[LAION256-cpu] - AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'
FAILED tests/evaluation/test_torch_metrics.py::test_clip_score[LAION256-cuda] - AttributeError: 'BaseModelOutputWithPooling' object has no attribute 'norm'
= 23 failed, 469 passed, 5 skipped, 245 deselected, 211 warnings in 2385.86s (0:39:45) =
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```


## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.