### PR TITLE
build: bump max torchao from 0.16.0 to 0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ dependencies = [
     "bitsandbytes; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "optimum-quanto>=0.2.5",
     "hqq==0.2.7.post1",
-    "torchao>=0.12.0,<0.16.0", # 0.16.0 breaks diffusers 0.36.0, torch+torch: https://github.com/pytorch/ao/issues/2919#issue-3375688762
+    "torchao>=0.12.0,<0.17.0", # breaking namespace change. torch+torchao: https://github.com/pytorch/ao/issues/2919#issue-3375688762
     "gliner; python_version >= '3.11'",
     "piq",
     "opencv-python",


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
Torchao version was pinned to <0.16.0 waiting for diffusers versions to be compatible with the newer versions.
It is now the case, so this PR raises the max version.
The name of the types imported in the torchao algorithm seem to have changed again between 0.16.0 and 0.17.0, creating bugs, so for no the dependency becomes <0.17.0

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.