### PR TITLE
fix: file exists on consecutive metric evaluations

### DIFF
--- a/src/pruna/engine/save.py
+++ b/src/pruna/engine/save.py
@@ -309,7 +309,7 @@ def save_before_apply(model: Any, model_path: str | Path, smash_config: SmashCon
         if file.is_file():
             shutil.copy(file, target_path)
         else:
-            shutil.copytree(file, target_path)
+            shutil.copytree(file, target_path, dirs_exist_ok=True)
 
 
 def save_pickled(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:


### PR DESCRIPTION

<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

This change resolves a FileExistsError caused by shutil.copytree when the destination directory already exists.

### TL;DR The Cause

#### Setting
When the model under evaluation is a _complex_ one (i.e., have submodules) such as Qwen-Image-2512, the metrics for each submodule are saved in a nested directory. When the evaluation comprise multiple `GPUMemoryStats` metrics, the `save_pretrained` method is invoked for each metric. When the model is smashed, the particular save function is `SAVE_FUNCTIONS.save_before_apply`.

#### Problem
The `save_before_apply` function distinguishes between files and directories and invokes `shutil.copy` and `shutil.copytree` correspondingly. However, they work differently with their default parameters. While `copy` always writes the file unconditionally (i.e., if there is already one with such a name, it is replaced), `copytree` fails when the directory exists.

[copy documentation](https://docs.python.org/3/library/shutil.html#shutil.copy); relevant
> Copies the file src to the file or directory dst. src and dst should be [path-like objects](https://docs.python.org/3/glossary.html#term-path-like-object) or strings. If dst specifies a directory, the file will be copied into dst using the base filename from src. If dst specifies a file that already exists, it will be replaced. Returns the path to the newly created file.

[copytree documentation](https://docs.python.org/3/library/shutil.html#shutil.copytree); relevant

> If dirs_exist_ok is false (the default) and dst already exists, a [FileExistsError](https://docs.python.org/3/library/exceptions.html#FileExistsError) is raised. If dirs_exist_ok is true, the copying operation will continue if it encounters existing directories, and files within the dst tree will be overwritten by corresponding files from the src tree.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
  - I did empirical tests, successfully running an experiment with a smashed model with DiskMemoryMetric and InferenceMemoryMetric in the same evaluation agent.
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.