### PR TITLE
feat: add static fp8 quantization algorithm

### DIFF
--- a/src/pruna/algorithms/fastercache.py
+++ b/src/pruna/algorithms/fastercache.py
@@ -58,7 +58,13 @@ class FasterCache(PrunaAlgorithmBase):
     dataset_required: bool = False
     runs_on: list[str] = ["cpu", "cuda", "accelerate"]
     compatible_before: Iterable[str] = [
-        "hqq_diffusers", "diffusers_int8", "sage_attn", "hyper", "padding_pruning", "moe_kernel_tuner",
+        "hqq_diffusers",
+        "diffusers_int8",
+        "sage_attn",
+        "hyper",
+        "padding_pruning",
+        "static_fp8_diffusers",
+        "moe_kernel_tuner",
     ]
     compatible_after: Iterable[str] = ["img2img_denoise", "realesrgan_upscale", "moe_kernel_tuner"]
 

--- a/src/pruna/algorithms/flash_attn3.py
+++ b/src/pruna/algorithms/flash_attn3.py
@@ -58,7 +58,7 @@ class FlashAttn3(PrunaAlgorithmBase):
     processor_required: bool = False
     runs_on: list[str] = ["cuda", "accelerate"]
     dataset_required: bool = False
-    compatible_before: Iterable[str] = ["torchao", "padding_pruning", "moe_kernel_tuner"]
+    compatible_before: Iterable[str] = ["torchao", "padding_pruning", "static_fp8_diffusers", "moe_kernel_tuner"]
     compatible_after: Iterable[str] = ["fora", "torch_compile", "moe_kernel_tuner"]
 
     def model_check_fn(self, model: Any) -> bool:

--- a/src/pruna/algorithms/fora.py
+++ b/src/pruna/algorithms/fora.py
@@ -53,6 +53,7 @@ class FORA(PrunaAlgorithmBase):
         "sage_attn",
         "hyper",
         "padding_pruning",
