### PR TITLE
fix: update moe tiny model for testing (transformers 5)

### DIFF
--- a/tests/algorithms/testers/moe_kernel_tuner.py
+++ b/tests/algorithms/testers/moe_kernel_tuner.py
@@ -16,7 +16,7 @@ from .base_tester import AlgorithmTesterBase
 class TestMoeKernelTuner(AlgorithmTesterBase):
     """Test the MoeKernelTuner."""
 
-    models = ["qwen_moe_tiny_random"]
+    models = ["tiny_random_qwen_moe"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = MoeKernelTuner

--- a/tests/algorithms/testers/reduce_noe.py
+++ b/tests/algorithms/testers/reduce_noe.py
@@ -6,7 +6,7 @@ from .base_tester import AlgorithmTesterBase
 class TestReduceNOE(AlgorithmTesterBase):
     """Test the ReduceNOE algorithm."""
 
-    models = ["qwen_moe_tiny_random"]
+    models = ["tiny_random_qwen_moe"]
     reject_models = ["sd_tiny_random"]
     allow_pickle_files = False
     algorithm_class = ReduceNOE

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -219,8 +219,8 @@ MODEL_FACTORY: dict[str, Callable] = {
     "wan_tiny_random": partial(get_diffusers_model, "pruna-test/wan-t2v-tiny-random", torch_dtype=torch.bfloat16),
     "flux_tiny": partial(get_diffusers_model, "pruna-test/tiny_flux", torch_dtype=torch.float16),
     "tiny_llama": partial(get_automodel_transformers, "pruna-test/tiny_llama", torch_dtype=torch.bfloat16),
-    "qwen_moe_tiny_random": partial(
-        get_automodel_transformers, "yujiepan/qwen1.5-moe-tiny-random", torch_dtype=torch.bfloat16
+    "tiny_random_qwen_moe": partial(
+        get_automodel_transformers, "peft-internal-testing/tiny-random-qwen-1.5-MoE", torch_dtype=torch.bfloat16
     ),
     "opt_125m": partial(get_automodel_transformers, "facebook/opt-125m", torch_dtype=torch.bfloat16),
 }


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

Current MoE implementation has been modified (https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/moe.py). Now, it seems that some MoE layers expects certain tensor strides to be 16-byte as they're using torch grouped_mm, which makes it stricter.

Previous model has really small dimensions (2-4), producing errors when loading in bf16.

I saw you had already some compatibility issue (https://github.com/PrunaAI/pruna/pull/533). So, not sure which are your thoughts about it.

```py
FAILED tests/algorithms/test_algorithms.py::test_full_integration[TestReduceNOE_qwen_moe_tiny_random-cuda] - RuntimeError: strides should be multiple of 16 bytes
```

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.