### PR TITLE
test: fix breaking nightly tests for ONEIG dataset

### DIFF
--- a/src/pruna/data/datasets/prompt.py
+++ b/src/pruna/data/datasets/prompt.py
@@ -25,7 +25,6 @@ OneIGCategory = Literal[
     "Anime_Stylization",
     "General_Object",
     "Knowledge_Reasoning",
-    "Multilingualism",
     "Portrait",
     "Text_Rendering",
     "3d rendering",

--- a/tests/data/test_datamodule.py
+++ b/tests/data/test_datamodule.py
@@ -121,13 +121,13 @@ def _benchmarks_with_category() -> list[tuple[str, str]]:
 @pytest.mark.parametrize("dataset_name, category", _benchmarks_with_category())
 def test_benchmark_category_filter(dataset_name: str, category: str) -> None:
     """Test dataset loading with each category filter; dataset has at least one sample."""
-    dm = PrunaDataModule.from_string(dataset_name, category=category, dataloader_args={"batch_size": 4})
+    dm = PrunaDataModule.from_string(dataset_name, category=category, dataloader_args={"batch_size": 3})
     _assert_at_least_one_sample(dm)
     dm.limit_datasets(10)
     batch = next(iter(dm.test_dataloader()))
     prompts, auxiliaries = batch
 
-    assert len(prompts) == 4
+    assert len(prompts) == 3
     assert all(isinstance(p, str) for p in prompts)
 
     def _category_in_aux(aux: dict, cat: str) -> bool:


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
Nine of our nightly tests were failing, all related to OneIG dataset checks.

After investigation, we found that eight of these were not actual failures. The tests were asserting that each category contained four samples, but some of those categories have fewer than four samples in the original dataset. We verified the OneIG dataset directly to confirm that these categories genuinely contain fewer than four samples and that the issue was not caused by a loading error on our side.

The remaining failure was caused by our loaders being unable to find the `Multilingualism` category. This is a real issue. Currently, `multilingualism` is not loaded through `OneIGBench`, but through `OneIGBenchZH`, which also includes Chinese prompts for all other main OneIG categories. We do not currently support this setup.

To enable benchmarking with Chinese prompts, we would need to integrate not only `multilingualism`, but also the other Chinese categories, which would require additional work. For now, I removed `multilingualism` from the list of available categories.


## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.