### PR TITLE
fix: stop auto decoding for audio datasets

### DIFF
--- a/src/pruna/data/datasets/audio.py
+++ b/src/pruna/data/datasets/audio.py
@@ -15,7 +15,7 @@
 from pathlib import Path
 from typing import Tuple, cast
 
-from datasets import Dataset, IterableDataset, load_dataset
+from datasets import Audio, Dataset, IterableDataset, load_dataset
 from huggingface_hub import snapshot_download
 
 from pruna.data.utils import split_train_into_train_val_test
@@ -39,6 +39,7 @@ def setup_librispeech_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
         The LibriSpeech dataset with explicit audio paths.
     """
     ds = load_dataset("argmaxinc/librispeech-200", split="train", streaming=False)
+    ds = ds.cast_column("audio", Audio(decode=False))
     ds = ds.map(lambda batch: {"sentence": ""})
     ds = cast(Dataset | IterableDataset, ds)
 


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
The LibriSpeech nightly dataset was failing in our nightly workflow. Initially, we suspected the issue was caused by missing or incorrect audio decoding libraries, so we tried to address it from that angle.

After further investigation, we realized the root cause was different: our collate functions expect audio file names as input, not already-decoded audio data. To match this expectation, we disabled automatic decoding for audio files.


## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.