### PR TITLE
fix: switch torch_dynamic and quanto saves to save_before_apply

### DIFF
--- a/src/pruna/algorithms/quanto.py
+++ b/src/pruna/algorithms/quanto.py
@@ -44,7 +44,7 @@ class Quanto(PrunaAlgorithmBase):
     algorithm_name: str = "quanto"
     group_tags: list[tags] = [tags.QUANTIZER]
     references: dict[str, str] = {"GitHub": "https://github.com/huggingface/optimum-quanto"}
-    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.reapply
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
     dataset_required: bool = False

--- a/src/pruna/algorithms/torch_dynamic.py
+++ b/src/pruna/algorithms/torch_dynamic.py
@@ -37,7 +37,7 @@ class TorchDynamic(PrunaAlgorithmBase):
     algorithm_name = "torch_dynamic"
     group_tags: list[tags] = [tags.QUANTIZER]
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.reapply
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.save_before_apply
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/src/pruna/algorithms/torch_dynamic.py
+++ b/src/pruna/algorithms/torch_dynamic.py
@@ -37,7 +37,7 @@ class TorchDynamic(PrunaAlgorithmBase):
     algorithm_name = "torch_dynamic"
     group_tags: list[tags] = [tags.QUANTIZER]
     references: dict[str, str] = {"GitHub": "https://github.com/pytorch/pytorch"}
-    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.pickled
+    save_fn: SAVE_FUNCTIONS = SAVE_FUNCTIONS.reapply
     tokenizer_required: bool = False
     processor_required: bool = False
     runs_on: list[str] = ["cpu", "cuda"]

--- a/tests/algorithms/testers/torch_dynamic.py
+++ b/tests/algorithms/testers/torch_dynamic.py
@@ -6,7 +6,7 @@ from .base_tester import AlgorithmTesterBase
 class TestTorchDynamic(AlgorithmTesterBase):
     """Test the torch dynamic quantizer."""
 
-    models = ["shufflenet"]
+    models = ["shufflenet", "smollm_135m"]
     reject_models = []
     allow_pickle_files = False
     algorithm_class = TorchDynamic


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
In transformers 5, llama architectures are not picklable because of the choice of kernel functions. 
Both quanto and torch_dynamic were facing saving problems, and are switched to save_before_apply to preserve compatibility with (among other) compilation algorithms (compilation algorithms use save_before_apply -> the quantized model's save functions is called -> for quanto or torch_dynamic that would be torch.save -> error).

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [ ] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.