### PR TITLE
fix: make CallSequenceTracker unwrap idempotent for bound methods

### DIFF
--- a/src/pruna/engine/call_sequence_tracker.py
+++ b/src/pruna/engine/call_sequence_tracker.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from functools import wraps
-from typing import Any, Dict, List, cast
+from typing import Any, Dict, List
 
 import torch
 
@@ -64,6 +64,9 @@ class CallSequenceTracker:
         module : torch.nn.Module
             The module to wrap.
         """
+        if hasattr(module.forward, "__call_tracker_original_forward__"):
+            return
+
         original_forward = module.forward
 
         @wraps(original_forward)
@@ -93,6 +96,7 @@ class CallSequenceTracker:
 
             return original_forward(*args, **kwargs)
 
+        wrapped_forward.__call_tracker_original_forward__ = original_forward
         module.forward = wrapped_forward
 
     def wrap(self, model: PrunaModel) -> None:
@@ -121,8 +125,9 @@ class CallSequenceTracker:
         torch.nn.Module
             The unwrapped module.
         """
-        if hasattr(module.forward, "__wrapped__"):
-            module.forward = cast(Any, getattr(module.forward, "__wrapped__"))
+        original_forward = getattr(module.forward, "__call_tracker_original_forward__", None)
+        if original_forward is not None:
+            module.forward = original_forward
         return module
 
     def get_call_sequence(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

Fixes a `TypeError` in `CallSequenceTracker` that breaks `total_macs` and `total_params` metrics when the same module’s `forward` is unwrapped more than once.

### Context

`ModelArchitectureStats` wraps all `nn.Module` forwards before a single inference run, records the call sequence, then calls `unwrap()` on each module while computing MACs/params. If a module appears multiple times in the call sequence, `unwrap()` runs on the same module more than once.

### Cause

`unwrap()` previously restored the module's `forward` by checking if the it has the `__wrapped__` attribute. The first unwrap correctly restores the bound method. As this bound method can still expose the `__wrapped__` attribute, a second unwrap then replaces it with the unbound function. Next calls to the model (e.g., to generate an image) then fail with a `TypeError` because `self` is no longer bound.

### Fix

This PR stores the original forward on a dedicated `__call_tracker_original_forward__` attribute, skips re-wrapping modules that are already tracked, and makes `unwrap()` idempotent on multiple calls.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [ ] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`) 

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [ ] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.