### PR TITLE
fix: use dtype instead of deprecated torch_dtype

### DIFF
--- a/src/pruna/algorithms/hqq.py
+++ b/src/pruna/algorithms/hqq.py
@@ -41,6 +41,15 @@ from pruna.engine.save import SAVE_FUNCTIONS
 from pruna.engine.utils import move_to_device, safe_memory_cleanup
 from pruna.logging.filter import SuppressOutput
 from pruna.logging.logger import pruna_logger
+import transformers
+from packaging.version import Version
+
+def _dtype_kwargs(dtype):
+    """`dtype` keyword of `from_pretrained` exists since transformers 4.56 (PR #39782);
+    older versions use `torch_dtype`."""
+    if Version(transformers.__version__) >= Version("4.56"):
+        return {"dtype": dtype}
+    return {"torch_dtype": dtype}
 
 
 class HQQ(PrunaAlgorithmBase):
@@ -274,7 +283,7 @@ class HQQ(PrunaAlgorithmBase):
                     quantization_config=quant_config_hf,
                     trust_remote_code=True,
                     device_map="auto",
-                    torch_dtype=torch.float16 if smash_config["compute_dtype"] == "torch.float16" else torch.bfloat16,
+                    **_dtype_kwargs(torch.float16 if smash_config["compute_dtype"] == "torch.float16" else torch.bfloat16),
                 )
 
                 # Delete the temporary directory and its contents


### PR DESCRIPTION
## Summary

`config.torch_dtype` and the `torch_dtype` keyword argument were deprecated in transformers 4.56 (PR #39782) and replaced by `dtype`. This PR updates the `AutoModelForCausalLM.from_pretrained` call in `src/pruna/algorithms/hqq.py` (line 272, HQQ quantization) to select the keyword from the installed transformers version using `packaging.version`, so transformers < 4.56 keeps working. The `quantization_config` argument is unchanged.

## Changes

- `src/pruna/algorithms/hqq.py`: add a `_dtype_kwargs` helper that returns `{"dtype": ...}` on transformers >= 4.56 and `{"torch_dtype": ...}` otherwise; the `from_pretrained` call passes it as `**_dtype_kwargs(torch.float16 if ... else ...)`.

## Test

- The modified file compiles (`python -m py_compile`).
- On transformers >= 4.56 the call uses `dtype` and emits no deprecation warning; on older versions it passes `torch_dtype` unchanged.

Fixes #734