### PR TITLE
fix: device casting for llama cpp

### DIFF
--- a/src/pruna/engine/utils.py
+++ b/src/pruna/engine/utils.py
@@ -410,7 +410,7 @@ def get_device(model: Any) -> str:
 
     from pruna.engine.pruna_model import PrunaModel
 
-    if safe_is_instance(model, PrunaModel):
+    if isinstance(model, PrunaModel):
         return get_device(model.model)
 
     # function scored import due to model_check's import of ModelContext


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
Nightlies are failing for llama cpp algorithm with 
```
          ValueError: Model and task have different devices. Model: cpu, task: cuda:0. 
E           If you want auto device casting, create the task without providing a device.
```
The model is configured to be on the GPU, so the issue seems to not being able to move a reloaded llama.cpp model to the device that's requested by the user.
I noticed in the `get_device` function in engine/utils, llama.cpp PR introduced this line: 
```
if safe_is_instance(model, PrunaModel):
    return get_device(model.model)
```
My suspicion is that the first if statement will never be true, because safe_is_instance will call PrunaModel.is_instance which already does this check for model.model. 
I am hoping this simple fix will also solve the device casting problem

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.