+        "static_fp8_diffusers",
         "moe_kernel_tuner",
     ]
     compatible_after: Iterable[str] = [

--- a/src/pruna/algorithms/global_utils/quantization/__init__.py
+++ b/src/pruna/algorithms/global_utils/quantization/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/pruna/algorithms/global_utils/quantization/swap_linear.py
+++ b/src/pruna/algorithms/global_utils/quantization/swap_linear.py
@@ -1,0 +1,68 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any, Callable, Dict
+
+import torch
+
+
+def swap_linear(
+    module: torch.nn.Module,
+    quantize_linear_layer_fn: Callable,
+    path: str = "",
+    kwargs: Dict[str, Any] = {},
+) -> None:
+    """
+    Swap one nn.Linear module in the given model with its quantized equivalent.
+
+    This function follows the provided path to the nn.Linear layer and swaps it
+    in place by calling ``quantize_linear_layer_fn``. That callback is responsible
+    for replacing the module and may delete the original linear to free its weights.
+
+    Parameters
+    ----------
+    module : nn.Module
+        The PyTorch module containing the linear layer to swap.
+    quantize_linear_layer_fn : Callable
+        The function to use to quantize the linear layer.
+        It must accept the following arguments in this order:
+        - parent: torch.nn.Module
+        - child_name: str
+        - **kwargs: Any
+    path : str
+        The path in the model hierarchy to find the linear layer to swap.
+    kwargs : Dict[str, Any]
+        The keyword arguments to pass to the quantize_linear_layer_fn.
+
+    Returns
+    -------
+    None
+        This function applies the quantization callback to the linear layer in-place.
+        It does not return anything.
+    """
+    if not path:
+        raise ValueError(f"Unexpected empty path: {path}")
+
+    attributes_to_linear = path.split(".")
+    attributes_to_parent, child_name = attributes_to_linear[:-1], attributes_to_linear[-1]
+
+    # get the submodule containing the linear layer
+    parent = module
+    for attr in attributes_to_parent:
+        parent = getattr(parent, attr)
+
+    # apply the quantization callback to the linear layer
+    child = getattr(parent, child_name)
+    if isinstance(child, torch.nn.Linear):
+        quantize_linear_layer_fn(parent, child_name, **kwargs)

--- a/src/pruna/algorithms/global_utils/quantization/symmetric_scale.py
+++ b/src/pruna/algorithms/global_utils/quantization/symmetric_scale.py
@@ -1,0 +1,57 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import torch
+
+
+def amax_to_scale(amax: torch.Tensor, max_val: float) -> torch.Tensor:
+    """
+    Convert an absolute-max value to a per-tensor quantization scale.
+
+    Parameters
+    ----------
+    amax : torch.Tensor
+        The absolute max value of the tensor to quantize.
+    max_val : float
+        The maximum representable magnitude of the target float dtype.
+
+    Returns
+    -------
+    torch.Tensor
+        The scale to use for quantization.
+    """
+    return (max_val / torch.clamp(amax, min=1e-12)).clamp(max=max_val)
+
+
+def scale_and_clamp(x: torch.Tensor, scale: torch.Tensor, max_val: float) -> torch.Tensor:
+    """
+    Map the input to the range [-max_val, max_val] using the given scale.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        The input to quantize.
+    scale : torch.Tensor
+        The scale to use for quantization.
+    max_val : float
+        The maximum representable magnitude of the target float dtype.
+
+    Returns
+    -------
+    torch.Tensor
+        The scaled input, clamped to ``[-max_val, max_val]``.
+    """
+    return (x * scale).clamp(-max_val, max_val)

--- a/src/pruna/algorithms/global_utils/quantization/symmetric_scale.py
+++ b/src/pruna/algorithms/global_utils/quantization/symmetric_scale.py
@@ -33,7 +33,7 @@ def amax_to_scale(amax: torch.Tensor, max_val: float) -> torch.Tensor:
     torch.Tensor
         The scale to use for quantization.
     """
-    return (max_val / torch.clamp(amax, min=1e-12)).clamp(max=max_val)
+    return (max_val / torch.clamp(amax, min=1e-12))
 
 
 def scale_and_clamp(x: torch.Tensor, scale: torch.Tensor, max_val: float) -> torch.Tensor:

--- a/src/pruna/algorithms/hqq.py
+++ b/src/pruna/algorithms/hqq.py
@@ -65,7 +65,7 @@ class HQQ(PrunaAlgorithmBase):
     compatible_before: Iterable[str] = ["torch_structured", "moe_kernel_tuner"]
     compatible_after: Iterable[str] = ["torch_compile", "sage_attn", "kvpress", "moe_kernel_tuner"]
     disjointly_compatible_before: Iterable[str] = []
-    disjointly_compatible_after: Iterable[str] = ["torchao"]
+    disjointly_compatible_after: Iterable[str] = ["torchao", "static_fp8_diffusers"]
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/hqq_diffusers.py
+++ b/src/pruna/algorithms/hqq_diffusers.py
@@ -77,7 +77,7 @@ class HQQDiffusers(PrunaAlgorithmBase):
         "moe_kernel_tuner",
     ]
     disjointly_compatible_before: Iterable[str] = []
-    disjointly_compatible_after: Iterable[str] = ["torchao"]
+    disjointly_compatible_after: Iterable[str] = ["torchao", "static_fp8_diffusers"]
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/pab.py
+++ b/src/pruna/algorithms/pab.py
@@ -54,7 +54,13 @@ class PAB(PrunaAlgorithmBase):
     dataset_required: bool = False
     runs_on: list[str] = ["cpu", "cuda", "accelerate"]
     compatible_before: Iterable[str] = [
-        "hqq_diffusers", "diffusers_int8", "sage_attn", "hyper", "padding_pruning", "moe_kernel_tuner",
+        "hqq_diffusers",
+        "diffusers_int8",
+        "sage_attn",
+        "hyper",
+        "padding_pruning",
+        "static_fp8_diffusers",
+        "moe_kernel_tuner",
     ]
     compatible_after: Iterable[str] = ["img2img_denoise", "realesrgan_upscale", "moe_kernel_tuner"]
 

--- a/src/pruna/algorithms/padding_pruning.py
+++ b/src/pruna/algorithms/padding_pruning.py
@@ -54,6 +54,7 @@ class PaddingPruner(PrunaAlgorithmBase):
         "torchao",
         "flash_attn3",
         "ring_attn",
+        "static_fp8_diffusers",
         "moe_kernel_tuner",
     ]
 

--- a/src/pruna/algorithms/qkv_diffusers.py
+++ b/src/pruna/algorithms/qkv_diffusers.py
@@ -48,6 +48,7 @@ class QKVFusing(PrunaAlgorithmBase):
         "hqq_diffusers",
         "quanto",
         "torchao",
+        "static_fp8_diffusers",
         "deepcache",
         "fora",
         "torch_compile",

--- a/src/pruna/algorithms/ring_attn/ring.py
+++ b/src/pruna/algorithms/ring_attn/ring.py
@@ -63,6 +63,7 @@ class RingAttn(PrunaAlgorithmBase):
     compatible_before: Iterable[str | AlgorithmTag] = [
         "qkv_diffusers",
         "padding_pruning",
+        "static_fp8_diffusers",
         "moe_kernel_tuner",
     ]
     compatible_after: Iterable[str | AlgorithmTag] = [

--- a/src/pruna/algorithms/static_fp8_diffusers/__init__.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pruna.algorithms.static_fp8_diffusers.static_fp8_diffusers import StaticFp8Diffusers
+
+__all__ = ["StaticFp8Diffusers"]

--- a/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
@@ -203,7 +203,7 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
         if target_modules is None:
             target_modules = self.get_model_dependent_hyperparameter_defaults(model, smash_config)["target_modules"]
             target_modules = cast(TARGET_MODULES_TYPE, target_modules)
-        
+
         target_linear_modules = filter_targeted_modules(
             keep_targeted_fn=lambda module, path: isinstance(module, torch.nn.Linear),
             model=model,

--- a/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
@@ -150,8 +150,10 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
         """
         Provide default `target_modules` using `target_backbone`, excluding sensitive modules.
 
-        Extends the base backbone targets by excluding embedding, norm, lm_head, and proj_out
-        modules which are sensitive to FP8 quantization.
+        Extends the base backbone targets by excluding layers which are sensitive to FP8 quantization,
+        including embedding, norm, lm_head, and proj_out layers. The matching pattern excludes
+        only layers which match the patterns "*embed*", "*norm*", "*lm_head", and "proj_out".
+        For a more precise control, the user should specify a custom matching pattern in the smash config.
 
         Parameters
         ----------
@@ -166,6 +168,7 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
             A dictionary with a "target_modules" key defining which modules should be targeted by default.
         """
         target_modules = target_backbone(model)
+
         proj_out_patterns = ["unet.proj_out", "transformer.proj_out", "proj_out"]
         extra_exclude = ["*embed*", "*norm*", "*lm_head"] + proj_out_patterns
         target_modules["exclude"].extend(extra_exclude)
@@ -200,6 +203,7 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
         if target_modules is None:
             target_modules = self.get_model_dependent_hyperparameter_defaults(model, smash_config)["target_modules"]
             target_modules = cast(TARGET_MODULES_TYPE, target_modules)
+        
         target_linear_modules = filter_targeted_modules(
             keep_targeted_fn=lambda module, path: isinstance(module, torch.nn.Linear),
             model=model,
@@ -235,6 +239,7 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
                     },
                 )
 
+            # Collect the quantized layers in each submodule.
             for submodule in module.modules():
                 if isinstance(submodule, StaticFp8Linear):
                     quantized_layers[id(submodule)] = submodule

--- a/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
@@ -18,11 +18,7 @@ from collections.abc import Iterable
 from typing import Any, cast
 
 import torch
-<<<<<<< HEAD
-from ConfigSpace import Constant, OrdinalHyperparameter
-=======
-from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
->>>>>>> 588fa3e (feat: add static fp8 quantization algorithm)
+from ConfigSpace import CategoricalHyperparameter, OrdinalHyperparameter
 
 from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
 from pruna.algorithms.base.tags import AlgorithmTag

--- a/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
@@ -18,7 +18,11 @@ from collections.abc import Iterable
 from typing import Any, cast
 
 import torch
+<<<<<<< HEAD
 from ConfigSpace import Constant, OrdinalHyperparameter
+=======
+from ConfigSpace import CategoricalHyperparameter, Constant, OrdinalHyperparameter
+>>>>>>> 588fa3e (feat: add static fp8 quantization algorithm)
 
 from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
 from pruna.algorithms.base.tags import AlgorithmTag
@@ -93,14 +97,16 @@ class StaticFp8Diffusers(PrunaAlgorithmBase):
             The hyperparameters.
         """
         return [
-            Constant(
+            CategoricalHyperparameter(
                 "weight_float8_dtype",
-                value="torch.float8_e4m3fn",
+                choices=["torch.float8_e4m3fn", "torch.float8_e5m2"],
+                default_value="torch.float8_e4m3fn",
                 meta={"desc": "The float8 dtype to use for weight quantization."},
             ),
-            Constant(
+            CategoricalHyperparameter(
                 "input_float8_dtype",
-                value="torch.float8_e4m3fn",
+                choices=["torch.float8_e4m3fn", "torch.float8_e5m2"],
+                default_value="torch.float8_e4m3fn",
                 meta={"desc": "The float8 dtype to use for input quantization."},
             ),
             OrdinalHyperparameter(

--- a/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/static_fp8_diffusers.py
@@ -1,0 +1,309 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, cast
+
+import torch
+from ConfigSpace import Constant, OrdinalHyperparameter
+
+from pruna.algorithms.base.pruna_base import PrunaAlgorithmBase
+from pruna.algorithms.base.tags import AlgorithmTag
+from pruna.algorithms.global_utils.quantization.swap_linear import swap_linear
+from pruna.algorithms.static_fp8_diffusers.utils import StaticFp8Linear, quantize_linear_layer_static_fp8
+from pruna.config.smash_config import SmashConfigPrefixWrapper
+from pruna.config.target_modules import (
+    TARGET_MODULES_TYPE,
+    TargetModules,
+    filter_targeted_modules,
+    map_targeted_nn_roots,
+    target_backbone,
+)
+from pruna.engine.load_artifacts import STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME
+from pruna.engine.model_checks import is_diffusers_model
+from pruna.engine.pruna_model import PrunaModel
+from pruna.engine.save import SAVE_FUNCTIONS
+from pruna.engine.utils import safe_memory_cleanup
+from pruna.logging.logger import pruna_logger
+
+
+class StaticFp8Diffusers(PrunaAlgorithmBase):
+    """
+    Static fp8 quantization for diffusion models with calibration over full generations.
+
+    Weights are statically quantized. The input (activation) scales are calibrated
+    by running a few complete noise-to-image generations from a calibration dataset.
+
+    The calibration is motivated by the importance of considering samples across all timesteps \
+    when calibrating the input scales, as highlighted in [Q-Diffusion](https://arxiv.org/abs/2302.04304) \
+    and [Post-training Quantization on Diffusion Models](https://arxiv.org/abs/2211.15736).
+    """
+
+    algorithm_name = "static_fp8_diffusers"
+    group_tags: list[AlgorithmTag] = [AlgorithmTag.QUANTIZER]
+    references: dict[str, str] = {
+        "Q-Diffusion": "https://arxiv.org/abs/2302.04304",
+        "Post-training Quantization on Diffusion Models": "https://arxiv.org/abs/2211.15736"
+    }
+    save_fn = SAVE_FUNCTIONS.save_before_apply
+    tokenizer_required = False
+    processor_required = False
+    runs_on: list[str] = ["cpu", "cuda", "accelerate"]
+    # dataset_required=True is not compatible with the save_before_apply hook,
+    # as the dataset is not stored on save, and thus not available on load.
+    dataset_required = False
+    compatible_before: Iterable[str | AlgorithmTag] = ["padding_pruning", "qkv_diffusers"]
+    compatible_after: Iterable[str | AlgorithmTag] = [
+        "fastercache",
+        "flash_attn3",
+        "fora",
+        "pab",
+        "realesrgan_upscale",
+        "ring_attn",
+        "sage_attn",
+        "torch_compile",
+    ]
+    disjointly_compatible_before: Iterable[str | AlgorithmTag] = [
+        "hqq",
+        "hqq_diffusers",
+        "torchao",
+    ]
+    disjointly_compatible_after: Iterable[str | AlgorithmTag] = []
+
+    def get_hyperparameters(self) -> list:
+        """
+        Configure all algorithm-specific hyperparameters with ConfigSpace.
+
+        Returns
+        -------
+        list
+            The hyperparameters.
+        """
+        return [
+            Constant(
+                "weight_float8_dtype",
+                value="torch.float8_e4m3fn",
+                meta={"desc": "The float8 dtype to use for weight quantization."},
+            ),
+            Constant(
+                "input_float8_dtype",
+                value="torch.float8_e4m3fn",
+                meta={"desc": "The float8 dtype to use for input quantization."},
+            ),
+            OrdinalHyperparameter(
+                "calibration_batches",
+                sequence=list(range(1, 65)),
+                default_value=4,
+                meta={
+                    "desc": (
+                        "How many batches to use for calibrating the static input scales. Default is 4."
+                        "The smash config `batch_size` is used. Default is 1."
+                        "Samples are drawn from the dataset attached to the SmashConfig via `add_data`."
+                    )
+                },
+            ),
+            TargetModules(
+                "target_modules",
+                default_value=None,
+                meta={
+                    "desc": (
+                        "Precise choices of which modules to quantize, "
+                        "e.g. {include: ['transformer.*']} to quantize only the transformer in a diffusion pipeline. "
+                        f"See the {TargetModules.documentation_name_with_link} documentation for more details."
+                    )
+                },
+            ),
+        ]
+
+    def model_check_fn(self, model: Any) -> bool:
+        """
+        Check whether the algorithm is compatible with a model.
+
+        Parameters
+        ----------
+        model : Any
+            The model to check.
+
+        Returns
+        -------
+        bool
+            Whether the algorithm is compatible with the model.
+        """
+        return is_diffusers_model(model)
+
+    def get_model_dependent_hyperparameter_defaults(
+        self, model: Any, smash_config: SmashConfigPrefixWrapper
+    ) -> dict[str, Any]:
+        """
+        Provide default `target_modules` using `target_backbone`, excluding sensitive modules.
+
+        Extends the base backbone targets by excluding embedding, norm, lm_head, and proj_out
+        modules which are sensitive to FP8 quantization.
+
+        Parameters
+        ----------
+        model : Any
+            The model to derive defaults from.
+        smash_config : SmashConfigPrefixWrapper
+            The algorithm-prefixed configuration.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary with a "target_modules" key defining which modules should be targeted by default.
+        """
+        target_modules = target_backbone(model)
+        proj_out_patterns = ["unet.proj_out", "transformer.proj_out", "proj_out"]
+        extra_exclude = ["*embed*", "*norm*", "*lm_head"] + proj_out_patterns
+        target_modules["exclude"].extend(extra_exclude)
+        return {"target_modules": target_modules}
+
+    def _apply(self, model: Any, smash_config: SmashConfigPrefixWrapper) -> Any:
+        """
+        Quantize the model and calibrate the static activation scales before compilation.
+
+        Parameters
+        ----------
+        model : Any
+            The model to quantize.
+        smash_config : SmashConfigPrefixWrapper
+            The configuration for the quantization.
+
+        Returns
+        -------
+        Any
+            The quantized, calibrated model.
+        """
+        weight_float8_dtype = (
+            torch.float8_e4m3fn if smash_config["weight_float8_dtype"] == "torch.float8_e4m3fn" else torch.float8_e5m2
+        )
+        input_float8_dtype = (
+            torch.float8_e4m3fn if smash_config["input_float8_dtype"] == "torch.float8_e4m3fn" else torch.float8_e5m2
+        )
+
+        quantized_layers: dict[int, StaticFp8Linear] = {}
+
+        target_modules: None | TARGET_MODULES_TYPE = smash_config["target_modules"]
+        if target_modules is None:
+            target_modules = self.get_model_dependent_hyperparameter_defaults(model, smash_config)["target_modules"]
+            target_modules = cast(TARGET_MODULES_TYPE, target_modules)
+        target_linear_modules = filter_targeted_modules(
+            keep_targeted_fn=lambda module, path: isinstance(module, torch.nn.Linear),
+            model=model,
+            target_modules=target_modules,
+        )
+
+        def quantize_nn_module(attr_name: str | None, module: torch.nn.Module, subpaths: list[str]) -> Any:
+            """
+            Apply static fp8 quantization to a nn.Module.
+
+            Parameters
+            ----------
+            attr_name : str | None
+                The name of the attribute in the model pointing to the nn.Module to quantize.
+            module : torch.nn.Module
+                The nn.Module to quantize.
+            subpaths : list[str]
+                The subpaths of the module to quantize.
+
+            Returns
+            -------
+            torch.nn.Module
+                The quantized nn.Module.
+            """
+            for subpath in subpaths:
+                swap_linear(
+                    module,
+                    quantize_linear_layer_fn=quantize_linear_layer_static_fp8,
+                    path=subpath,
+                    kwargs={
+                        "weight_float8_dtype": weight_float8_dtype,
+                        "input_float8_dtype": input_float8_dtype,
+                    },
+                )
+
+            for submodule in module.modules():
+                if isinstance(submodule, StaticFp8Linear):
+                    quantized_layers[id(submodule)] = submodule
+
+            return module
+
+        model = map_targeted_nn_roots(quantize_nn_module, model, target_linear_modules)
+
+        # Persist the calibrated activation scales such that loading
+        # restores them instead of re-running calibration runs.
+        if STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME not in smash_config.save_artifacts_fns:
+            smash_config.save_artifacts_fns.append(STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME)
+
+        # On load, the sidecar (loaded after this reapply) restores the frozen scales, so calibration is skipped.
+        is_loading = STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME in smash_config.load_artifacts_fns
+        if is_loading:
+            pruna_logger.info("Loading static_fp8_diffusers. Skipping calibration. Scales restored from artifacts.")
+        elif smash_config.data is None:
+            raise ValueError("static_fp8_diffusers requires a calibration dataset to fix the static input scales, "
+                             "but no data is attached to the SmashConfig (use `smash_config.add_data(...)`).")
+        else:
+            self._calibrate(
+                model, list(quantized_layers.values()), smash_config
+            )
+
+        safe_memory_cleanup()
+        return model
+
+    @staticmethod
+    def _calibrate(
+        model: Any,
+        layers: list[StaticFp8Linear],
+        smash_config: SmashConfigPrefixWrapper,
+    ) -> None:
+        """
+        Calibrate the static activation scales over complete noise-to-image generations.
+
+        Do up to ``smash_config["calibration_batches"]`` noise-to-image batch generations using samples drawn from
+        the validation dataloader of the dataset attached to the SmashConfig via ``add_data``.
+
+        Parameters
+        ----------
+        model : Any
+            The quantized pipeline to run calibration generations on.
+        layers : list[StaticFp8Linear]
+            The quantized layers to finalize once calibration completes.
+        smash_config : SmashConfigPrefixWrapper
+            The configuration providing the calibration data and metadata.
+        """
+        pruna_model = PrunaModel(model)
+        calibration_batches = int(smash_config["calibration_batches"])
+
+        batch_count = 0
+        with torch.no_grad():
+            for batch in smash_config.val_dataloader():
+                pruna_model.run_inference(batch)
+                batch_count += 1
+                if batch_count == calibration_batches:
+                    break
+            else:
+                if batch_count == 0:
+                    raise ValueError("Calibration dataset does not contain any batches.")
+                pruna_logger.warning(
+                    "Calibration dataset does not contain as many batches as requested. "
+                    f"Only {batch_count} batches were used."
+                )
+
+        for layer in layers:
+            layer.freeze_input_scale()
+
+        pruna_logger.info(f"static_fp8_diffusers calibrated over {batch_count} batch(es).")
+        del pruna_model

--- a/src/pruna/algorithms/static_fp8_diffusers/utils.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/utils.py
@@ -1,0 +1,245 @@
+# Copyright 2025 - Pruna AI GmbH. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as f
+
+from pruna.algorithms.global_utils.quantization.symmetric_scale import amax_to_scale, scale_and_clamp
+
+
+class StaticFp8Linear(torch.nn.Module):
+    """
+    Linear layer with static fp8 weight and activation quantization.
+
+    Based on the ``F8Linear`` class from https://github.com/aredden/flux-fp8-api, but with a
+    two-phase design coordinated by a boolean flag and tailored to the pruna squash framework.
+
+    - Calibration phase - While ``input_initialized`` is False, the input is not quantized.
+      The layer computes a high-precision output and accumulates a running ``amax`` over the input activations.
+    - Inference - When ``input_initialized`` is True (i.e., after a ``freeze_input_scale`` call), the input scale
+      is frozen and the layer uses the fast ``torch._scaled_mm`` fp8 matrix multiplication.
+
+    Parameters
+    ----------
+    in_features : int
+        The number of input features.
+    out_features : int
+        The number of output features.
+    bias : bool, optional
+        Whether to use bias.
+    device : torch.device, optional
+        The device to use.
+    dtype : torch.dtype, optional
+        The dtype to use for the weight and bias.
+    weight_float8_dtype : torch.dtype, optional
+        The float8 dtype to use for quantizing the weight.
+    weight_float_data : torch.Tensor, optional
+        The weight to use in ``dtype`` float. If None, a new, zero weight is initialized.
+    bias_float_data : torch.Tensor, optional
+        The bias to use in ``dtype`` float. If None, a new, zero bias is initialized.
+    input_float8_dtype : torch.dtype, optional
+        The float8 dtype to use for quantizing the input.
+    """
+
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        bias: bool = True,
+        device=None,
+        dtype=torch.float16,
+        weight_float8_dtype=torch.float8_e4m3fn,
+        weight_float_data: Optional[torch.Tensor] = None,
+        bias_float_data: Optional[torch.Tensor] = None,
+        input_float8_dtype=torch.float8_e5m2,
+    ) -> None:
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight_float8_dtype = weight_float8_dtype
+        self.input_float8_dtype = input_float8_dtype
+        self.weight_initialized = False
+        self.input_initialized = False
+        self.weight_max_value = torch.finfo(self.weight_float8_dtype).max
+        self.input_max_value = torch.finfo(self.input_float8_dtype).max
+        factory_kwargs = {"dtype": dtype, "device": device}
+        if weight_float_data is None:
+            self.weight = torch.nn.Parameter(torch.empty((out_features, in_features), **factory_kwargs))
+        else:
+            self.weight = torch.nn.Parameter(weight_float_data, requires_grad=weight_float_data.requires_grad)
+        if bias_float_data is None:
+            if bias:
+                self.bias = torch.nn.Parameter(torch.empty(out_features, **factory_kwargs))
+            else:
+                self.register_parameter("bias", None)
+        else:
+            self.bias = torch.nn.Parameter(bias_float_data, requires_grad=bias_float_data.requires_grad)
+        self.register_buffer("input_running_amax", torch.tensor(0.0, device=device, dtype=torch.float32))
+        self.register_buffer("weight_scale", torch.tensor(1.0, device=device, dtype=torch.float32))
+        self.register_buffer("weight_scale_reciprocal", torch.tensor(1.0, device=device, dtype=torch.float32))
+        self.register_buffer("weight_float8_data", None)
+        self.register_buffer("input_scale", torch.tensor(1.0, device=device, dtype=torch.float32))
+        self.register_buffer("input_scale_reciprocal", torch.tensor(1.0, device=device, dtype=torch.float32))
+
+    def quantize_weight(self) -> None:
+        """Quantize the weight of the linear layer (static, no calibration required)."""
+        if self.weight_initialized:
+            return
+        amax = torch.max(torch.abs(self.weight.data)).float()
+
+        self.weight_scale = amax_to_scale(amax, self.weight_max_value)
+        self.weight_scale_reciprocal = self.weight_scale.reciprocal()
+        self.weight_float8_data = (
+            scale_and_clamp(self.weight.data, self.weight_scale, self.weight_max_value).to(
+                self.weight_float8_dtype
+            )
+        )
+
+        self.weight.data = torch.zeros(1, dtype=self.weight.dtype, device=self.weight.device, requires_grad=False)
+        self.weight_initialized = True
+
+    def _dequantized_weight(self, dtype: torch.dtype) -> torch.Tensor:
+        """Reconstruct the (lossy) high-precision weight from its fp8 representation and cast to ``dtype``."""
+        return (self.weight_float8_data.to(torch.float32) * self.weight_scale_reciprocal).to(dtype)
+
+    def freeze_input_scale(self) -> None:
+        """Freeze the input scale from the accumulated statistics and switch to quantized mode."""
+        if self.input_initialized:
+            return
+        self.input_scale = amax_to_scale(self.input_running_amax, self.input_max_value)
+        self.input_scale_reciprocal = self.input_scale.reciprocal()
+        self.input_initialized = True
+
+    def _calibration_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Gather input statistics without quantizing the input and return a high-precision output."""
+        amax = torch.max(torch.abs(x)).to(torch.float32)
+        self.input_running_amax = torch.maximum(self.input_running_amax, amax)
+        weight = self._dequantized_weight(x.dtype)
+        return f.linear(x, weight, self.bias)
+
+    def _quantized_forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Fast fp8 forward pass using the frozen input scale."""
+        x = scale_and_clamp(x, self.input_scale, self.input_max_value).to(self.input_float8_dtype)
+
+        prev_dims = x.shape[:-1]
+        x = x.reshape(-1, self.in_features)
+
+        # torch._scaled_mm requires column-major weight matrix ((1, K) stride),
+        # which .T produces using a view (i.e., no memory changes)
+        out = torch._scaled_mm(
+            x,
+            self.weight_float8_data.T,
+            scale_a=self.input_scale_reciprocal,
+            scale_b=self.weight_scale_reciprocal,
+            bias=self.bias,
+            out_dtype=self.weight.dtype,
+            use_fast_accum=True,
+        )
+        out = out.reshape(*prev_dims, self.out_features)
+        return out
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Run the forward pass.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            The input to the linear layer.
+
+        Returns
+        -------
+        torch.Tensor
+            The output of the linear layer.
+        """
+        if not self.input_initialized:
+            return self._calibration_forward(x)
+        return self._quantized_forward(x)
+
+    @classmethod
+    def from_linear(
+        cls,
+        linear: torch.nn.Linear,
+        weight_float8_dtype=torch.float8_e4m3fn,
+        input_float8_dtype=torch.float8_e5m2,
+    ) -> "StaticFp8Linear":
+        """
+        Create a new StaticFp8Linear instance from a nn.Linear instance.
+
+        Parameters
+        ----------
+        linear : torch.nn.Linear
+            The linear layer to convert to StaticFp8Linear.
+        weight_float8_dtype : torch.dtype
+            The float8 dtype to use for weight quantization.
+        input_float8_dtype : torch.dtype
+            The float8 dtype to use for input quantization.
+
+        Returns
+        -------
+        StaticFp8Linear
+            The new StaticFp8Linear instance.
+        """
+        f8_lin = cls(
+            in_features=linear.in_features,
+            out_features=linear.out_features,
+            bias=linear.bias is not None,
+            device=linear.weight.device,
+            dtype=linear.weight.dtype,
+            weight_float8_dtype=weight_float8_dtype,
+            weight_float_data=linear.weight.data,
+            bias_float_data=(linear.bias.data if linear.bias is not None else None),
+            input_float8_dtype=input_float8_dtype,
+        )
+        f8_lin.quantize_weight()
+        return f8_lin
+
+
+def quantize_linear_layer_static_fp8(
+    parent: torch.nn.Module,
+    child_name: str,
+    weight_float8_dtype: torch.dtype,
+    input_float8_dtype: torch.dtype,
+) -> None:
+    """
+    Quantize a linear layer with static fp8 quantization.
+
+    Parameters
+    ----------
+    parent : torch.nn.Module
+        The parent module of the linear layer.
+    child_name : str
+        The name of the linear layer.
+    weight_float8_dtype : torch.dtype
+        The float8 dtype to use for weight quantization.
+    input_float8_dtype : torch.dtype
+        The float8 dtype to use for input quantization.
+
+    Returns
+    -------
+    None
+        This function modifies the model in-place and does not return anything.
+    """
+    child = getattr(parent, child_name)
+    quantized_linear = StaticFp8Linear.from_linear(
+        child,
+        weight_float8_dtype=weight_float8_dtype,
+        input_float8_dtype=input_float8_dtype,
+    )
+    setattr(parent, child_name, quantized_linear)
+    del child

--- a/src/pruna/algorithms/static_fp8_diffusers/utils.py
+++ b/src/pruna/algorithms/static_fp8_diffusers/utils.py
@@ -66,7 +66,7 @@ class StaticFp8Linear(torch.nn.Module):
         weight_float8_dtype=torch.float8_e4m3fn,
         weight_float_data: Optional[torch.Tensor] = None,
         bias_float_data: Optional[torch.Tensor] = None,
-        input_float8_dtype=torch.float8_e5m2,
+        input_float8_dtype=torch.float8_e4m3fn,
     ) -> None:
         super().__init__()
         self.in_features = in_features
@@ -175,8 +175,9 @@ class StaticFp8Linear(torch.nn.Module):
     def from_linear(
         cls,
         linear: torch.nn.Linear,
+        *,
         weight_float8_dtype=torch.float8_e4m3fn,
-        input_float8_dtype=torch.float8_e5m2,
+        input_float8_dtype=torch.float8_e4m3fn,
     ) -> "StaticFp8Linear":
         """
         Create a new StaticFp8Linear instance from a nn.Linear instance.

--- a/src/pruna/algorithms/torch_compile/torch_compile.py
+++ b/src/pruna/algorithms/torch_compile/torch_compile.py
@@ -89,6 +89,7 @@ class TorchCompile(PrunaAlgorithmBase):
         "text_to_text_lora",
         "text_to_text_perp",
         "moe_kernel_tuner",
+        "static_fp8_diffusers",
     ]
     compatible_after: Iterable[str] = ["img2img_denoise", "realesrgan_upscale", "moe_kernel_tuner"]
 

--- a/src/pruna/algorithms/torchao.py
+++ b/src/pruna/algorithms/torchao.py
@@ -105,7 +105,7 @@ class Torchao(PrunaAlgorithmBase):
         "moe_kernel_tuner",
     ]
     disjointly_compatible_before: Iterable[str] = ["hqq", "hqq_diffusers"]
-    disjointly_compatible_after: Iterable[str] = []
+    disjointly_compatible_after: Iterable[str] = ["static_fp8_diffusers"]
 
     def get_hyperparameters(self) -> list:
         """

--- a/src/pruna/algorithms/upscale.py
+++ b/src/pruna/algorithms/upscale.py
@@ -79,6 +79,7 @@ class RealESRGAN(PrunaAlgorithmBase):
         "qkv_diffusers",
         "ring_attn",
         "hyper",
+        "static_fp8_diffusers",
     ]
     required_install: str = "``pip install pruna[upscale]``"
 

--- a/src/pruna/engine/load_artifacts.py
+++ b/src/pruna/engine/load_artifacts.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from enum import Enum
 
 try:
@@ -25,9 +26,95 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from safetensors.torch import load_file
 
 from pruna.config.smash_config import SmashConfig
+from pruna.engine.utils import get_nn_modules
 from pruna.logging.logger import pruna_logger
+
+STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME = "static_fp8_diffusers_artifacts"
+STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME = "static_fp8_diffusers_artifacts.safetensors"
+# Calibrated activation state to persist. Weight-side buffers are re-derived deterministically
+# from the float weights during resmash, so they are intentionally not saved here.
+STATIC_FP8_DIFFUSERS_ARTIFACT_ATTRS = ("input_running_amax",)
+
+
+def module_path_prefix(module_name: str | None, submodule_name: str | None) -> str:
+    """
+    Get the dotted key prefix for a (root, submodule) pair, with a trailing dot.
+
+    Used symmetrically by save and load so that state-dict keys line up. The root
+    name is ``None`` for a bare ``nn.Module`` and the component attribute name for a
+    pipeline. The submodule name is ``""`` for the root module itself.
+
+    Parameters
+    ----------
+    module_name : str | None
+        The name of the top-level module.
+    submodule_name : str | None
+        The name of the submodule.
+
+    Returns
+    -------
+    str
+        The path prefix ending with a trailing dot, or an empty string if both names are None.
+    """
+    if module_name is None and submodule_name is None:
+        return ""
+    elif module_name is None:
+        return f"{submodule_name}."
+    elif not submodule_name:
+        return f"{module_name}."
+    else:
+        return f"{module_name}.{submodule_name}."
+
+
+def iter_typed_linears(model: Any, linear_cls: type) -> Iterator[tuple[str, Any]]:
+    """
+    Yield ``(key_prefix, module)`` for every module of ``linear_cls`` in the model (pipeline-aware).
+
+    Parameters
+    ----------
+    model : Any
+        The model (bare nn.Module or diffusers pipeline) to walk.
+    linear_cls : type
+        The linear module class to match (e.g. ``StaticFp8Linear``).
+
+    Yields
+    ------
+    tuple[str, Any]
+        The dotted key prefix and the matching linear module found at that path.
+    """
+    nn_modules: dict[str | None, torch.nn.Module]
+    try:
+        nn_modules = model.get_nn_modules()
+    except AttributeError:
+        nn_modules = get_nn_modules(model)
+
+    for root_name, root in nn_modules.items():
+        for submodule_name, submodule in root.named_modules():
+            if isinstance(submodule, linear_cls):
+                yield module_path_prefix(root_name, submodule_name), submodule
+
+
+def iter_static_fp8_linears(model: Any) -> Iterator[tuple[str, Any]]:
+    """
+    Yield ``(key_prefix, module)`` for every ``StaticFp8Linear`` in the model (pipeline-aware).
+
+    Parameters
+    ----------
+    model : Any
+        The model (bare nn.Module or diffusers pipeline) to walk.
+
+    Yields
+    ------
+    tuple[str, Any]
+        The dotted key prefix and the ``StaticFp8Linear`` module found at that path.
+    """
+    # Local import to avoid importing the algorithm package unless artifacts are used.
+    from pruna.algorithms.static_fp8_diffusers.utils import StaticFp8Linear
+
+    yield from iter_typed_linears(model, StaticFp8Linear)
 
 
 def load_artifacts(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
@@ -152,6 +239,63 @@ def load_moe_kernel_tuner_artifacts(model: Any, model_path: str | Path, smash_co
         )
 
 
+def load_static_fp8_diffusers_artifacts(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
+    """
+    Restore calibrated activation scales saved by ``save_static_fp8_diffusers_artifacts``.
+
+    Parameters
+    ----------
+    model : Any
+        The freshly re-quantized model whose activation scales should be restored.
+    model_path : str | Path
+        Directory the artifacts file is read from.
+    smash_config : SmashConfig
+        The SmashConfig (unused, kept for the artifact-loader signature).
+
+    Returns
+    -------
+    None
+        The function restores the activation scales in-place and does not return anything.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the artifacts file is missing (calibration was skipped during load).
+    ValueError
+        If the artifacts file is incomplete for one or more quantized layers.
+    """
+    artifacts_path = Path(model_path) / STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME
+    if not artifacts_path.exists():
+        raise FileNotFoundError(
+            f"static_fp8_diffusers artifacts expected at '{artifacts_path}' but not found."
+        )
+
+    state_dict = load_file(str(artifacts_path))
+    layers = list(iter_static_fp8_linears(model))
+    if not layers:
+        raise ValueError("No static_fp8_diffusers quantized layers found in the model.")
+
+    missing_layers: list[str] = []
+    for prefix, layer in layers:
+        if any(f"{prefix}{attr}" not in state_dict for attr in STATIC_FP8_DIFFUSERS_ARTIFACT_ATTRS):
+            missing_layers.append(prefix or "<root>")
+            continue
+
+        for attr in STATIC_FP8_DIFFUSERS_ARTIFACT_ATTRS:
+            buffer = getattr(layer, attr)
+            setattr(layer, attr, state_dict[f"{prefix}{attr}"].to(device=buffer.device, dtype=buffer.dtype))
+
+        layer.freeze_input_scale()
+
+    if missing_layers:
+        raise ValueError(
+            "static_fp8_diffusers artifacts are incomplete."
+            "To use this artifact, exclude the following modules: " + ", ".join(missing_layers)
+        )
+
+    pruna_logger.info(f"Loaded static_fp8_diffusers artifacts from '{artifacts_path}'")
+
+
 class LOAD_ARTIFACTS_FUNCTIONS(Enum):  # noqa: N801
     """
     Enumeration of *artifact* load functions.
@@ -188,6 +332,7 @@ class LOAD_ARTIFACTS_FUNCTIONS(Enum):  # noqa: N801
 
     torch_artifacts = member(load_torch_artifacts)
     moe_kernel_tuner_artifacts = member(load_moe_kernel_tuner_artifacts)
+    static_fp8_diffusers_artifacts = member(load_static_fp8_diffusers_artifacts)
 
     def __call__(self, *args, **kwargs) -> None:
         """Call the underlying load function."""

--- a/src/pruna/engine/save_artifacts.py
+++ b/src/pruna/engine/save_artifacts.py
@@ -23,9 +23,16 @@ from pathlib import Path
 from typing import Any
 
 import torch
+from safetensors.torch import save_file
 
 from pruna.config.smash_config import SmashConfig
-from pruna.engine.load_artifacts import LOAD_ARTIFACTS_FUNCTIONS
+from pruna.engine.load_artifacts import (
+    LOAD_ARTIFACTS_FUNCTIONS,
+    STATIC_FP8_DIFFUSERS_ARTIFACT_ATTRS,
+    STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME,
+    STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME,
+    iter_typed_linears,
+)
 from pruna.logging.logger import pruna_logger
 
 
@@ -118,6 +125,73 @@ def save_moe_kernel_tuner_artifacts(model: Any, model_path: str | Path, smash_co
     smash_config.load_artifacts_fns.append(LOAD_ARTIFACTS_FUNCTIONS.moe_kernel_tuner_artifacts.name)
 
 
+def save_module_attr_artifacts(
+    model: Any,
+    model_path: str | Path,
+    smash_config: SmashConfig,
+    *,
+    linear_cls: type,
+    attrs: tuple[str, ...],
+    filename: str,
+    load_fn_name: str,
+) -> None:
+    """
+    Save named module attributes for all ``linear_cls`` modules to a safetensors file.
+
+    Parameters
+    ----------
+    model : Any
+        The model whose matching linear modules should be exported.
+    model_path : str | Path
+        Directory where the artifacts safetensors file will be written.
+    smash_config : SmashConfig
+        The SmashConfig whose ``load_artifacts_fns`` list will be updated with
+        ``load_fn_name`` so the artifacts are restored on load.
+    linear_cls : type
+        The linear module class to match (e.g. ``StaticFp8Linear``).
+    attrs : tuple[str, ...]
+        Buffer or tensor attribute names to persist for each matched module.
+    filename : str
+        Basename of the safetensors file written under ``model_path``.
+    load_fn_name : str
+        Name of the corresponding load-artifacts function to append to
+        ``smash_config.load_artifacts_fns``.
+    """
+    state_dict = {}
+    for prefix, layer in iter_typed_linears(model, linear_cls):
+        for attr in attrs:
+            state_dict[f"{prefix}{attr}"] = getattr(layer, attr)
+
+    save_file(state_dict, str(Path(model_path) / filename))
+    smash_config.load_artifacts_fns.append(load_fn_name)
+
+
+def save_static_fp8_diffusers_artifacts(model: Any, model_path: str | Path, smash_config: SmashConfig) -> None:
+    """
+    Save calibrated activation scales for all ``StaticFp8Linear`` modules.
+
+    Parameters
+    ----------
+    model : Any
+        The quantized model whose activation calibration state should be exported.
+    model_path : str | Path
+        Directory where the artifacts file is written.
+    smash_config : SmashConfig
+        The SmashConfig whose ``load_artifacts_fns`` is updated such that the artifacts are loaded.
+    """
+    from pruna.algorithms.static_fp8_diffusers.utils import StaticFp8Linear
+
+    save_module_attr_artifacts(
+        model,
+        model_path,
+        smash_config,
+        linear_cls=StaticFp8Linear,
+        attrs=STATIC_FP8_DIFFUSERS_ARTIFACT_ATTRS,
+        filename=STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME,
+        load_fn_name=STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME,
+    )
+
+
 class SAVE_ARTIFACTS_FUNCTIONS(Enum):  # noqa: N801
     """
     Enumeration of *artifact* save functions.
@@ -154,6 +228,7 @@ class SAVE_ARTIFACTS_FUNCTIONS(Enum):  # noqa: N801
 
     torch_artifacts = member(save_torch_artifacts)
     moe_kernel_tuner_artifacts = member(save_moe_kernel_tuner_artifacts)
+    static_fp8_diffusers_artifacts = member(save_static_fp8_diffusers_artifacts)
 
     def __call__(self, *args, **kwargs) -> None:
         """

--- a/tests/algorithms/test_quantization_utils.py
+++ b/tests/algorithms/test_quantization_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from pruna.algorithms.global_utils.quantization.swap_linear import swap_linear
+from pruna.algorithms.global_utils.quantization.symmetric_scale import amax_to_scale, scale_and_clamp
+
+
+class _IdentityReplacement(torch.nn.Module):
+    """Stand-in module used to detect that a linear layer was swapped."""
+
+    def __init__(self, tag: str) -> None:
+        super().__init__()
+        self.tag = tag
+
+
+def _replace_linear_with_identity(parent: torch.nn.Module, child_name: str, tag: str = "swapped") -> None:
+    """Quantize callback that replaces a child with ``_IdentityReplacement``."""
+    setattr(parent, child_name, _IdentityReplacement(tag))
+
+
+@pytest.mark.cpu
+def test_swap_linear_replaces_nested_linear() -> None:
+    """Test that ``swap_linear`` follows a dotted path and applies the callback in place."""
+    model = torch.nn.Sequential(torch.nn.Sequential(torch.nn.Linear(2, 3), torch.nn.ReLU()))
+
+    swap_linear(model, _replace_linear_with_identity, path="0.0", kwargs={"tag": "inner"})
+
+    replacement = model[0][0]
+    assert isinstance(replacement, _IdentityReplacement)
+    assert replacement.tag == "inner"
+    assert isinstance(model[0][1], torch.nn.ReLU)
+
+
+@pytest.mark.cpu
+def test_swap_linear_skips_non_linear_child() -> None:
+    """Test that ``swap_linear`` does not call the callback when the path is not an ``nn.Linear``."""
+    model = torch.nn.Sequential(torch.nn.ReLU(), torch.nn.Linear(2, 2))
+    calls: list[tuple[Any, ...]] = []
+
+    def record_call(parent: torch.nn.Module, child_name: str, **kwargs: Any) -> None:
+        calls.append((parent, child_name, kwargs))
+
+    swap_linear(model, record_call, path="0")
+
+    assert calls == []
+    assert isinstance(model[0], torch.nn.ReLU)
+
+
+@pytest.mark.cpu
+def test_swap_linear_empty_path_raises() -> None:
+    """Test that ``swap_linear`` rejects an empty path."""
+    model = torch.nn.Linear(2, 2)
+    with pytest.raises(ValueError, match="empty path"):
+        swap_linear(model, _replace_linear_with_identity, path="")
+
+
+@pytest.mark.cpu
+def test_amax_to_scale_non_zero_amax() -> None:
+    """Test the nominal per-tensor scale ``max_val / amax``."""
+    amax = torch.tensor(2.0)
+    max_val = 448.0
+    scale = amax_to_scale(amax, max_val)
+    torch.testing.assert_close(scale, torch.tensor(224.0))
+
+
+@pytest.mark.cpu
+def test_amax_to_scale_zero_amax() -> None:
+    """Test that a near-zero amax does not explode; the scale is capped at ``max_val``."""
+    amax = torch.tensor(0.0)
+    max_val = 448.0
+    scale = amax_to_scale(amax, max_val)
+    torch.testing.assert_close(scale, torch.tensor(max_val))
+
+
+@pytest.mark.cpu
+def test_scale_and_clamp_maps_and_clips() -> None:
+    """Test that values are scaled then clipped to ``[-max_val, max_val]``."""
+    x = torch.tensor([-3.0, 0.5, 3.0])
+    scale = torch.tensor(2.0)
+    max_val = 4.0
+    out = scale_and_clamp(x, scale, max_val)
+    torch.testing.assert_close(out, torch.tensor([-4.0, 1.0, 4.0]))

--- a/tests/algorithms/test_quantization_utils.py
+++ b/tests/algorithms/test_quantization_utils.py
@@ -69,12 +69,12 @@ def test_amax_to_scale_non_zero_amax() -> None:
 
 @pytest.mark.cpu
 def test_amax_to_scale_zero_amax() -> None:
-    """Test that a near-zero amax does not explode; the scale is capped at ``max_val``."""
+    """Test that a zero amax is floored so the scale stays finite."""
     amax = torch.tensor(0.0)
     max_val = 448.0
     scale = amax_to_scale(amax, max_val)
-    torch.testing.assert_close(scale, torch.tensor(max_val))
-
+    torch.testing.assert_close(scale, torch.tensor(max_val / 1e-12))
+    assert torch.isfinite(scale)
 
 @pytest.mark.cpu
 def test_scale_and_clamp_maps_and_clips() -> None:

--- a/tests/algorithms/testers/static_fp8_diffusers.py
+++ b/tests/algorithms/testers/static_fp8_diffusers.py
@@ -1,0 +1,68 @@
+from typing import Any
+
+import pytest
+
+from pruna.algorithms.static_fp8_diffusers import StaticFp8Diffusers
+from pruna.algorithms.static_fp8_diffusers.utils import StaticFp8Linear
+from pruna.engine.load_artifacts import (
+    STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME,
+    STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME,
+)
+from pruna.engine.pruna_model import PrunaModel
+
+from .base_tester import AlgorithmTesterBase
+
+
+@pytest.mark.high_gpu  # requires GPUs with compute capabilities >= 9.0 (e.g. H100) or >= 8.9 (e.g. L40S)
+@pytest.mark.slow
+class TestStaticFp8Diffusers(AlgorithmTesterBase):
+    """Test static FP8 quantization for diffusers."""
+
+    models = ["flux_tiny_random"]
+    reject_models = ["llama_3_tiny_random"]
+    allow_pickle_files = False
+    algorithm_class = StaticFp8Diffusers
+    metrics = ["ssim"]
+    artifacts_filename = STATIC_FP8_DIFFUSERS_ARTIFACTS_FILENAME
+    artifacts_function_name = STATIC_FP8_DIFFUSERS_ARTIFACTS_FUNCTION_NAME
+    hyperparameters = {
+        "static_fp8_diffusers_calibration_batches": 1,
+    }
+
+    @classmethod
+    def compatible_devices(cls) -> list[str]:
+        """CPU cannot run torch._scaled_mm fp8 matmul used by this algorithm."""
+        return [d for d in super().compatible_devices() if d != "cpu"]
+
+    @staticmethod
+    def _fp8_linear_layers(model: PrunaModel, linear_cls: type) -> list[Any]:
+        """Collect all submodules of ``linear_cls`` across pipeline roots."""
+        return [
+            submodule
+            for module in model.get_nn_modules().values()
+            for submodule in module.modules()
+            if isinstance(submodule, linear_cls)
+        ]
+
+    def _assert_calibrated_linears(self, model: PrunaModel) -> None:
+        """Assert the model contains calibrated StaticFp8Linear layers."""
+        layers = self._fp8_linear_layers(model, StaticFp8Linear)
+        assert layers, "Expected StaticFp8Linear layers"
+        assert all(layer.input_initialized for layer in layers)
+
+    def post_smash_hook(self, model: PrunaModel) -> None:
+        """Assert calibrated StaticFp8Linear layers after smash."""
+        self._assert_calibrated_linears(model)
+
+    def post_load_hook(self, model: PrunaModel) -> None:
+        """Assert calibrated layers and that the artifact loader is registered."""
+        super().post_load_hook(model)
+        self._assert_calibrated_linears(model)
+        assert self.artifacts_function_name in model.smash_config.load_artifacts_fns
+
+    def execute_save(self, smashed_model: PrunaModel) -> None:
+        """Save the smashed model and assert the calibration artifact was written."""
+        super().execute_save(smashed_model)
+        artifact_path = self._saving_path / self.artifacts_filename
+        assert artifact_path.exists(), f"Expected artifact at {artifact_path} after save"
+        assert artifact_path.stat().st_size > 0

--- a/tests/engine/test_artifacts.py
+++ b/tests/engine/test_artifacts.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import load_file
+
+from pruna.config.smash_config import SmashConfig
+from pruna.engine.load_artifacts import iter_typed_linears, module_path_prefix
+from pruna.engine.save_artifacts import save_module_attr_artifacts
+
+
+class DummyFp8Linear(torch.nn.Module):
+    """Minimal stand-in for an FP8 linear module used in artifact unit tests."""
+
+    def __init__(self, in_features: int = 4, out_features: int = 2) -> None:
+        super().__init__()
+        self.register_buffer("calibration_value", torch.tensor(1.5))
+
+
+@pytest.mark.cpu
+@pytest.mark.parametrize(
+    ("module_name", "submodule_name", "expected"),
+    [
+        (None, None, ""),
+        (None, "child", "child."),
+        ("transformer", "", "transformer."),
+        ("transformer", "blocks.0", "transformer.blocks.0."),
+    ],
+)
+def test_module_path_prefix(module_name: str | None, submodule_name: str | None, expected: str) -> None:
+    """
+    Test dotted key prefixes used symmetrically by artifact save and load.
+
+    Parameters
+    ----------
+    module_name : str | None
+        The top-level module name, or None for a bare module tree.
+    submodule_name : str | None
+        The submodule name within the root module.
+    expected : str
+        The expected prefix ending with a trailing dot.
+    """
+    assert module_path_prefix(module_name, submodule_name) == expected
+
+
+@pytest.mark.cpu
+def test_iter_typed_linears_bare_module() -> None:
+    """Test ``iter_typed_linears`` on a bare ``nn.Module`` tree without pipeline roots."""
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2), DummyFp8Linear())
+    layers = list(iter_typed_linears(model, DummyFp8Linear))
+    assert len(layers) == 1
+    prefix, layer = layers[0]
+    assert prefix == "1."
+    assert isinstance(layer, DummyFp8Linear)
+
+
+@pytest.mark.cpu
+def test_iter_typed_linears_pipeline_model() -> None:
+    """Test ``iter_typed_linears`` on a model that exposes ``get_nn_modules``."""
+    transformer = torch.nn.Sequential(DummyFp8Linear(), torch.nn.Linear(2, 2))
+    unet = torch.nn.Sequential(torch.nn.Linear(2, 2), DummyFp8Linear())
+    model = SimpleNamespace(
+        get_nn_modules=lambda: {"transformer": transformer, "unet": unet},
+    )
+    layers = list(iter_typed_linears(model, DummyFp8Linear))
+    assert len(layers) == 2
+    prefixes = {prefix for prefix, _ in layers}
+    assert prefixes == {"transformer.0.", "unet.1."}
+
+
+@pytest.mark.cpu
+def test_save_module_attr_artifacts(tmp_path: Path) -> None:
+    """
+    Test saving module attributes to safetensors and registering the load function.
+
+    Parameters
+    ----------
+    tmp_path : Path
+        Temporary directory provided by pytest for writing artifact files.
+    """
+    transformer = torch.nn.Sequential(DummyFp8Linear(), torch.nn.Linear(2, 2))
+    unet = torch.nn.Sequential(torch.nn.Linear(2, 2), DummyFp8Linear())
+    model = SimpleNamespace(
+        get_nn_modules=lambda: {"transformer": transformer, "unet": unet},
+    )
+    smash_config = SmashConfig()
+    load_fn_name = "dummy_fp8_artifacts"
+
+    save_module_attr_artifacts(
+        model,
+        tmp_path,
+        smash_config,
+        linear_cls=DummyFp8Linear,
+        attrs=("calibration_value",),
+        filename="dummy_fp8_artifacts.safetensors",
+        load_fn_name=load_fn_name,
+    )
+
+    artifact_path = tmp_path / "dummy_fp8_artifacts.safetensors"
+    assert artifact_path.exists()
+    state_dict = load_file(str(artifact_path))
+    assert set(state_dict) == {"transformer.0.calibration_value", "unet.1.calibration_value"}
+    assert load_fn_name in smash_config.load_artifacts_fns


### PR DESCRIPTION
## Description
This algorithm implements symmetric linear quantization using the `amax` value.

- The weights are quantized once and the full-precision weights are discarder.
- The activations are quantized on-the-go, using a fixed scale. The scale is computed during calibration - complete noise-to-image generations during "smash".

## Type of Change
<!-- Mark the appropriate option with an "x" (no spaces around the "x") -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (no functional change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
<!-- How did you verify your changes? Which tests did you run? -->
- [x] I added or updated tests covering my changes
- [x] Existing tests pass locally (`uv run pytest -m "cpu and not slow"`)

For full setup and testing instructions, see the [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html).

## Checklist
<!-- Mark items with "x" (no spaces around the "x") -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code, especially for agent-assisted changes
- [x] I updated the documentation where necessary

## Additional Notes
### Setup

There are multiple other algorithms in the comparison, used for reference.

- `f8_dummy` - The practical speed limit when it comes to static quantization. The method skips calibration and uses a fixed (random) number as scales. _Thus, it does not need any boolean flags indicating the "mode" we run in, nor any conditional statements._
- `fp8_dynamic` - The theoretical best when it comes to quality. It does not precompute scales, but instead each layer computes them on-the-go, as the input arrives. This is what `torchao` provides under [Float8DynamicActivationFloat8WeightConfig](https://docs.pytorch.org/ao/main/api_reference/generated/torchao.quantization.Float8DynamicActivationFloat8WeightConfig.html#torchao.quantization.Float8DynamicActivationFloat8WeightConfig).

Our goal is to implement a static quantization algorithm, s.t. it _matches_ the dummy's speed and the dynamic's quality.

### Results

The experiments are conducted using Qwen-Image-2512. Pairwise scores are computed w.r.t. a bf16 variant. All models are compressed using `smash`. The `_compiled` suffix indicates `torch.compile` applied with `target: module_list` and `fullgraph: false`.

| Quantization Algorithm | CLIP Score ⬆️ | Inference (ms) | Speedup | Disk Memory | Inference Memory | Memory Cmp. |
| --- | --- | --- | --- | --- | --- | --- |
| fp8_dummy_compiled | N/A | 8997.427506 | 1.75x | 42490 | 47118 | 0.77x |
| static_fp8_diffusers_compiled | 23.551832 | 9171.238864 | 1.72x | 42518 | 47148 | 0.77x |
| fp8_dynamic_compiled | 23.835505 | 9875.194669 | 1.60x | 42430 | 47170 | 0.77x |
| static_fp8_diffusers | 23.833471 | 15453.424490 | 1.02x | 42554 | 47580 | 0.77x |
| baseline | 23.956564 | 15760.324677 | 1.00x | 55302 | 60208 | 1.00x |

OpenImage, 100 prompts

| Quantization Algorithm | Pairwise CLIP Score ⬆️ | CMMD ⬇️ | LPIPS ⬇️ | MSSSIM ⬆️ | PSNR ⬆️ |
| --- | --- | --- | --- | --- | --- |
| fp8_dynamic_compiled | 98.247383 | 0.007629 | 0.071664 | 0.948175 | 26.475830 |
| static_fp8_diffusers_compiled | 98.211365 | 0.009179 | 0.076860 | 0.944918 | 26.176754 |

LAION256, 46 prompts

| Quantization Algorithm | Pairwise CLIP Score ⬆️ | CMMD ⬇️ | LPIPS ⬇️ | MSSSIM ⬆️ | PSNR ⬆️ |
| --- | --- | --- | --- | --- | --- |
| fp8_dynamic_compiled | 96.642136 | 0.019193 | 0.075059 | 0.950166 | 26.583673 |
| static_fp8_diffusers_compiled | 96.565979 | 0.021219 | 0.084726 | 0.939995 | 25.400696 |

### Extra

#### How to store the scales?

The AlgorithBase has a property called `dataset_required` which feels really appropriate for this algorithm. However, it comes with a caveat.

1. On [smash](https://github.com/PrunaAI/pruna/blob/main/src/pruna/smash.py#L73), the smash config is checked. In particular, whenever `dataset_calibrated` is set to True, the data property is also required (call in [smash](https://github.com/PrunaAI/pruna/blob/main/src/pruna/smash.py#L73) → [check](https://github.com/PrunaAI/pruna/blob/main/src/pruna/config/pre_smash_routines.py#L138-L139))
2. On model save, the smash configuration is saved as JSON, but the data property is intentionally omitted (call in [save_pruna_model](https://github.com/PrunaAI/pruna/blob/main/src/pruna/engine/save.py#L100) → [code](https://github.com/PrunaAI/pruna/blob/main/src/pruna/config/smash_config.py#L338-L339)).
3. On model load, the smash functions is invoked again when there is an algorithm with save_before_apply (call in [load_pruna_model](https://github.com/PrunaAI/pruna/blob/main/src/pruna/engine/load.py#L85-L86) → (default) [resmash](https://github.com/PrunaAI/pruna/blob/main/src/pruna/engine/load.py#L226))

Now consider that we have an algorithm with `dataset_required=True`. We smash it, save it, load it, and … crash. The resmashing checks whether there is any data and finds none. For this reason, I decided to use the data property (allowing users to pass any dataset for calibration - as a string among the pruna native datasets, as a PrunaDataModule, etc; [code](https://github.com/PrunaAI/pruna/blob/main/src/pruna/config/smash_config.py#L431-L478)) but manually check whether the data is present when the model is being smashed for the first time (i.e., not loaded from previously saved one). This is a similar approach as the one adopted in [Quanto](https://github.com/PrunaAI/pruna/blob/main/src/pruna/algorithms/quanto.py), even though calibration is not required there.

#### What do we store?

- the input_running_amax, allowing us to change the input quantization upon load (e4m3 to e5m2 or vice versa) without the need to run calibration again.

#### Why custom `get_model_dependent_hyperparameter_defaults`?
Why did I choose to create a custom method but not follow the example in torchao (skipped modules [here](https://github.com/PrunaAI/pruna/blob/main/src/pruna/algorithms/torchao.py#L39-L73) and function [here](https://github.com/PrunaAI/pruna/blob/main/src/pruna/algorithms/torchao.py#L185-L216)?

There are numerous [diffusers](https://huggingface.co/docs/diffusers/index) models and each and every one might name its modules in a different manner. Trying to list all _common_ embedding and norm modules might only lead to an unexpected behavior - when some modules are quantized and others are not, using a _heuristic_ unknown to the user. The simple solution I adopt clearly states that, by default, it would skip any layers which include "embed" or "norm" in their naming.

---

Thanks for contributing to **Pruna**! We're excited to review your work.

New to contributing? Check out our [Contributing Guide](https://docs.pruna.ai/en/stable/docs_pruna/contributions/how_to_contribute.html) for everything you need to get started.

> **Note:** 
> - Draft PRs or PRs without a clear and detailed overview may be delayed.  
> - Please mark your PR as **Ready for Review** and ensure the sections above are filled out.
> - Contributions that are entirely AI-generated without meaningful human review are discouraged.