### PR TITLE
chore: use safety@pruna.ai for code of conduct reports

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-johanna.sommer@pruna.ai or bertrand.charpentier@pruna.ai.
+reported to the team at safety@pruna.ai.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
Aligns the Code of Conduct enforcement contact with the canonical company email list: safety@pruna.ai handles security, compliance, and privacy reports. Using the role address instead of personal inboxes avoids reports going stale when individuals change roles or leave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)