### PR TITLE
fix: ignore the kwargs the datamodule collate function does not accept

### DIFF
--- a/src/pruna/data/pruna_datamodule.py
+++ b/src/pruna/data/pruna_datamodule.py
@@ -101,6 +101,9 @@ class PrunaDataModule(LightningDataModule):
             pruna_logger.error("Datasets must contain exactly 3 elements: train, validation, and test.")
             raise ValueError()
 
+        # Shallow-copy before injecting tokenizer: avoids mutating the caller's dict and
+        # leaking keys into the shared default from collate_fn_args=dict().
+        collate_fn_args = dict(collate_fn_args)
         if tokenizer is not None:
             collate_fn_args["tokenizer"] = tokenizer
             if "max_seq_len" not in collate_fn_args:
@@ -375,6 +378,11 @@ def get_collate_fn(collate_fn_name: str, collate_fn_args: dict) -> Callable:
 
     if missing_required_params:
         raise ValueError(f"The following required parameters are missing in collate_fn_args: {missing_required_params}")
+
+    # Drop kwargs the collate function does not accept (e.g. tokenizer forwarded for prompt_collate).
+    has_var_keyword = any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values())
+    if not has_var_keyword:  # if the signature does not contain **kwargs
+        collate_fn_args = {k: v for k, v in collate_fn_args.items() if k in signature.parameters}
 
     # Create a partial with the given arguments
     collate_fn = partial(collate_fn, **collate_fn_args)

--- a/tests/config/test_smashconfig_data.py
+++ b/tests/config/test_smashconfig_data.py
@@ -1,6 +1,9 @@
 from typing import Any, Callable
+from unittest.mock import MagicMock
+import inspect
 
 import pytest
+from datasets import Dataset
 
 from pruna import SmashConfig
 from pruna.data.datasets.image import setup_imagenet_dataset
@@ -61,3 +64,40 @@ def test_img_args_override(
         image, _ = next(iter(dataloader))
         assert image.shape[2] == args_override["img_size"]
         assert image.shape[3] == args_override["img_size"]
+
+
+@pytest.mark.cpu
+def test_add_prompt_data_ignores_unrelated_tokenizer() -> None:
+    """Tokenizer on SmashConfig must not break prompt_collate (e.g. after loading a diffusers model)."""
+    ds = Dataset.from_dict({"text": ["a cat", "a dog"]})
+    smash_config = SmashConfig()
+    tokenizer = MagicMock()
+    tokenizer.model_max_length = 77
+    smash_config.tokenizer = tokenizer
+    smash_config.add_data((ds, ds, ds), "prompt_collate")
+    assert smash_config.data is not None
+    prompts, none = next(iter(smash_config.data.train_dataloader(batch_size=2, shuffle=False)))
+    assert sorted(prompts) == ["a cat", "a dog"]
+    assert none is None
+
+
+@pytest.mark.cpu
+def test_from_datasets_does_not_mutate_collate_fn_args() -> None:
+    """from_datasets must copy collate_fn_args before injecting tokenizer."""
+    ds = Dataset.from_dict({"text": ["a cat", "a dog"]})
+    datasets = (ds, ds, ds)
+    tokenizer = MagicMock()
+    tokenizer.model_max_length = 77
+
+    caller_args: dict[str, object] = {}
+    PrunaDataModule.from_datasets(
+        datasets,
+        "text_generation_collate",
+        tokenizer=tokenizer,
+        collate_fn_args=caller_args,
+    )
+
+    assert caller_args == {}
+
+    default_args = inspect.signature(PrunaDataModule.from_datasets).parameters["collate_fn_args"].default
+    assert default_args == {}


### PR DESCRIPTION
<!--
Please fill out the sections below so maintainers can review your PR efficiently.
-->

## Description
<!-- What does this PR do and why? A sentence or two is fine. -->

Fixes a `TypeError` when adding prompt data to `SmashConfig` after a tokenizer is attached. Separately, prevents `from_datasets` to mutate the caller’s `collate_fn_args` or the shared default `dict()`.

## Context
`SmashConfig.add_data()` always forwards `smash_config.tokenizer` into `PrunaDataModule.from_datasets()` / `from_string()` unless used with a `PrunaDataModule` object. A tokenizer is needed for text-generation collates, but collates like `prompt_collate` only accept `(data, column_map=...)`. This often shows up after loading a diffusers model, which leaves a tokenizer on the config while the user adds prompt datasets for evaluation or inference.

## Cause
`get_collate_fn()` passed all of `collate_fn_args` into `partial(collate_fn, **collate_fn_args)`. When `tokenizer` was present but the collate function did not accept it, Python raised `TypeError: got an unexpected keyword argument 'tokenizer'`.

Separately, `from_datasets()` injected `tokenizer` and `max_seq_len` directly into the incoming `collate_fn_args` dict. Because the default is `collate_fn_args=dict()`, Python reuses one shared dict across calls that omit the argument. That mutated either the caller’s dict or the shared default in place, leaking keys (`tokenizer`, `max_seq_len`) into later calls.

## Fix
This PR filters `collate_fn_args` to parameters the collate function actually accepts (unless its signature has `**kwargs`), and shallow-copies `collate_fn_args` before injecting the tokenizer so callers and the default dict are not inadvertently modified.

## Related Issue
<!-- If this PR addresses an existing issue, please link to it here -->
Fixes #(issue number)

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [x] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

Added CPU tests in `tests/config/test_smashconfig_data.py`:
- `test_add_prompt_data_ignores_unrelated_tokenizer`: `prompt_collate` still works when `SmashConfig.tokenizer` is set
- `test_from_datasets_does_not_mutate_collate_fn_args`: caller dict and the default `collate_fn_args` stay empty after tokenizer injection


## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [x] I updated the documentation where necessary

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.