### PR TITLE
fix: stop audio decoding

### DIFF
--- a/src/pruna/data/datasets/audio.py
+++ b/src/pruna/data/datasets/audio.py
@@ -15,7 +15,7 @@
 from pathlib import Path
 from typing import Tuple, cast
 
-from datasets import Audio, Dataset, IterableDataset, load_dataset
+from datasets import Dataset, IterableDataset
 from huggingface_hub import snapshot_download
 
 from pruna.data.utils import split_train_into_train_val_test
@@ -38,9 +38,12 @@ def setup_librispeech_dataset(seed: int) -> Tuple[Dataset, Dataset, Dataset]:
     Tuple[Dataset, Dataset, Dataset]
         The LibriSpeech dataset with explicit audio paths.
     """
-    ds = load_dataset("argmaxinc/librispeech-200", split="train", streaming=False)
-    ds = ds.cast_column("audio", Audio(decode=False))
-    ds = ds.map(lambda batch: {"sentence": ""})
+    dataset_path = Path(snapshot_download("argmaxinc/librispeech-200", repo_type="dataset", allow_patterns=["*.flac"]))
+    audio_paths = sorted(str(path) for path in dataset_path.rglob("*.flac"))
+    if not audio_paths:
+        raise ValueError("No LibriSpeech audio files were found in the downloaded dataset snapshot.")
+
+    ds = Dataset.from_dict({"audio": [{"path": path} for path in audio_paths], "sentence": [""] * len(audio_paths)})
     ds = cast(Dataset | IterableDataset, ds)
 
     ds_train, ds_val, ds_test = split_train_into_train_val_test(ds, seed)


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->
Librispeech dataset in our nighlies are failing. We already tried to fix it in #686 but the setup for the Librispeech dataset is still trying to encode audio.  This fix attemps to fix that because our audio collate function expects a file path and not an encoded audio file.
## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.