### PR TITLE
fix: unallocate metric model prior restoring original model

### DIFF
--- a/src/pruna/evaluation/metrics/metric_memory.py
+++ b/src/pruna/evaluation/metrics/metric_memory.py
@@ -185,6 +185,7 @@ class GPUMemoryStats(BaseMetric):
 
             peak_memory = (max(before_sum, load_sum, after_sum) - before_sum) / 1024**2
 
+            del metric_model
             safe_memory_cleanup()
 
         if len(model_device_indices) > 1 and self.device_map is None:


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

Addresses a bug that did not de-reference the metric model before loading back the original model, ultimatelly limiting models under evaluation to 50% GPU VRAM size at most.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
  - Testing this change requires monitoring the GPU memory usage during the run. There are multiple ways - _continuously_ monitoring the GPU utilization or spying on `move_to_device` and capturing the torch allocated memory pre/post every call. The first approach is tedious to setup and overcomplicated (and flaky - the exact threshold will vary based on the model). The second approach ties the tests to the implementation - in case the execution order changes, the test will fail. Thus, I rely on the empirical tests in TL;DR - Investigation.
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

## TL;DR - Investigation

Trying to do disk-memory evaluation on Qwen-Image-2512 on A100 resulted in an unexpected OOM error - the model is approximately 50GB and the GPU has 80GB VRAM. Testing with a smaller model - Flux 1.0 dev (≈32GB) reveals that there is a point in time when two models are on the GPU.

<img width="1072" height="306" alt="image" src="https://github.com/user-attachments/assets/20c3fa88-9a01-4e35-a6c7-198c45a4704a" />

This happened because `metric_model` was still referenced when the `safe_memory_cleanup` was invoked on line 188 pre-change, and thus the memory was not freed before the _original_ model was moved to the GPU again (on line 195 pre-change).

Here is how the GPU VRAM looks post-change.

### black-forest-labs/FLUX.1-dev
<img width="1072" height="306" alt="image" src="https://github.com/user-attachments/assets/13b79f21-a045-4ca2-a191-cfdc885d65e7" />

### Qwen/Qwen-Image-2512
<img width="1072" height="306" alt="image" src="https://github.com/user-attachments/assets/39f8fe54-d342-4084-adf0-c834a5aec7b0" />


---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.